### PR TITLE
feat: Inbox 실 API 연동 — convert-to-goal/action + archive (#22)

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -232,11 +232,17 @@ export const inboxApi = {
   update: (inboxId: string, body: InboxUpdateRequest) =>
     request<InboxItem>(`/inbox/${inboxId}`, { method: 'PATCH', body }),
 
-  promote: (inboxId: string) =>
-    request<InboxItem>(`/inbox/${inboxId}/promote`, { method: 'POST', body: {} }),
+  // Inbox → Goal (tier=maintain, 한도 초과 시 422 GOAL_TIER_LIMIT_EXCEEDED)
+  convertToGoal: (inboxId: string) =>
+    request<InboxItem>(`/inbox/${inboxId}/convert-to-goal`, { method: 'POST', body: {} }),
 
-  remove: (inboxId: string) =>
-    request<void>(`/inbox/${inboxId}`, { method: 'DELETE' }),
+  // Inbox → ActionItem(source=inbox)
+  convertToAction: (inboxId: string) =>
+    request<InboxItem>(`/inbox/${inboxId}/convert-to-action`, { method: 'POST', body: {} }),
+
+  // soft delete (status=archived, 204 No Content)
+  archive: (inboxId: string) =>
+    request<void>(`/inbox/${inboxId}/archive`, { method: 'POST', body: {} }),
 };
 
 // ── Habits (S27) ──────────────────────────────────────────────

--- a/src/screens/InboxScreen.tsx
+++ b/src/screens/InboxScreen.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { Sparkle, ArrowUp, Trash, TreeStructure } from '@phosphor-icons/react';
+import { Sparkle, ArrowUp, Archive, TreeStructure, ListChecks } from '@phosphor-icons/react';
 import { ApiError, inboxApi } from '../lib/api';
 import type { InboxItem, InboxStatus } from '../types/api';
 
@@ -65,22 +65,49 @@ export function InboxScreen() {
     }
   };
 
