### PR TITLE
Chore: FE CI 워크플로우 신설 (tsc + vite build)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - run: npm run build


### PR DESCRIPTION
## Summary
- `.github/workflows/ci.yml` 신설 — PR / main push 마다 typecheck + production build 자동 실행.
- Issue #2 DoD 의 "FE CI 신설 (`.github/workflows/ci.yml`)" 항목 처리.

## What changed
- `ubuntu-latest` + Node 22 (현재 로컬 `v24.14.0` 호환 LTS)
- `actions/setup-node@v4` 의 `cache: npm` 으로 `node_modules` 캐싱
- `npm ci` → `npm run build` (= `tsc && vite build`) 만 실행

## Scope 밖
- **eslint**: 레포에 ESLint 설정 없음 (`package.json`/`.eslintrc` 둘 다 미존재). rule set 결정이 별도 논의 필요해서 본 PR 에서는 제외. 후속 PR 권장.
- **axios / react-query 도입**: Issue #2 DoD 의 다른 항목이라 본 PR 에서 처리 안 함.

## Test plan
- [x] 로컬 `npm run build` 통과 (4613 modules, 3.23s)
- [ ] CI 가 본 PR 에서 초록불 (가장 중요한 검증)
- [ ] 후속 PR 에서도 자동 트리거 확인

Refs #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)