### PR TITLE
Feat: <AiDraftCard> 공통 컴포넌트 + S06 적용 (Issue #12)

### DIFF
--- a/src/app/MobileKitPage.tsx
+++ b/src/app/MobileKitPage.tsx
@@ -16,6 +16,7 @@ import { EveningCheckInScreen } from '../screens/EveningCheckInScreen';
 import { WeeklyCalendarScreenV2 } from '../screens/WeeklyCalendarScreen';
 import { ReflectScreen } from '../screens/ReflectScreen';
 import { WeeklyReviewScreenV2 } from '../screens/WeeklyReviewScreen';
+import { AiDraftCard } from '../components/AiDraftCard';
 
 // ── Safe-area wrapper ──────────────────────────────────────────
 function Safe({ scroll = true, children }: { scroll?: boolean; children: React.ReactNode }) {
@@ -190,6 +191,64 @@ export function MobileKitPage() {
             <Safe><RecoveredScreen recoveryCount={38} onDone={() => {}} /></Safe>
           </ScreenCard>
         </ScreenGrid>
+      </div>
+
+      {/* ── ⑤ Components · 공통 카드 ── */}
+      <SectionDivider label="공통 컴포넌트" sub="베이스라인 §1.4 잠금 결정 — AI 카드는 100% 이 컴포넌트 통과" />
+      <div style={{ width: '100%', maxWidth: 1320 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 16, paddingTop: 10 }}>
+          <StepBadge n="C" color="#B85F8E" label="AiDraftCard · Issue #12" />
+          <span style={{ fontSize: 12, color: 'var(--text-3)' }}>3 variants · isDraft + aiSource + llmRunId + 3버튼 + 금지어 검수</span>
+        </div>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(320px, 1fr))', gap: 24 }}>
+          <div>
+            <div style={{ fontSize: 11, fontWeight: 600, letterSpacing: '0.08em', textTransform: 'uppercase' as const, color: 'var(--brand)', marginBottom: 8 }}>aiSource: llm</div>
+            <AiDraftCard
+              isDraft={true}
+              aiSource="llm"
+              llmRunId="run_a1b2c3d4e5f6"
+              onAccept={() => {}}
+              onEdit={() => {}}
+              onReject={() => {}}
+            >
+              <p style={{ margin: 0, fontSize: 13, lineHeight: 1.6, color: 'var(--text-2)' }}>
+                목표 달성을 위해 화요일/목요일 저녁 60분 블록 2개를 추천드려요. 일요일은 휴식으로 비워두었어요.
+              </p>
+            </AiDraftCard>
+            <p style={{ fontSize: 12, color: 'var(--text-3)', margin: '8px 0 0' }}>정상 LLM 응답. 코랄 점선 + Sparkle.</p>
+          </div>
+          <div>
+            <div style={{ fontSize: 11, fontWeight: 600, letterSpacing: '0.08em', textTransform: 'uppercase' as const, color: 'var(--text-3)', marginBottom: 8 }}>aiSource: rule (fallback)</div>
+            <AiDraftCard
+              isDraft={true}
+              aiSource="rule"
+              onAccept={() => {}}
+              onEdit={() => {}}
+              onReject={() => {}}
+            >
+              <p style={{ margin: 0, fontSize: 13, lineHeight: 1.6, color: 'var(--text-2)' }}>
+                저녁 시간대 빈 슬롯에 자동 분배했어요. 8 블록 · 총 8h.
+              </p>
+            </AiDraftCard>
+            <p style={{ fontSize: 12, color: 'var(--text-3)', margin: '8px 0 0' }}>BE 가 룰 fallback 으로 응답. 모래 점선 + Robot + 안내 풋터.</p>
+          </div>
+          <div>
+            <div style={{ fontSize: 11, fontWeight: 600, letterSpacing: '0.08em', textTransform: 'uppercase' as const, color: 'var(--danger, #C9573D)', marginBottom: 8 }}>금지어 감지 → rule 강제 전환</div>
+            <AiDraftCard
+              isDraft={true}
+              aiSource="llm"
+              llmRunId="run_forbidden"
+              onAccept={() => {}}
+              onEdit={() => {}}
+              onReject={() => {}}
+            >
+              <p style={{ margin: 0, fontSize: 13, lineHeight: 1.6, color: 'var(--text-2)' }}>
+                지난주 실패율이 높았어요. 이번 주는 줄여서 다시 시도해봐요.
+              </p>
+            </AiDraftCard>
+            <p style={{ fontSize: 12, color: 'var(--text-3)', margin: '8px 0 0' }}>"실패율" 감지. 자동으로 룰 시각으로 전환 + dev console.error.</p>
+          </div>
+        </div>
       </div>
 
       {/* ── ④ Reflect / Sustain ── */}

--- a/src/components/AiDraftCard.tsx
+++ b/src/components/AiDraftCard.tsx
@@ -1,0 +1,211 @@
+import React, { useEffect } from 'react';
+import { Sparkle, Robot, CheckCircle, PencilSimple, X } from '@phosphor-icons/react';
+
+export type AiSource = 'llm' | 'rule';
+
+export interface AiDraftCardProps {
+  isDraft: boolean;
+  aiSource: AiSource;
+  llmRunId?: string | null;
+  children: React.ReactNode;
+  onAccept: () => void;
+  onEdit: () => void;
+  onReject: () => void;
+  acceptLabel?: string;
+  editLabel?: string;
+  rejectLabel?: string;
+}
+
+// 베이스라인 §1.4 잠금 결정. BE 필터 통과 후에도 한번 더 클라이언트에서 검수.
+const FORBIDDEN_PATTERNS: RegExp[] = [
+  /실패/,
+  /(?:^|[^가-힣])또(?:[^가-힣]|$)/,
+  /안\s?됐/,
+  /못했/,
+  /왜\s*안/,
+  /실패율/,
+];
+
+function hasForbidden(text: string): boolean {
+  return FORBIDDEN_PATTERNS.some((p) => p.test(text));
+}
+
+function extractText(node: React.ReactNode): string {
+  if (node == null || typeof node === 'boolean') return '';
+  if (typeof node === 'string' || typeof node === 'number') return String(node);
+  if (Array.isArray(node)) return node.map(extractText).join(' ');
+  if (React.isValidElement(node)) {
+    const props = (node as React.ReactElement<{ children?: React.ReactNode }>).props;
+    return extractText(props.children);
+  }
+  return '';
+}
+
+export function AiDraftCard({
+  isDraft,
+  aiSource,
+  llmRunId,
+  children,
+  onAccept,
+  onEdit,
+  onReject,
+  acceptLabel = '수락',
+  editLabel = '수정',
+  rejectLabel = '재생성',
+}: AiDraftCardProps) {
+  useEffect(() => {
+    if (!isDraft && import.meta.env.DEV) {
+      // §1.4 잠금: 모든 AI 카드는 isDraft=true. 안전 default 로 점선 시각은 유지.
+      console.warn(
+        '[AiDraftCard] isDraft=false. §1.4 잠금 결정 위반 의심. 안전 default 로 점선 시각 유지.',
+      );
+    }
+  }, [isDraft]);
+
+  const text = extractText(children);
+  const forbidden = hasForbidden(text);
+  if (forbidden && import.meta.env.DEV) {
+    console.error('[AiDraftCard] 금지어 감지. 룰 fallback 시각으로 전환.', { llmRunId });
+  }
+  // 금지어 감지 시 룰 fallback 시각으로 강제 전환.
+  const visualSource: AiSource = forbidden ? 'rule' : aiSource;
+
+  const isLlm = visualSource === 'llm';
+  const borderColor = isLlm ? 'var(--coral-400, #E26D4E)' : 'var(--sand-400, #B8A990)';
+  const headerBg = isLlm ? 'var(--coral-50, #FCEEE6)' : 'var(--sand-100, #F2E9DC)';
+  const accentColor = isLlm ? 'var(--brand, #E26D4E)' : 'var(--text-2, #6E5C4C)';
+
+  return (
+    <div
+      style={{
+        border: `1.5px dashed ${borderColor}`,
+        borderRadius: 14,
+        background: 'var(--surface-raised, #FFFCF6)',
+        overflow: 'hidden',
+      }}
+    >
+      <div
+        style={{
+          padding: '8px 12px',
+          background: headerBg,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 6,
+          fontSize: 11,
+          fontWeight: 700,
+          letterSpacing: '0.06em',
+          textTransform: 'uppercase',
+          color: accentColor,
+          fontFamily: 'var(--font-mono, monospace)',
+        }}
+      >
+        {isLlm ? <Sparkle size={11} weight="fill" /> : <Robot size={11} weight="fill" />}
+        <span>{isLlm ? 'AI 초안' : '오프라인 모드 · 룰 기반'}</span>
+        {import.meta.env.DEV && llmRunId && (
+          <span
+            style={{ marginLeft: 'auto', opacity: 0.6, fontSize: 9 }}
+            title={`llmRunId: ${llmRunId}`}
+          >
+            #{llmRunId.slice(0, 6)}
+          </span>
+        )}
+      </div>
+
+      <div style={{ padding: '12px 14px' }}>
+        {children}
+        {!isLlm && (
+          <div
+            style={{
+              marginTop: 10,
+              fontSize: 11,
+              color: 'var(--text-3, #8E7C68)',
+              background: 'var(--sand-50, #F8F1E4)',
+              border: '1px solid var(--sand-200, #E4D4BC)',
+              borderRadius: 8,
+              padding: '6px 10px',
+              lineHeight: 1.5,
+            }}
+          >
+            오프라인 모드(룰 기반)로 자동 분배됨. AI 호출 가능 시 다시 생성해보세요.
+          </div>
+        )}
+      </div>
+
+      <div
+        style={{
+          display: 'flex',
+          gap: 6,
+          padding: '8px 10px 10px',
+          borderTop: '1px solid var(--sand-200, #E4D4BC)',
+        }}
+      >
+        <button
+          onClick={onReject}
+          type="button"
+          style={{
+            flex: 1,
+            height: 40,
+            borderRadius: 10,
+            border: '1px solid var(--sand-300, #D8C5A8)',
+            background: 'transparent',
+            color: 'var(--text-2, #6E5C4C)',
+            fontWeight: 600,
+            fontSize: 13,
+            fontFamily: 'inherit',
+            cursor: 'pointer',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 4,
+          }}
+        >
+          <X size={12} /> {rejectLabel}
+        </button>
+        <button
+          onClick={onEdit}
+          type="button"
+          style={{
+            flex: 1,
+            height: 40,
+            borderRadius: 10,
+            border: '1px solid var(--sand-300, #D8C5A8)',
+            background: 'var(--surface-ground, #FAF6EE)',
+            color: 'var(--text-1, #1A1714)',
+            fontWeight: 600,
+            fontSize: 13,
+            fontFamily: 'inherit',
+            cursor: 'pointer',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 4,
+          }}
+        >
+          <PencilSimple size={12} /> {editLabel}
+        </button>
+        <button
+          onClick={onAccept}
+          type="button"
+          style={{
+            flex: 1.4,
+            height: 40,
+            borderRadius: 10,
+            border: 'none',
+            background: 'var(--brand, #E26D4E)',
+            color: '#FFFCF6',
+            fontWeight: 700,
+            fontSize: 13,
+            fontFamily: 'inherit',
+            cursor: 'pointer',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 4,
+          }}
+        >
+          <CheckCircle size={13} weight="fill" /> {acceptLabel}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/screens/WeeklyPlanGenerationScreen.tsx
+++ b/src/screens/WeeklyPlanGenerationScreen.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useEffect } from 'react';
-import { Sparkle, Clock, Plus, ArrowRight, X, Trash } from '@phosphor-icons/react';
+import { Clock, X, Trash } from '@phosphor-icons/react';
 import { WEEK_PLAN_DEFAULT, GOAL_COLORS, DAYS_KO } from '../data';
 import { SetupProgress } from './CalendarScheduleScreen';
+import { AiDraftCard } from '../components/AiDraftCard';
 import type { Block } from '../types';
 
 interface WeeklyPlanGenerationScreenProps {
@@ -137,25 +138,8 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
       {/* Header */}
       <div style={{ flexShrink: 0, padding: '14px 18px 12px', borderBottom: '1px solid var(--sand-200)' }}>
         <SetupProgress current={4} total={5} label="계획" />
-        <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--brand)', fontFamily: 'var(--font-mono)', marginBottom: 4, display: 'flex', alignItems: 'center', gap: 4 }}>
-          <Sparkle size={11} weight="fill" /> AI 생성 완료
-        </div>
         <h2 style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 22, letterSpacing: '-0.02em', margin: '0 0 6px' }}>이번 주 계획이에요</h2>
-        <p style={{ fontSize: 12, color: 'var(--text-2)', margin: '0 0 10px' }}>블록을 탭하면 수정할 수 있어요.</p>
-        <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
-          <span className="tnum" style={{ height: 24, padding: '0 10px', background: 'var(--text-1)', color: '#FAF6EE', borderRadius: 9999, fontSize: 11, fontWeight: 600, display: 'inline-flex', alignItems: 'center', gap: 4 }}>
-            <Clock size={11} weight="fill" /> 총 {totalH.toFixed(1)}h
-          </span>
-          {Object.entries(goalCount).map(([g, mins]) => {
-            const c = GOAL_COLORS[g] || GOAL_COLORS['SQLD'];
-            return (
-              <span key={g} style={{ height: 24, padding: '0 10px', background: c.bg, border: `1px solid ${c.bd}`, color: c.fg, borderRadius: 9999, fontSize: 11, fontWeight: 600, display: 'inline-flex', alignItems: 'center', gap: 4 }}>
-                <span style={{ width: 6, height: 6, borderRadius: 9999, background: c.fg }} />
-                {g} <span className="tnum">{(mins / 60).toFixed(1)}h</span>
-              </span>
-            );
-          })}
-        </div>
+        <p style={{ fontSize: 12, color: 'var(--text-2)', margin: 0 }}>블록을 탭하면 수정할 수 있어요.</p>
       </div>
 
       {/* Day headers */}
@@ -203,14 +187,33 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
         </div>
       </div>
 
-      {/* Footer */}
-      <div style={{ flexShrink: 0, padding: '12px 18px', paddingBottom: 'max(28px, env(safe-area-inset-bottom, 28px))', borderTop: '1px solid var(--sand-200)', background: 'var(--surface-ground)', display: 'flex', gap: 8 }}>
-        <button onClick={addBlock} style={{ flex: 1, height: 44, borderRadius: 12, border: '1.5px dashed var(--coral-300)', background: 'transparent', color: 'var(--coral-700)', fontWeight: 600, fontSize: 13, fontFamily: 'inherit', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6 }}>
-          <Plus size={14} /> 추가
-        </button>
-        <button onClick={onContinue} style={{ flex: 2, height: 44, borderRadius: 12, border: 'none', background: 'var(--brand)', color: '#FFFCF6', fontWeight: 700, fontSize: 14, fontFamily: 'inherit', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6 }}>
-          이대로 시작 <ArrowRight size={14} />
-        </button>
+      {/* AI Draft footer — Issue #12 §1.4 잠금 결정 시각화 */}
+      <div style={{ flexShrink: 0, padding: '10px 14px', paddingBottom: 'max(14px, env(safe-area-inset-bottom, 14px))', background: 'var(--surface-ground)' }}>
+        <AiDraftCard
+          isDraft={true}
+          aiSource="llm"
+          onAccept={onContinue}
+          onEdit={addBlock}
+          onReject={() => setGenerating(true)}
+          acceptLabel="이대로 시작"
+          editLabel="블록 추가"
+          rejectLabel="재생성"
+        >
+          <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+            <span className="tnum" style={{ height: 24, padding: '0 10px', background: 'var(--text-1)', color: '#FAF6EE', borderRadius: 9999, fontSize: 11, fontWeight: 600, display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+              <Clock size={11} weight="fill" /> 총 {totalH.toFixed(1)}h
+            </span>
+            {Object.entries(goalCount).map(([g, mins]) => {
+              const c = GOAL_COLORS[g] || GOAL_COLORS['SQLD'];
+              return (
+                <span key={g} style={{ height: 24, padding: '0 10px', background: c.bg, border: `1px solid ${c.bd}`, color: c.fg, borderRadius: 9999, fontSize: 11, fontWeight: 600, display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+                  <span style={{ width: 6, height: 6, borderRadius: 9999, background: c.fg }} />
+                  {g} <span className="tnum">{(mins / 60).toFixed(1)}h</span>
+                </span>
+              );
+            })}
+          </div>
+        </AiDraftCard>
       </div>
 
       {editing && (


### PR DESCRIPTION
## Summary
- DevBaseline §1.4 잠금 결정의 FE 차원 박제 컴포넌트 `<AiDraftCard>` 신설.
- S06 First Plan Review (`WeeklyPlanGenerationScreen`) 의 footer 를 본 컴포넌트로 교체.
- `/kit` 카탈로그에 3 variants (llm / rule / 금지어 자동 전환) 등록.

## What changed
### 새 컴포넌트 — `src/components/AiDraftCard.tsx`
- props: `isDraft`, `aiSource: 'llm' | 'rule'`, `llmRunId?`, `onAccept/onEdit/onReject`, label props
- `isDraft=false`: dev-only `console.warn` + **안전 default 로 점선 시각 유지**
- `aiSource='llm'`: 코랄 점선 + Sparkle + 'AI 초안' 헤더
- `aiSource='rule'`: 모래 점선 + Robot + 'AI 호출 가능 시 다시 생성' 안내 풋터
- **금지어 클라이언트 검수** (실패 / 또 / 안 됐 / 못했 / 왜 안 / 실패율) — 감지 시 자동 rule 시각으로 강제 전환 + dev `console.error`
- `llmRunId`: dev-only 디버깅 툴팁 (`import.meta.env.DEV` 가드 — prod 빌드에서 제거)

### S06 적용 — `WeeklyPlanGenerationScreen.tsx`
- 기존 footer (`추가` / `이대로 시작`) 를 `<AiDraftCard>` 로 교체
  - body: 요약 칩 (총 시간 + 목표별 시간)
  - footer 3버튼: **재생성** (`setGenerating(true)`) / **블록 추가** (`addBlock`) / **이대로 시작** (`onContinue`)
- 화면 상단의 'AI 생성 완료' 라벨은 카드 헤더로 흡수 → 중복 제거

### /kit 카탈로그 — `MobileKitPage.tsx`
- 'C. AiDraftCard' 섹션 추가, 3 variants 시각 비교

## §1.4 체크리스트
- [x] `<AiDraftCard>` 컴포넌트 작성 + /kit 카탈로그 등록
- [x] S06 적용 (footer 교체)
- [x] `isDraft=true` 미통과 카드 grep 0건 (S06 외 AI 카드 없음)
- [x] `aiSource:"rule"` 시 차별 안내 노출
- [x] 금지어 클라 검수 (정규식 6종, '또' 는 한글 단어 경계 매칭)
- [x] dev-only `llmRunId` 툴팁이 `import.meta.env.DEV` 가드
- [ ] BE Idempotency-Key 트릭 fallback 응답 검증 — BE #32 머지 후 별도 PR

## Scope 밖
- **S19 Recovery / Goal decompose / Inbox 자동 카테고리** 적용: 이번 이슈에선 'S06 적용 + 컴포넌트 export 까지' 로 한정 (이슈 본문 §3).
- **BE LLM 응답 필드 (`aiSource`, `isDraft`, `llmRunId`) 의 실제 소비**: BE #32 가 응답에 필드 채워주면 S06 의 props 하드코딩 (`isDraft={true} aiSource="llm"`) 을 응답 기반으로 교체 예정.

## Test plan
- [x] 로컬 `npm run build` 통과 (4614 modules, 3.41s)
- [ ] `/?force=weekly-plan` → 1.4s 생성 애니메이션 후 footer 가 `<AiDraftCard>` 로 보이고 3버튼 동작
- [ ] /kit 의 C. AiDraftCard 섹션 — 세 카드 시각 차이 확인
- [ ] 금지어 카드: dev console 에 `[AiDraftCard] 금지어 감지` error 확인 + 자동 rule 시각
- [ ] CI 초록불

Refs #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)