-  const remove = async (id: string) => {
+  // 변경된 항목을 목록에 반영. 활성 status 필터와 안 맞으면(예: archived) 빠짐.
+  const applyUpdate = (updated: InboxItem) => {
+    setItems((s) => {
+      const next = s.map((x) => (x.inboxId === updated.inboxId ? updated : x));
+      return filter === 'all' ? next : next.filter((x) => x.status === filter);
+    });
+  };
+
+  // soft delete — 백엔드는 status=archived 로 바꿀 뿐 행을 지우지 않음 (204).
+  const archive = async (id: string) => {
+    setError(null);
     try {
-      await inboxApi.remove(id);
-      setItems((s) => s.filter((x) => x.inboxId !== id));
+      await inboxApi.archive(id);
+      const item = items.find((x) => x.inboxId === id);
+      if (item) applyUpdate({ ...item, status: 'archived' });
     } catch (err: unknown) {
-      const msg = err instanceof ApiError ? `[${err.code}] ${err.message}` : '삭제 실패';
+      const msg = err instanceof ApiError ? `[${err.code}] ${err.message}` : '보관 실패';
       setError(msg);
     }
   };
 
-  const promote = async (id: string) => {
+  const convertToGoal = async (id: string) => {
+    setError(null);
     try {
-      const next = await inboxApi.promote(id);
-      setItems((s) => s.map((x) => (x.inboxId === id ? next : x)));
+      applyUpdate(await inboxApi.convertToGoal(id));
     } catch (err: unknown) {
-      const msg = err instanceof ApiError ? `[${err.code}] ${err.message}` : '목표로 승격 실패';
+      // Maintain 한도 초과(422)는 백엔드 메시지가 사용자 친화적이라 그대로 노출.
+      const msg =
+        err instanceof ApiError
+          ? err.code === 'GOAL_TIER_LIMIT_EXCEEDED'
+            ? err.message
+            : `[${err.code}] ${err.message}`
+          : '목표로 전환 실패';
+      setError(msg);
+    }
+  };
+
+  const convertToAction = async (id: string) => {
+    setError(null);
+    try {
+      applyUpdate(await inboxApi.convertToAction(id));
+    } catch (err: unknown) {
+      const msg = err instanceof ApiError ? `[${err.code}] ${err.message}` : '할 일로 전환 실패';
       setError(msg);
     }
   };
@@ -145,20 +172,31 @@ export function InboxScreen() {
                 )}
                 <div style={{ flex: 1 }} />
                 {status !== 'promoted' && status !== 'archived' && (
+                  <>
+                    <button
+                      onClick={() => convertToAction(it.inboxId)}
+                      style={{ height: 26, padding: '0 10px', borderRadius: 9999, border: '1px solid var(--sand-200)', background: 'var(--surface-raised)', color: 'var(--text-2)', fontSize: 11, fontWeight: 600, cursor: 'pointer', fontFamily: 'inherit', display: 'inline-flex', alignItems: 'center', gap: 4 }}
+                    >
+                      <ListChecks size={11} weight="fill" /> 할 일로
+                    </button>
+                    <button
+                      onClick={() => convertToGoal(it.inboxId)}
+                      style={{ height: 26, padding: '0 10px', borderRadius: 9999, border: '1px solid var(--coral-200)', background: 'var(--brand-soft)', color: 'var(--coral-700)', fontSize: 11, fontWeight: 600, cursor: 'pointer', fontFamily: 'inherit', display: 'inline-flex', alignItems: 'center', gap: 4 }}
+                    >
+                      <TreeStructure size={11} weight="fill" /> 목표로
+                    </button>
+                  </>
+                )}
+                {status !== 'archived' && (
                   <button
-                    onClick={() => promote(it.inboxId)}
-                    style={{ height: 26, padding: '0 10px', borderRadius: 9999, border: '1px solid var(--coral-200)', background: 'var(--brand-soft)', color: 'var(--coral-700)', fontSize: 11, fontWeight: 600, cursor: 'pointer', fontFamily: 'inherit', display: 'inline-flex', alignItems: 'center', gap: 4 }}
+                    onClick={() => archive(it.inboxId)}
+                    style={{ width: 26, height: 26, borderRadius: 9999, border: 'none', background: 'transparent', color: 'var(--text-3)', cursor: 'pointer', display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}
+                    aria-label="보관"
+                    title="보관"
                   >
-                    <TreeStructure size={11} weight="fill" /> 목표로
+                    <Archive size={13} />
                   </button>
                 )}
-                <button
-                  onClick={() => remove(it.inboxId)}
-                  style={{ width: 26, height: 26, borderRadius: 9999, border: 'none', background: 'transparent', color: 'var(--text-3)', cursor: 'pointer', display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}
-                  aria-label="삭제"
-                >
-                  <Trash size={13} />
-                </button>
               </div>
             </div>
           );

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -161,6 +161,8 @@ export interface NotificationSettingsUpdateRequest {
 
 // ── Inbox (S24·S25) ───────────────────────────────────────────
 export type InboxStatus = 'captured' | 'classified' | 'archived' | 'promoted';
+// 백엔드가 강제하는 6종 enum (#40, schemas/inbox.py)
+export type InboxCategory = 'study' | 'project' | 'health' | 'routine' | 'schedule' | 'other';
 
 export interface InboxItem {
   inboxId: string;
@@ -176,7 +178,7 @@ export interface InboxCreateRequest {
 }
 
 export interface InboxUpdateRequest {
-  userCategory?: string;
+  userCategory?: InboxCategory;
   status?: InboxStatus;
 }
 


### PR DESCRIPTION
## 배경
백엔드 #40 (api-contract **v1.1**)에서 Inbox(§18)가 mock → 실 DB 구현으로 바뀌면서 엔드포인트 2개가 rename 되고 1개가 신설됨. 프론트가 옛 경로(`/promote`, `DELETE`)를 그대로 부르고 있어 **승격·삭제가 404** 나는 상태라 이를 맞춤.

## 변경된 계약 (백엔드 #40)
| 동작 | 이전 (mock) | 변경 후 |
|------|------|------|
| 목표로 전환 | `POST /inbox/{id}/promote` | `POST /inbox/{id}/convert-to-goal` |
| 삭제 | `DELETE /inbox/{id}` | `POST /inbox/{id}/archive` (204, soft delete) |
| 할 일로 전환 | (없음) | `POST /inbox/{id}/convert-to-action` 🆕 |

## 작업 내용
- **`lib/api.ts`** — `inboxApi.promote`→`convertToGoal`, `remove`→`archive` 로 경로 교체, `convertToAction` 신규
- **`InboxScreen.tsx`**
  - "할 일로"(convert-to-action) 버튼 추가, 삭제(Trash)→보관(Archive) 아이콘 교체
  - archive 는 soft delete(`status=archived`) 라 행 제거 대신 status 갱신 + 활성 status 필터 반영
  - convert-to-goal 의 422 `GOAL_TIER_LIMIT_EXCEEDED`(Maintain ≤5) 는 백엔드 메시지 그대로 노출
- **`types/api.ts`** — `InboxCategory` 6종 enum(`study/project/health/routine/schedule/other`) 추가, `InboxUpdateRequest.userCategory` 좁힘

## 검증
- `tsc --noEmit` 통과
- 옛 메서드(`inboxApi.promote/remove`) 잔존 참조 없음 확인

## 참고
- `aiSource`/`isDraft` LLM 메타는 백엔드에서 후속 chore PR로 분리됨 → 본 PR 범위 밖
- 로컬 동작 확인(백엔드 띄워서)은 아직 안 함 — 리뷰 후 필요 시 진행

Closes #22 (frontend 측)

🤖 Generated with [Claude Code](https://claude.com/claude-code)