### PR TITLE
feat: S26 목표 관리 화면 (Goals 관리) — tier별 CRUD + 한도 422 + decompose

### DIFF
--- a/src/app/DesktopSidebar.tsx
+++ b/src/app/DesktopSidebar.tsx
@@ -1,4 +1,4 @@
-import { House, CalendarBlank, ChartBar, Tray, Gear } from '@phosphor-icons/react';
+import { House, CalendarBlank, ChartBar, Tray, Gear, Target } from '@phosphor-icons/react';
 import { Wordmark } from '../components/Wordmark';
 import { useNavigation } from '../contexts/NavigationContext';
 import type { TabId, ScreenId } from '../types';
@@ -77,8 +77,25 @@ export function DesktopSidebar() {
         </div>
       )}
 
-      {/* 하단: 설정 진입 + Re:Action 안내 */}
+      {/* 하단: 목표 관리 + 설정 진입 + Re:Action 안내 */}
       <div style={{ marginTop: 'auto', display: 'flex', flexDirection: 'column', gap: 8 }}>
+        {showNav && (
+          <button
+            onClick={() => setScreen('goals')}
+            style={{
+              display: 'flex', alignItems: 'center', gap: 10,
+              padding: '10px 12px', borderRadius: 12, border: 'none',
+              background: screen === 'goals' ? 'var(--sand-100)' : 'transparent',
+              color: screen === 'goals' ? 'var(--text-1)' : 'var(--text-3)',
+              fontFamily: 'inherit', fontSize: 14,
+              fontWeight: screen === 'goals' ? 600 : 500,
+              cursor: 'pointer', textAlign: 'left', width: '100%',
+            }}
+          >
+            <Target size={20} weight={screen === 'goals' ? 'fill' : 'regular'} color={screen === 'goals' ? 'var(--brand)' : 'var(--text-3)'} />
+            목표 관리
+          </button>
+        )}
         {showNav && (
           <button
             onClick={() => setScreen('settings')}

--- a/src/app/ReActionMerged.tsx
+++ b/src/app/ReActionMerged.tsx
@@ -8,6 +8,7 @@ import { SetupScreen } from '../screens/SetupScreen';
 import { WeeklyPlanGenerationScreen } from '../screens/WeeklyPlanGenerationScreen';
 import { MorningBriefScreen } from '../screens/MorningBriefScreen';
 import { InboxScreen } from '../screens/InboxScreen';
+import { GoalsScreen } from '../screens/GoalsScreen';
 import { SettingsScreen } from '../screens/SettingsScreen';
 import { MergedTodayScreen } from '../screens/TodayScreen';
 import { FocusScreen } from '../screens/FocusScreen';
@@ -39,6 +40,7 @@ const NAV_META: Record<ScreenId, { label: string; back: ScreenId | null }> = {
   'weekly':                 { label: '주간 계획',      back: null },
   'inbox':                  { label: 'LIFE INBOX',     back: null },
   'review':                 { label: '주간 리뷰',      back: null },
+  'goals':                  { label: '목표 관리',      back: 'today' },
   'settings':               { label: '설정',           back: 'today' },
 };
 
@@ -216,6 +218,7 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
         {screen === 'weekly' && <WeeklyCalendarScreenV2 />}
         {screen === 'inbox' && <InboxScreen />}
         {screen === 'review' && <WeeklyReviewScreenV2 />}
+        {screen === 'goals' && <GoalsScreen />}
         {screen === 'settings' && <SettingsScreen />}
       </div>
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -17,6 +17,8 @@ import type {
   FixedSchedule,
   FixedScheduleCreateRequest,
   FreeBusy,
+  GoalCreateRequest,
+  GoalDecomposition,
   GoalsByTier,
   GoalUpdateRequest,
   Habit,
@@ -185,12 +187,21 @@ export const interviewApi = {
 export const goalsApi = {
   list: () => request<GoalsByTier>('/goals'),
 
+  create: (body: GoalCreateRequest) =>
+    request<ApiGoal>('/goals', { method: 'POST', body }),
+
   update: (goalId: string, body: GoalUpdateRequest) =>
     request<ApiGoal>(`/goals/${goalId}`, { method: 'PATCH', body }),
 
   // Focus/Maintain → Parked 전환. Parked 는 tier 한도가 없어 전용 엔드포인트 사용.
   park: (goalId: string) =>
     request<ApiGoal>(`/goals/${goalId}/park`, { method: 'POST', body: {} }),
+
+  remove: (goalId: string) =>
+    request<void>(`/goals/${goalId}`, { method: 'DELETE' }),
+
+  decompose: (goalId: string) =>
+    request<GoalDecomposition>(`/goals/${goalId}/decompose`, { method: 'POST', body: {} }),
 };
 
 // ── Time Policies (S07) ───────────────────────────────────────

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -5,6 +5,7 @@ import type {
   ActionItem,
   AnonymizeRequest,
   ApiErrorPayload,
+  ApiGoal,
   ApiRecoveryProposal,
   AuthSession,
   CalendarConnection,
@@ -17,6 +18,7 @@ import type {
   FixedScheduleCreateRequest,
   FreeBusy,
   GoalsByTier,
+  GoalUpdateRequest,
   Habit,
   HabitCreateRequest,
   HabitInstance,
@@ -182,6 +184,13 @@ export const interviewApi = {
 // ── Goals (S03·S26) ───────────────────────────────────────────
 export const goalsApi = {
   list: () => request<GoalsByTier>('/goals'),
+
+  update: (goalId: string, body: GoalUpdateRequest) =>
+    request<ApiGoal>(`/goals/${goalId}`, { method: 'PATCH', body }),
+
+  // Focus/Maintain → Parked 전환. Parked 는 tier 한도가 없어 전용 엔드포인트 사용.
+  park: (goalId: string) =>
+    request<ApiGoal>(`/goals/${goalId}/park`, { method: 'POST', body: {} }),
 };
 
 // ── Time Policies (S07) ───────────────────────────────────────

--- a/src/screens/GoalClassificationScreen.tsx
+++ b/src/screens/GoalClassificationScreen.tsx
@@ -74,9 +74,25 @@ export function GoalClassificationScreen({ onNext }: GoalClassificationScreenPro
     { focus: 0, maintain: 0, parked: 0 },
   );
 
-  const changeStatus = (id: string, s: GoalStatus) => {
+  // 재분류 영속화: parked 는 전용 park 엔드포인트(tier 한도 자유), focus/maintain 은 PATCH.
+  // 더미 데이터(goal_ 접두사 없는 id)는 로컬만 변경해 데모 흐름을 유지하고,
+  // tier 한도 초과(422) 등 서버 검증 실패 시에는 되돌리고 사유를 표시한다.
+  const changeStatus = async (id: string, s: GoalStatus) => {
+    const prev = goals;
     setGoals((gs) => gs.map((g) => (g.id === id ? { ...g, status: s } : g)));
     setSelected(null);
+    if (!id.startsWith('goal_')) return;
+    setError(null);
+    try {
+      if (s === 'parked') await goalsApi.park(id);
+      else await goalsApi.update(id, { goalTier: s });
+    } catch (err: unknown) {
+      if (err instanceof ApiError) {
+        setGoals(prev);
+        setError(`[${err.code}] ${err.message}`);
+      }
+      // 네트워크/비-ApiError 는 데모 흐름 유지 — 로컬 변경을 그대로 둔다.
+    }
   };
 
   return (

--- a/src/screens/GoalsScreen.tsx
+++ b/src/screens/GoalsScreen.tsx
@@ -1,0 +1,434 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { Plus, Trash, PencilSimple, TreeStructure, Target } from '@phosphor-icons/react';
+import { ApiError, goalsApi } from '../lib/api';
+import type { ApiGoal, GoalDecomposition, GoalTier } from '../types/api';
+import { GOAL_STATUS_META } from '../data';
+import { ReButton } from '../components/ReButton';
+import { AiDraftCard } from '../components/AiDraftCard';
+
+// Focus ≤ 3 / Maintain ≤ 5. Parked 는 한도 자유 (백엔드 _TIER_LIMITS 와 동일).
+const TIER_LIMIT: Record<GoalTier, number | null> = { focus: 3, maintain: 5, parked: null };
+const TIER_ORDER: GoalTier[] = ['focus', 'maintain', 'parked'];
+
+const CATEGORY_OPTIONS: { value: string; label: string }[] = [
+  { value: 'study', label: '학습' },
+  { value: 'project', label: '프로젝트' },
+  { value: 'health', label: '건강' },
+  { value: 'routine', label: '루틴' },
+  { value: 'schedule', label: '일정' },
+  { value: 'career', label: '커리어' },
+  { value: 'relationship', label: '관계' },
+  { value: 'self_dev', label: '자기계발' },
+  { value: 'other', label: '기타' },
+];
+const CATEGORY_LABEL: Record<string, string> = Object.fromEntries(
+  CATEGORY_OPTIONS.map((c) => [c.value, c.label]),
+);
+
+// 백엔드가 비어있을 때 시연용 더미. id 에 goal_ 접두사가 없으므로 mutation 은 로컬에만 반영.
+const DEMO_GOALS: ApiGoal[] = [
+  { goalId: 'demo-1', title: '토익 700+ 달성', category: 'study', goalTier: 'focus', priorityLevel: 1, deadline: '2026-12-07', estimatedMinutes: 1920, status: 'active' },
+  { goalId: 'demo-2', title: '캡스톤 프로젝트', category: 'project', goalTier: 'focus', priorityLevel: 2, deadline: '2026-06-20', estimatedMinutes: 2400, status: 'active' },
+  { goalId: 'demo-3', title: '학교 수업 출석·과제', category: 'schedule', goalTier: 'maintain', priorityLevel: 3, deadline: null, estimatedMinutes: 960, status: 'active' },
+  { goalId: 'demo-4', title: '헬스장 운동 루틴', category: 'health', goalTier: 'parked', priorityLevel: 4, deadline: null, estimatedMinutes: 0, status: 'active' },
+];
+
+const isReal = (id: string) => id.startsWith('goal_');
+
+interface EditDraft {
+  title: string;
+  deadline: string;
+  priorityLevel: number;
+}
+
+export function GoalsScreen() {
+  const [goals, setGoals] = useState<ApiGoal[]>(DEMO_GOALS);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [editId, setEditId] = useState<string | null>(null);
+  const [edit, setEdit] = useState<EditDraft | null>(null);
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+  const [decomp, setDecomp] = useState<{ goalId: string; data: GoalDecomposition } | null>(null);
+  const [decompBusy, setDecompBusy] = useState<string | null>(null);
+
+  // 추가 폼
+  const [showAdd, setShowAdd] = useState(false);
+  const [addTitle, setAddTitle] = useState('');
+  const [addCategory, setAddCategory] = useState('study');
+  const [addTier, setAddTier] = useState<GoalTier>('focus');
+  const [addDeadline, setAddDeadline] = useState('');
+  const [addError, setAddError] = useState<string | null>(null);
+  const [addLimitHit, setAddLimitHit] = useState(false);
+
+  const fetchGoals = useCallback(() => {
+    setIsLoading(true);
+    let cancelled = false;
+    goalsApi
+      .list()
+      .then((res) => {
+        if (cancelled) return;
+        const flat = [...res.focus, ...res.maintain, ...res.parked];
+        // 백엔드가 비어있으면 더미 유지 — 시연 흐름을 끊지 않는다.
+        if (flat.length > 0) setGoals(flat);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setError(
+          err instanceof ApiError
+            ? `[${err.code}] ${err.message}`
+            : '목표를 불러오지 못했어요. 더미 데이터로 진행합니다.',
+        );
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => fetchGoals(), [fetchGoals]);
+
+  const count = (tier: GoalTier) => goals.filter((g) => g.goalTier === tier).length;
+
+  // ── tier 변경 (focus/maintain → PATCH, parked → park) ──
+  const changeTier = async (goal: ApiGoal, tier: GoalTier) => {
+    if (goal.goalTier === tier) return;
+    const prev = goals;
+    setGoals((gs) => gs.map((g) => (g.goalId === goal.goalId ? { ...g, goalTier: tier } : g)));
+    setError(null);
+    if (!isReal(goal.goalId)) return; // 더미 — 로컬만
+    try {
+      const updated = tier === 'parked'
+        ? await goalsApi.park(goal.goalId)
+        : await goalsApi.update(goal.goalId, { goalTier: tier });
+      setGoals((gs) => gs.map((g) => (g.goalId === updated.goalId ? updated : g)));
+    } catch (err: unknown) {
+      if (err instanceof ApiError) {
+        setGoals(prev); // 422 한도 초과 등 — 되돌리고 사유 표시
+        setError(err.code === 'GOAL_TIER_LIMIT_EXCEEDED' ? err.message : `[${err.code}] ${err.message}`);
+      }
+    }
+  };
+
+  // ── 인라인 수정 (제목/마감/우선순위) ──
+  const startEdit = (goal: ApiGoal) => {
+    setEditId(goal.goalId);
+    setEdit({ title: goal.title, deadline: goal.deadline ?? '', priorityLevel: goal.priorityLevel });
+  };
+
+  const saveEdit = async (goal: ApiGoal) => {
+    if (!edit) return;
+    const body = {
+      title: edit.title.trim(),
+      deadline: edit.deadline.trim() || null,
+      priorityLevel: edit.priorityLevel,
+    };
+    const prev = goals;
+    setGoals((gs) => gs.map((g) => (g.goalId === goal.goalId ? { ...g, ...body } : g)));
+    setEditId(null);
+    setEdit(null);
+    setError(null);
+    if (!isReal(goal.goalId)) return;
+    try {
+      const updated = await goalsApi.update(goal.goalId, body);
+      setGoals((gs) => gs.map((g) => (g.goalId === updated.goalId ? updated : g)));
+    } catch (err: unknown) {
+      if (err instanceof ApiError) {
+        setGoals(prev);
+        setError(`[${err.code}] ${err.message}`);
+      }
+    }
+  };
+
+  // ── 삭제 (soft) ──
+  const removeGoal = async (goal: ApiGoal) => {
+    const prev = goals;
+    setGoals((gs) => gs.filter((g) => g.goalId !== goal.goalId));
+    setConfirmDeleteId(null);
+    setExpandedId(null);
+    if (!isReal(goal.goalId)) return;
+    try {
+      await goalsApi.remove(goal.goalId);
+    } catch (err: unknown) {
+      if (err instanceof ApiError) {
+        setGoals(prev);
+        setError(`[${err.code}] ${err.message}`);
+      }
+    }
+  };
+
+  // ── decompose (Draft Layer) ──
+  const runDecompose = async (goal: ApiGoal) => {
+    setDecompBusy(goal.goalId);
+    setError(null);
+    try {
+      const data = await goalsApi.decompose(goal.goalId);
+      setDecomp({ goalId: goal.goalId, data });
+    } catch (err: unknown) {
+      setError(err instanceof ApiError ? `[${err.code}] ${err.message}` : '분해에 실패했어요.');
+    } finally {
+      setDecompBusy(null);
+    }
+  };
+
+  // ── 추가 ──
+  const resetAdd = () => {
+    setShowAdd(false);
+    setAddTitle('');
+    setAddCategory('study');
+    setAddTier('focus');
+    setAddDeadline('');
+    setAddError(null);
+    setAddLimitHit(false);
+  };
+
+  const addGoal = async (tierOverride?: GoalTier) => {
+    const tier = tierOverride ?? addTier;
+    if (!addTitle.trim()) return;
+    const body = {
+      title: addTitle.trim(),
+      category: addCategory,
+      goalTier: tier,
+      priorityLevel: 3,
+      deadline: addDeadline.trim() || null,
+    };
+    setAddError(null);
+    try {
+      const created = await goalsApi.create(body);
+      setGoals((gs) => [...gs, created]);
+      resetAdd();
+    } catch (err: unknown) {
+      if (err instanceof ApiError) {
+        setAddError(err.message);
+        setAddLimitHit(err.code === 'GOAL_TIER_LIMIT_EXCEEDED');
+      } else {
+        // 백엔드 미동작 — 더미라도 추가해 시연 유지
+        setGoals((gs) => [
+          ...gs,
+          { goalId: `demo-${Date.now()}`, title: body.title, category: body.category, goalTier: tier, priorityLevel: 3, deadline: body.deadline, estimatedMinutes: 0, status: 'active' },
+        ]);
+        resetAdd();
+      }
+    }
+  };
+
+  return (
+    <div style={{ height: '100%', display: 'flex', flexDirection: 'column', background: 'var(--surface-ground)' }}>
+      <div style={{ flex: 1, overflowY: 'auto', padding: '14px 18px 28px', display: 'flex', flexDirection: 'column', gap: 14 }}>
+        {/* 헤더 + tier 사용량 */}
+        <div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 4 }}>
+            <Target size={18} weight="fill" color="var(--brand)" />
+            <h1 style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 22, letterSpacing: '-0.02em', margin: 0 }}>목표 관리</h1>
+          </div>
+          <p style={{ fontSize: 12, color: 'var(--text-2)', margin: '0 0 8px' }}>
+            {isLoading ? '목표를 불러오는 중…' : '집중·유지·보류로 나눠 관리해요. 집중은 최대 3개, 유지는 5개까지.'}
+          </p>
+          <div style={{ display: 'flex', gap: 6 }}>
+            {(['focus', 'maintain'] as GoalTier[]).map((t) => {
+              const m = GOAL_STATUS_META[t];
+              const limit = TIER_LIMIT[t];
+              const n = count(t);
+              const full = limit != null && n >= limit;
+              return (
+                <span key={t} className="tnum" style={{ height: 24, padding: '0 10px', background: m.bg, border: `1px solid ${m.border}`, color: m.color, borderRadius: 9999, fontSize: 11, fontWeight: 700, display: 'inline-flex', alignItems: 'center', gap: 4, opacity: full ? 1 : 0.92 }}>
+                  {m.label} {n}/{limit}{full ? ' · 가득참' : ''}
+                </span>
+              );
+            })}
+          </div>
+        </div>
+
+        {error && (
+          <div style={{ background: '#FAE2D8', border: '1px solid var(--coral-200)', color: 'var(--coral-700)', borderRadius: 10, padding: '10px 12px', fontSize: 11 }}>
+            {error}
+          </div>
+        )}
+
+        {/* tier 별 그룹 */}
+        {TIER_ORDER.map((tier) => {
+          const items = goals.filter((g) => g.goalTier === tier);
+          if (items.length === 0) return null;
+          const m = GOAL_STATUS_META[tier];
+          return (
+            <div key={tier} style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+              <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--text-3)', fontFamily: 'var(--font-mono)' }}>
+                {m.label} · {items.length}
+              </div>
+              {items.map((g) => {
+                const isExp = expandedId === g.goalId;
+                const isEditing = editId === g.goalId;
+                return (
+                  <div key={g.goalId} style={{ background: 'var(--surface-raised)', border: `1.5px solid ${isExp ? m.border : 'var(--sand-200)'}`, borderRadius: 14, padding: 12 }}>
+                    {/* 카드 본문 */}
+                    <div onClick={() => { setExpandedId(isExp ? null : g.goalId); setConfirmDeleteId(null); }} style={{ display: 'flex', alignItems: 'flex-start', gap: 10, cursor: 'pointer' }}>
+                      <div style={{ flex: 1, minWidth: 0 }}>
+                        <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 5, flexWrap: 'wrap' }}>
+                          <span style={{ height: 20, padding: '0 8px', borderRadius: 9999, background: m.bg, border: `1px solid ${m.border}`, fontSize: 10, fontWeight: 700, color: m.color, fontFamily: 'var(--font-mono)', display: 'inline-flex', alignItems: 'center' }}>{m.label}</span>
+                          <span style={{ height: 20, padding: '0 7px', background: 'var(--sand-100)', border: '1px solid var(--sand-200)', borderRadius: 9999, fontSize: 10, color: 'var(--text-2)', display: 'inline-flex', alignItems: 'center' }}>{CATEGORY_LABEL[g.category] ?? g.category}</span>
+                        </div>
+                        <div style={{ fontWeight: 700, fontSize: 14, color: 'var(--text-1)', letterSpacing: '-0.01em' }}>{g.title}</div>
+                        <div style={{ display: 'flex', gap: 5, flexWrap: 'wrap', marginTop: 4 }}>
+                          {g.deadline && (
+                            <span className="tnum" style={{ height: 20, padding: '0 7px', background: 'var(--sand-100)', border: '1px solid var(--sand-200)', borderRadius: 9999, fontSize: 10, color: 'var(--text-2)', display: 'inline-flex', alignItems: 'center' }}>~{g.deadline}</span>
+                          )}
+                          <span className="tnum" style={{ height: 20, padding: '0 7px', background: 'var(--sand-100)', border: '1px solid var(--sand-200)', borderRadius: 9999, fontSize: 10, color: 'var(--text-3)', display: 'inline-flex', alignItems: 'center' }}>우선순위 {g.priorityLevel}</span>
+                        </div>
+                      </div>
+                    </div>
+
+                    {/* 인라인 수정 폼 */}
+                    {isExp && isEditing && edit && (
+                      <div onClick={(e) => e.stopPropagation()} style={{ marginTop: 10, paddingTop: 10, borderTop: '1px solid var(--sand-200)', display: 'flex', flexDirection: 'column', gap: 8 }}>
+                        <input value={edit.title} onChange={(e) => setEdit({ ...edit, title: e.target.value })} placeholder="제목" style={inputStyle} />
+                        <div style={{ display: 'flex', gap: 6 }}>
+                          <input value={edit.deadline} onChange={(e) => setEdit({ ...edit, deadline: e.target.value })} placeholder="마감 YYYY-MM-DD" style={{ ...inputStyle, flex: 1 }} />
+                          <select value={edit.priorityLevel} onChange={(e) => setEdit({ ...edit, priorityLevel: Number(e.target.value) })} style={{ ...inputStyle, width: 96 }}>
+                            {[1, 2, 3, 4, 5].map((p) => <option key={p} value={p}>우선순위 {p}</option>)}
+                          </select>
+                        </div>
+                        <div style={{ display: 'flex', gap: 6 }}>
+                          <ReButton variant="ghost" size="sm" onClick={() => { setEditId(null); setEdit(null); }}>취소</ReButton>
+                          <div style={{ flex: 1 }}>
+                            <ReButton variant="primary" size="sm" full onClick={() => saveEdit(g)} disabled={!edit.title.trim()}>저장</ReButton>
+                          </div>
+                        </div>
+                      </div>
+                    )}
+
+                    {/* 액션 패널 */}
+                    {isExp && !isEditing && (
+                      <div onClick={(e) => e.stopPropagation()} style={{ marginTop: 10, paddingTop: 10, borderTop: '1px solid var(--sand-200)', display: 'flex', flexDirection: 'column', gap: 8 }}>
+                        <div style={{ display: 'flex', gap: 5 }}>
+                          {TIER_ORDER.map((t) => {
+                            const tm = GOAL_STATUS_META[t];
+                            const active = g.goalTier === t;
+                            return (
+                              <button key={t} onClick={() => changeTier(g, t)} style={{ flex: 1, height: 36, borderRadius: 9999, fontSize: 11, fontWeight: 600, background: active ? tm.color : 'var(--surface-ground)', color: active ? '#FFFCF6' : 'var(--text-3)', border: `1px solid ${active ? tm.color : 'var(--sand-200)'}`, cursor: 'pointer', fontFamily: 'var(--font-mono)' }}>{tm.label}</button>
+                            );
+                          })}
+                        </div>
+                        <div style={{ display: 'flex', gap: 6 }}>
+                          <IconAction icon={<PencilSimple size={13} />} label="수정" onClick={() => startEdit(g)} />
+                          <IconAction icon={<TreeStructure size={13} />} label={decompBusy === g.goalId ? '분해 중…' : '분해'} onClick={() => runDecompose(g)} disabled={decompBusy === g.goalId} />
+                          {confirmDeleteId === g.goalId ? (
+                            <button onClick={() => removeGoal(g)} style={{ flex: 1, height: 34, borderRadius: 10, border: 'none', background: 'var(--danger)', color: '#FFFCF6', fontWeight: 700, fontSize: 11, cursor: 'pointer', fontFamily: 'inherit' }}>정말 삭제</button>
+                          ) : (
+                            <IconAction icon={<Trash size={13} />} label="삭제" tone="danger" onClick={() => setConfirmDeleteId(g.goalId)} />
+                          )}
+                        </div>
+
+                        {decomp && decomp.goalId === g.goalId && (
+                          <AiDraftCard
+                            isDraft
+                            aiSource="llm"
+                            onAccept={() => setDecomp(null)}
+                            onEdit={() => setDecomp(null)}
+                            onReject={() => runDecompose(g)}
+                            acceptLabel="반영"
+                            editLabel="닫기"
+                            rejectLabel="다시"
+                          >
+                            <div style={{ fontSize: 11, color: 'var(--text-2)', marginBottom: 6 }}>하위 단계 제안</div>
+                            <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                              {decomp.data.nodes.map((n) => (
+                                <div key={n.nodeId} style={{ paddingLeft: n.depth * 12, fontSize: 12, color: 'var(--text-1)', display: 'flex', alignItems: 'center', gap: 6 }}>
+                                  <span style={{ width: 4, height: 4, borderRadius: 9999, background: 'var(--brand)', flexShrink: 0 }} />
+                                  {n.title}
+                                </div>
+                              ))}
+                            </div>
+                          </AiDraftCard>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          );
+        })}
+
+        {/* 추가 */}
+        {showAdd ? (
+          <div style={{ background: 'var(--brand-soft)', border: '1px solid var(--coral-200)', borderRadius: 14, padding: 12, display: 'flex', flexDirection: 'column', gap: 8 }}>
+            <div style={{ fontWeight: 700, fontSize: 13, color: 'var(--coral-700)' }}>새 목표</div>
+            <input value={addTitle} onChange={(e) => setAddTitle(e.target.value)} placeholder="예: 정보처리기사 필기" style={inputStyle} />
+            <div style={{ display: 'flex', gap: 6 }}>
+              <select value={addCategory} onChange={(e) => setAddCategory(e.target.value)} style={{ ...inputStyle, flex: 1 }}>
+                {CATEGORY_OPTIONS.map((c) => <option key={c.value} value={c.value}>{c.label}</option>)}
+              </select>
+              <input value={addDeadline} onChange={(e) => setAddDeadline(e.target.value)} placeholder="마감 YYYY-MM-DD" style={{ ...inputStyle, flex: 1 }} />
+            </div>
+            <div style={{ display: 'flex', gap: 5 }}>
+              {TIER_ORDER.map((t) => {
+                const tm = GOAL_STATUS_META[t];
+                const active = addTier === t;
+                return (
+                  <button key={t} onClick={() => { setAddTier(t); setAddLimitHit(false); }} style={{ flex: 1, height: 34, borderRadius: 9999, fontSize: 11, fontWeight: 600, background: active ? tm.color : 'var(--surface-raised)', color: active ? '#FFFCF6' : 'var(--text-3)', border: `1px solid ${active ? tm.color : 'var(--sand-200)'}`, cursor: 'pointer', fontFamily: 'var(--font-mono)' }}>{tm.label}</button>
+                );
+              })}
+            </div>
+            {addError && (
+              <div style={{ background: '#FAE2D8', border: '1px solid var(--coral-200)', color: 'var(--coral-700)', borderRadius: 9, padding: '8px 10px', fontSize: 11, display: 'flex', flexDirection: 'column', gap: 6 }}>
+                <span>{addError}</span>
+                {addLimitHit && addTier !== 'maintain' && (
+                  <button onClick={() => addGoal('maintain')} style={{ alignSelf: 'flex-start', height: 28, padding: '0 10px', borderRadius: 9999, border: '1px solid var(--coral-300, #EBA98F)', background: 'var(--surface-raised)', color: 'var(--coral-700)', fontSize: 11, fontWeight: 600, cursor: 'pointer', fontFamily: 'inherit' }}>
+                    유지(Maintain)로 추가할까요?
+                  </button>
+                )}
+              </div>
+            )}
+            <div style={{ display: 'flex', gap: 6 }}>
+              <ReButton variant="ghost" size="sm" onClick={resetAdd}>취소</ReButton>
+              <div style={{ flex: 1 }}>
+                <ReButton variant="primary" size="sm" full onClick={() => addGoal()} disabled={!addTitle.trim()}>추가</ReButton>
+              </div>
+            </div>
+          </div>
+        ) : (
+          <button onClick={() => setShowAdd(true)} style={{ display: 'flex', alignItems: 'center', gap: 6, justifyContent: 'center', height: 40, borderRadius: 12, border: '1.5px dashed var(--sand-300)', background: 'transparent', color: 'var(--text-2)', fontWeight: 600, fontSize: 12, cursor: 'pointer', fontFamily: 'inherit' }}>
+            <Plus size={14} /> 목표 추가
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+const inputStyle: React.CSSProperties = {
+  padding: '9px 11px',
+  borderRadius: 9,
+  border: '1px solid var(--sand-200)',
+  background: 'var(--surface-raised)',
+  fontSize: 12,
+  fontFamily: 'inherit',
+  outline: 'none',
+  color: 'var(--text-1)',
+};
+
+function IconAction({ icon, label, onClick, tone = 'default', disabled = false }: {
+  icon: React.ReactNode;
+  label: string;
+  onClick: () => void;
+  tone?: 'default' | 'danger';
+  disabled?: boolean;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      style={{
+        flex: 1, height: 34, borderRadius: 10, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 5,
+        border: `1px solid ${tone === 'danger' ? 'var(--coral-200)' : 'var(--sand-200)'}`,
+        background: 'var(--surface-ground)',
+        color: tone === 'danger' ? 'var(--danger)' : 'var(--text-2)',
+        fontWeight: 600, fontSize: 11, cursor: disabled ? 'wait' : 'pointer', fontFamily: 'inherit', opacity: disabled ? 0.6 : 1,
+      }}
+    >
+      {icon} {label}
+    </button>
+  );
+}

--- a/src/screens/TodayScreen.tsx
+++ b/src/screens/TodayScreen.tsx
@@ -11,7 +11,21 @@ import type { Task } from '../types';
 import { FAIL_REASONS, MERGED_PROPOSALS, MORNING_DATA } from '../data';
 import { useNavigation } from '../contexts/NavigationContext';
 import { habitsApi, todayApi } from '../lib/api';
-import { Gear } from '@phosphor-icons/react';
+import { Gear, Target } from '@phosphor-icons/react';
+
+// Today 헤더 우상단 — 목표 관리(S26) 진입점.
+function GoalsButton() {
+  const { setScreen } = useNavigation();
+  return (
+    <button
+      onClick={() => setScreen('goals')}
+      aria-label="목표 관리"
+      style={{ width: 36, height: 36, borderRadius: 9999, border: 'none', background: 'var(--surface-raised)', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer', flexShrink: 0 }}
+    >
+      <Target size={16} color="var(--text-2)" />
+    </button>
+  );
+}
 
 // Today 헤더 우상단 — Settings 화면 진입점.
 function SettingsButton() {
@@ -396,6 +410,7 @@ export function MergedTodayScreen({ tasks, onOpen, onMarkDone, onPartial, onFail
                 <span className="tnum" style={{ position: 'absolute', top: -2, right: -2, minWidth: 16, height: 16, padding: '0 4px', borderRadius: 9999, background: 'var(--brand)', color: '#FFFCF6', fontSize: 9, fontWeight: 700, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>{partialTasks.length}</span>
               </button>
             )}
+            <GoalsButton />
             <SettingsButton />
           </div>
         </div>

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -100,6 +100,28 @@ export interface GoalUpdateRequest {
   goalTier?: GoalTier;
 }
 
+export interface GoalCreateRequest {
+  title: string;
+  category: string;
+  goalTier: GoalTier;
+  priorityLevel: number; // 1~5
+  deadline?: string | null; // YYYY-MM-DD
+  estimatedMinutes?: number | null;
+}
+
+export interface GoalNode {
+  nodeId: string;
+  parentId: string | null;
+  title: string;
+  depth: number;
+}
+
+export interface GoalDecomposition {
+  goalId: string;
+  rootNodeId: string;
+  nodes: GoalNode[];
+}
+
 // ── Time Policies (S07) ───────────────────────────────────────
 export type PolicyType =
   | 'sleep'

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -93,6 +93,13 @@ export interface GoalsByTier {
   parked: ApiGoal[];
 }
 
+export interface GoalUpdateRequest {
+  title?: string;
+  deadline?: string | null; // YYYY-MM-DD
+  priorityLevel?: number;
+  goalTier?: GoalTier;
+}
+
 // ── Time Policies (S07) ───────────────────────────────────────
 export type PolicyType =
   | 'sleep'

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -29,6 +29,7 @@ export type ScreenId =
   | 'weekly'
   | 'inbox'
   | 'review'
+  | 'goals'
   | 'settings';
 
 export type TabId = 'today' | 'weekly' | 'inbox' | 'review';


### PR DESCRIPTION
## 요약
- #10(S26) 의 미구현 갭이던 **독립 목표 관리 화면** 신규. 온보딩 재분류 영속화(동반 커밋)와 함께 goals 프론트 연동을 마무리.

## 변경
### 새 화면 `GoalsScreen` (S26)
- tier별(집중/유지/보류) 그룹 + 한도 사용량(집중 n/3 · 유지 n/5) 표시
- 카드별: 재분류(focus/maintain→PATCH, parked→park) · 인라인 수정(제목/마감/우선순위) · park · soft delete
- 목표 추가 폼 — 집중/유지 한도 초과 시 `422 GOAL_TIER_LIMIT_EXCEEDED` 인라인 + "유지로 추가" 제안
- decompose → `AiDraftCard`(Draft Layer + 3버튼)로 하위 단계 노출
### API / 네비게이션
- `goalsApi.create/remove/decompose` + 타입(`GoalCreateRequest`/`GoalDecomposition`/`GoalNode`)
- `ScreenId` 에 `goals` 추가, Today 헤더 + 데스크탑 사이드바 진입점
### 동반 커밋 (caa4c5f)
- 온보딩 `GoalClassificationScreen` 재분류를 백엔드에 저장(`goalsApi.update/park`).

## 검증
- `tsc` + `vite build` 통과
- docker(postgres+backend) 실 DB 로 create/update/park/delete/decompose + 422 한도 경로 E2E 확인
- ⚠️ 브라우저 클릭 테스트는 미실시(드라이버 미설치) — 빌드/타입/API 레벨까지 검증

## 참고
- base가 `feat/backend-api-integration` 인 **스택 PR** (main 대비 깔끔한 diff 위해, PR #15 머지 후 정리)
- #10 은 S24/25/27 도 포함하므로 자동 close 는 걸지 않음 — S26 부분만 처리

Refs #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)