### PR TITLE
feat: Today·Recovery 실행 루프 실 API 연동 — start/check-in/실패태깅/복구카드 (#19, #20)

### DIFF
--- a/src/app/MobileKitPage.tsx
+++ b/src/app/MobileKitPage.tsx
@@ -181,6 +181,7 @@ export function MobileKitPage() {
             <Safe scroll={false}>
               <MergedRecoveryScreen
                 task={{ id: 'demo', title: 'GROUP BY / HAVING 실습', status: 'failed', goal: 'g1', carryover: false }}
+                executionId={null}
                 failReason="막막함"
                 onAccept={() => {}}
                 onDismiss={() => {}}

--- a/src/app/ReActionMerged.tsx
+++ b/src/app/ReActionMerged.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { CaretLeft } from '@phosphor-icons/react';
 import { MergedTabBar } from '../components/TabBar';
 import { SystemIntroScreen } from '../screens/SystemIntroScreen';
@@ -18,7 +18,35 @@ import { WeeklyCalendarScreenV2 } from '../screens/WeeklyCalendarScreen';
 import { WeeklyReviewScreenV2 } from '../screens/WeeklyReviewScreen';
 import { BASE_TASKS } from '../data';
 import { useNavigation } from '../contexts/NavigationContext';
-import type { ScreenId, TabId, Task } from '../types';
+import { reflectionApi, todayApi } from '../lib/api';
+import type { ScreenId, TabId, Task, TaskStatus } from '../types';
+import type { AgendaCard, FailureTagMaster } from '../types/api';
+
+// 백엔드 actionId('action_<uuid>') 만 실 API 체인을 태운다 — mock id('t1' 등)는 로컬 전용.
+const isBackendTask = (id: string) => id.startsWith('action_');
+
+// AgendaCard.status(#19-A) → 화면 TaskStatus
+const STATUS_MAP: Record<string, TaskStatus> = {
+  planned: 'todo',
+  in_progress: 'in_progress',
+  done: 'done',
+  partial_done: 'partial_done',
+  failed: 'failed',
+  over_done: 'done',
+};
+
+function cardToTask(card: AgendaCard): Task {
+  return {
+    id: card.actionId,
+    title: card.title,
+    status: STATUS_MAP[card.status] ?? 'todo',
+    dur: `${card.estimatedMinutes}분`,
+    carryover: card.source === 'recovery_carryover',
+    tag: card.source.startsWith('recovery_')
+      ? { tone: 'coral', label: '복구 카드' }
+      : undefined,
+  };
+}
 
 // onboarding 흐름은 백엔드 §3 state machine 을 기반으로 하되, 클라이언트에서 두 쌍을
 // 묶고 coping-style 을 제거해 8단계 → 5단계로 줄였다 (recovery.tone 은 인터뷰에서 받음):
@@ -87,11 +115,62 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
   const [activeTask, setActiveTask] = useState<Task | null>(null);
   const [failReason, setFailReason] = useState('');
   const [recoveryCount, setRecoveryCount] = useState(37);
+  // taskId(action_<uuid>) → executionId(exec_<uuid>) — #19-B 실행 추적
+  const [executions, setExecutions] = useState<Record<string, string>>({});
+  // 13종 실패 사유 마스터 (S18 칩 + label→tagCode 매핑) — #19-B
+  const [failTags, setFailTags] = useState<FailureTagMaster[]>([]);
+  // 복구 화면에 넘길 실행 ID — #20-A
+  const [activeExecutionId, setActiveExecutionId] = useState<string | null>(null);
+
+  // mock-and-replace: 백엔드 agenda 에 오늘 카드가 있으면 mock(BASE_TASKS) 교체.
+  useEffect(() => {
+    let cancelled = false;
+    todayApi.agenda().then(
+      (agenda) => {
+        if (cancelled) return;
+        if (agenda.cards.length > 0) setTasks(agenda.cards.map(cardToTask));
+      },
+      () => { /* 백엔드 미기동 — mock 유지 */ },
+    );
+    reflectionApi.failureTags().then(
+      (tags) => { if (!cancelled) setFailTags(tags); },
+      () => { /* mock 라벨 유지 */ },
+    );
+    return () => { cancelled = true; };
+  }, []);
+
+  // [▶ 시작] — 실행 생성 (이미 시작했으면 기존 executionId 재사용). #19-B
+  const ensureExecution = async (taskId: string): Promise<string | null> => {
+    if (!isBackendTask(taskId)) return null;
+    if (executions[taskId]) return executions[taskId];
+    try {
+      const res = await todayApi.start(taskId);
+      setExecutions((m) => ({ ...m, [taskId]: res.executionId }));
+      return res.executionId;
+    } catch {
+      return executions[taskId] ?? null;
+    }
+  };
+
+  // Quick Check-in (4칩 중 done/failed 만 — partial 은 #19-B-2). 실패는 조용히.
+  const checkInRemote = async (
+    taskId: string,
+    completionStatus: 'done' | 'failed',
+  ): Promise<string | null> => {
+    const executionId = await ensureExecution(taskId);
+    if (!executionId) return null;
+    try {
+      await todayApi.checkIn({ executionId, completionStatus });
+    } catch { /* 이미 체크인됨(409) 등 — 데모 흐름 유지 */ }
+    return executionId;
+  };
 
   const showTabs = !hideTabs && TAB_SCREENS.includes(screen);
 
-  const markDone = (id: string) =>
+  const markDone = (id: string) => {
     setTasks((ts) => ts.map((t) => t.id === id ? { ...t, status: 'done' } : t));
+    void checkInRemote(id, 'done');
+  };
 
   const markPartial = (id: string, pct: number) =>
     setTasks((ts) => ts.map((t) => t.id === id
@@ -103,7 +182,20 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
     setTasks((ts) => ts.map((t) => t.id === id ? { ...t, status: 'failed', failReason: reason } : t));
     setActiveTask(tasks.find((t) => t.id === id) || null);
     setFailReason(reason);
-    setScreen('recovery');
+    // 실 API 체인: 체크인(failed) → 실패 사유 태깅 → 복구 화면 (#19-B → §11 → §12)
+    void (async () => {
+      const executionId = await checkInRemote(id, 'failed');
+      setActiveExecutionId(executionId);
+      if (executionId) {
+        const tagCode = failTags.find((t) => t.labelKo === reason)?.tagCode;
+        if (tagCode) {
+          try {
+            await reflectionApi.tagExecution(executionId, { tagCodes: [tagCode] });
+          } catch { /* 이미 태깅됨(409) 등 */ }
+        }
+      }
+      setScreen('recovery');
+    })();
   };
 
   // 실제 시작 트리거 — task 를 in_progress 로 전이하고 focus 화면으로.
@@ -120,12 +212,15 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
       }),
     );
     setActiveTask({ ...t, status: 'in_progress' });
+    void ensureExecution(id);
     setScreen('focus');
   };
 
   const openRecovery = () => {
     const partial = tasks.find((t) => t.status === 'partial_done' || t.status === 'recovery_pending');
-    setActiveTask(partial || tasks[1]);
+    const target = partial || tasks[1];
+    setActiveTask(target);
+    setActiveExecutionId(target ? (executions[target.id] ?? null) : null);
     setScreen('recovery');
   };
 
@@ -179,6 +274,7 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
         {screen === 'today' && (
           <MergedTodayScreen
             tasks={tasks}
+            failTags={failTags}
             onOpen={openTask}
             onMarkDone={markDone}
             onPartial={markPartial}
@@ -190,6 +286,7 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
         {screen === 'focus' && activeTask && (
           <FocusScreen
             task={activeTask}
+            executionId={activeTask ? (executions[activeTask.id] ?? null) : null}
             elapsedMin={18} totalMin={45}
             onBack={() => { setScreen('today'); setActiveTask(null); }}
             onPause={() => setScreen('today')}
@@ -199,6 +296,7 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
         {screen === 'recovery' && (
           <MergedRecoveryScreen
             task={activeTask}
+            executionId={activeExecutionId}
             failReason={failReason}
             onAccept={acceptRecovery}
             onDismiss={() => setScreen('today')}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -2,17 +2,19 @@
 // 응답·에러·인증·Idempotency 규약은 docs/api-contract.md v0.7 의 §1 을 따른다.
 
 import type {
-  ActionItem,
+  ActionDetail,
   AnonymizeRequest,
   ApiErrorPayload,
-  ApiRecoveryProposal,
   AuthSession,
   CalendarConnection,
   CheckInRequest,
+  CheckInResponse,
+  ExecutionStartResponse,
   ConsentRecord,
   ConsentUpdateRequest,
-  ExecutionEvent,
-  FailureTag,
+  FailureTagMaster,
+  FailureTagRequest,
+  FailureTagResponse,
   FixedSchedule,
   FixedScheduleCreateRequest,
   FreeBusy,
@@ -32,6 +34,8 @@ import type {
   PlanScheduledBlock,
   PushSubscribeRequest,
   RecoveryDecisionRequest,
+  RecoveryDecisionResponse,
+  RecoveryProposalsResponse,
   ReflectionBatchRequest,
   ReflectionPendingItem,
   ReplanDiff,
@@ -265,36 +269,38 @@ export const habitsApi = {
     }),
 };
 
-// ── Today / Execution (S10-S13) — 현재 백엔드 501. fetch 래퍼만 미리 ──
+// ── Today / Execution (S10-S13) — #19-A 조회 + #19-B start/check-ins 구현 ──
 export const todayApi = {
   agenda: () => request<TodayAgenda>('/today/agenda'),
 
-  getAction: (actionItemId: string) =>
-    request<ActionItem>(`/today/actions/${actionItemId}`),
+  getAction: (actionId: string) =>
+    request<ActionDetail>(`/today/actions/${actionId}`),
 
-  start: (actionItemId: string) =>
-    request<ExecutionEvent>(`/today/actions/${actionItemId}/start`, {
+  // [▶ 시작] → execution_events 생성. 블록 없으면 서버가 즉석 블록 생성 (#19-B)
+  start: (actionId: string) =>
+    request<ExecutionStartResponse>(`/today/actions/${actionId}/start`, {
       method: 'POST',
       body: {},
     }),
 
+  // pause/resume 은 #19-B-2 까지 백엔드 501
   pause: (executionId: string) =>
-    request<ExecutionEvent>(`/today/focus/${executionId}/pause`, {
+    request<unknown>(`/today/focus/${executionId}/pause`, {
       method: 'POST',
       body: {},
     }),
 
   resume: (executionId: string) =>
-    request<ExecutionEvent>(`/today/focus/${executionId}/resume`, {
+    request<unknown>(`/today/focus/${executionId}/resume`, {
       method: 'POST',
       body: {},
     }),
 
-  checkIn: (body: CheckInRequest, idempotencyKey?: string) =>
-    request<ExecutionEvent>('/today/check-ins', {
+  // Quick Check-in 4칩 (#19-B). needsFailureTags=true → S18 → §12 Recovery
+  checkIn: (body: CheckInRequest) =>
+    request<CheckInResponse>('/today/check-ins', {
       method: 'POST',
       body,
-      idempotencyKey,
     }),
 };
 
@@ -336,29 +342,40 @@ export const reviewsApi = {
     }),
 };
 
-// ── Reflection (S17·S18) — 백엔드 501. fetch 래퍼만 미리 ────────
+// ── Reflection (S17·S18) — #19-B failure-tags 구현. pending/batch 는 501 ──
 export const reflectionApi = {
   pending: () => request<ReflectionPendingItem[]>('/reflection/pending'),
 
-  failureTags: () => request<FailureTag[]>('/reflection/failure-tags'),
+  // 13종 실패 사유 마스터 (S18 칩 원본)
+  failureTags: () => request<FailureTagMaster[]>('/reflection/failure-tags'),
 
   batch: (body: ReflectionBatchRequest, idempotencyKey: string) =>
     request<void>('/reflection/batch', { method: 'POST', body, idempotencyKey }),
 
-  tagExecution: (executionId: string, body: { tags: string[]; memoEncrypted?: string }) =>
-    request<void>(`/reflection/failure-tags/${executionId}`, { method: 'POST', body }),
+  // 실패 사유 0~2개 태깅 — 이 태그가 Recovery 룰 엔진(§12) 입력이 된다 (#19-B)
+  tagExecution: (executionId: string, body: FailureTagRequest) =>
+    request<FailureTagResponse>(`/reflection/failure-tags/${executionId}`, {
+      method: 'POST',
+      body,
+    }),
 };
 
-// ── Recovery / Replan (S19·S20) — 백엔드 501 ───────────────────
+// ── Recovery / Replan (S19·S20) — #20-A 구현. replan 은 501 ────
 export const recoveryApi = {
+  // 회복 카드 2~4장 생성 (Draft Layer). pending 존재 시 그대로 반환 — 재호출 안전
   generateProposals: (executionId: string) =>
-    request<ApiRecoveryProposal[]>('/recovery/proposals/generate', {
+    request<RecoveryProposalsResponse>('/recovery/proposals/generate', {
       method: 'POST',
       body: { executionId },
     }),
 
+  // 수락/스킵 확정 — Idempotency-Key 필수 (§1.7)
   decide: (body: RecoveryDecisionRequest, idempotencyKey: string) =>
-    request<void>('/recovery/decisions', { method: 'POST', body, idempotencyKey }),
+    request<RecoveryDecisionResponse>('/recovery/decisions', {
+      method: 'POST',
+      body,
+      idempotencyKey,
+    }),
 };
 
 export const replanApi = {

--- a/src/screens/FocusScreen.tsx
+++ b/src/screens/FocusScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React from 'react';
 import { CaretLeft, Pause, Check } from '@phosphor-icons/react';
 import { Chip } from '../components/Chip';
 import { ReButton } from '../components/ReButton';
@@ -8,6 +8,9 @@ import type { Task } from '../types';
 interface FocusScreenProps {
   // 잘못된 상태(force navigation, 빈 tasks 등)로 마운트되어도 폭발하지 않도록 null 허용.
   task: Task | null;
+  // 실행 ID(exec_<uuid>) — 시작/체크인 등 실행 생명주기는 컨트롤러(ReActionMerged)가
+  // 소유한다 (#19-B). 본 화면은 표시 + pause 시도만.
+  executionId?: string | null;
   elapsedMin: number;
   totalMin: number;
   onPause: () => void;
@@ -15,21 +18,7 @@ interface FocusScreenProps {
   onBack: () => void;
 }
 
-export function FocusScreen({ task, elapsedMin, totalMin, onPause, onComplete, onBack }: FocusScreenProps) {
-  // mock-and-replace: 백엔드 /today/* 가 501. 시작/일시정지/완료를 mock 으로 시도하되
-  // 실패는 조용히 — 화면 흐름(onPause/onComplete) 은 그대로 진행.
-  const executionIdRef = useRef<string | null>(null);
-
-  // 첫 진입 시 시작 호출 (executionId 확보 시도)
-  React.useEffect(() => {
-    if (!task) return;
-    let cancelled = false;
-    todayApi.start(task.id).then(
-      (e) => { if (!cancelled) executionIdRef.current = e.executionId; },
-      () => { /* 501 — 그냥 진행 */ },
-    );
-    return () => { cancelled = true; };
-  }, [task?.id]);
+export function FocusScreen({ task, executionId, elapsedMin, totalMin, onPause, onComplete, onBack }: FocusScreenProps) {
 
   // task 없이 잘못 마운트된 경우 — 빈 흰 화면 대신 명확한 안내 + 뒤로가기.
   if (!task) {
@@ -43,21 +32,15 @@ export function FocusScreen({ task, elapsedMin, totalMin, onPause, onComplete, o
   }
 
   const handlePause = () => {
-    if (executionIdRef.current) {
-      todayApi.pause(executionIdRef.current).catch(() => {});
+    // pause 는 #19-B-2 까지 백엔드 501 — 시도만 하고 조용히 진행.
+    if (executionId) {
+      todayApi.pause(executionId).catch(() => {});
     }
     onPause();
   };
 
   const handleComplete = () => {
-    if (executionIdRef.current) {
-      todayApi
-        .checkIn(
-          { executionId: executionIdRef.current, completionStatus: 'done', actualDuration: elapsedMin },
-          `check-${executionIdRef.current}`,
-        )
-        .catch(() => {});
-    }
+    // done 체크인은 컨트롤러(markDone → checkInRemote)가 수행 — 이중 체크인 방지.
     onComplete();
   };
 

--- a/src/screens/RecoveryScreen.tsx
+++ b/src/screens/RecoveryScreen.tsx
@@ -2,25 +2,89 @@ import React, { useEffect, useState } from 'react';
 import {
   ArrowsClockwise,
   XCircle,
-  Sparkle,
   Check,
   Info,
 } from '@phosphor-icons/react';
 import { MERGED_PROPOSALS } from '../data';
 import { recoveryApi } from '../lib/api';
 import type { Task, RecoveryProposal } from '../types';
+import type { RecoveryCard, RecoveryGroup } from '../types/api';
 
 interface MergedRecoveryScreenProps {
   task: Task | null;
+  // 실패 체크인된 실행 ID(exec_<uuid>) — 있으면 실 API(#20-A) 카드, 없으면 mock.
+  executionId: string | null;
   failReason?: string;
   onAccept: (optionId: string) => void;
   onDismiss: () => void;
 }
 
-export function MergedRecoveryScreen({ task, failReason, onAccept, onDismiss }: MergedRecoveryScreenProps) {
+// UX 4 그룹 → 카드 색 (api-contract §12)
+const GROUP_STYLE: Record<RecoveryGroup, { type: string; bg: string; bc: string; ac: string }> = {
+  DOWNSCOPE:  { type: 'DOWNSCOPE',  bg: '#E5EFE3',          bc: '#b4dfc8',           ac: 'var(--success)' },
+  RESCHEDULE: { type: 'RESCHEDULE', bg: '#FBEEDA',          bc: '#F2D29A',           ac: 'var(--warning)' },
+  CARRY_OVER: { type: 'CARRY OVER', bg: 'var(--brand-soft)', bc: 'var(--coral-200)', ac: 'var(--brand)' },
+  PARK:       { type: 'PARK',       bg: 'var(--sand-100)',  bc: 'var(--sand-200)',   ac: 'var(--text-2)' },
+};
+
+// 백엔드 RecoveryCard(#20-A) → 화면 표시용 RecoveryProposal.
+// conf(성공률)는 실측 통계가 쌓이기 전까지 표시하지 않는다 (undefined).
+function cardToProposal(card: RecoveryCard): RecoveryProposal {
+  const style = GROUP_STYLE[card.optionGroup] ?? GROUP_STYLE.DOWNSCOPE;
+  return {
+    id: card.attemptId,
+    type: style.type,
+    bg: style.bg,
+    bc: style.bc,
+    ac: style.ac,
+    title: card.labelKo,
+    desc: card.suggestedActionText,
+    why: card.triggerTag
+      ? `선택하신 실패 사유(${card.triggerTag})에 가장 잘 맞는 전략이에요.`
+      : '실패 사유와 무관하게 부담을 낮춰주는 기본 전략이에요.',
+    time: card.minRecoveryUnitMinutes > 0 ? `${card.minRecoveryUnitMinutes}분~` : '이번 주 보류',
+  };
+}
+
+export function MergedRecoveryScreen({ task, executionId, failReason, onAccept, onDismiss }: MergedRecoveryScreenProps) {
   const [sel, setSel] = useState<string | null>(null);
   const [showWhy, setShowWhy] = useState<string | null>(null);
   const [accepted, setAccepted] = useState(false);
+  // mock-and-replace: 실 API 카드 도착 전까지 mock 제안 표시.
+  const [proposals, setProposals] = useState<RecoveryProposal[]>(MERGED_PROPOSALS);
+  const [fromApi, setFromApi] = useState(false);
+
+  // 실패 체크인된 실행이 있으면 실제 회복 카드 생성 (#20-A).
+  // pending 카드가 이미 있으면 백엔드가 그대로 반환하므로 재호출 안전.
+  useEffect(() => {
+    if (!executionId) return;
+    let cancelled = false;
+    recoveryApi.generateProposals(executionId).then(
+      (res) => {
+        if (cancelled || res.cards.length === 0) return;
+        setProposals(res.cards.map(cardToProposal));
+        setFromApi(true);
+        setSel(null);
+      },
+      () => { /* 백엔드 미기동/미자격 — mock 유지 */ },
+    );
+    return () => { cancelled = true; };
+  }, [executionId]);
+
+  const accept = () => {
+    if (!sel) return;
+    // 실 API 카드면 사용자 결정 확정 (Idempotency-Key 필수, §1.7).
+    if (fromApi && executionId) {
+      recoveryApi
+        .decide(
+          { executionId, decision: 'accepted', acceptedAttemptId: sel },
+          `rec-${executionId}-${sel}`,
+        )
+        .catch(() => { /* 이미 결정됨(409) 등 — 데모 흐름 유지 */ });
+    }
+    setAccepted(true);
+    setTimeout(() => onAccept(sel), 1400);
+  };
 
   // task 없이 잘못 마운트된 경우 — 회색 빈 영역을 보여주지 않도록 안내 화면.
   if (!task) {
@@ -33,34 +97,8 @@ export function MergedRecoveryScreen({ task, failReason, onAccept, onDismiss }: 
     );
   }
 
-  // mock-and-replace: 진입 시 LLM 회복 제안 생성 시도. 백엔드 501 → 더미 그대로.
-  useEffect(() => {
-    let cancelled = false;
-    recoveryApi.generateProposals(task.id).then(
-      (proposals) => {
-        if (cancelled) return;
-        // TODO(backend-#20): proposals → RecoveryProposal[] 매핑
-        void proposals;
-      },
-      () => { /* 501 ok */ },
-    );
-    return () => { cancelled = true; };
-  }, [task]);
-
-  const accept = () => {
-    if (!sel) return;
-    // mock-and-replace: 사용자 선택 저장 시도. Idempotency-Key 동봉.
-    if (task) {
-      recoveryApi
-        .decide({ executionId: task.id, proposalId: sel }, `rec-${task.id}-${sel}`)
-        .catch(() => { /* 501 ok */ });
-    }
-    setAccepted(true);
-    setTimeout(() => onAccept(sel), 1400);
-  };
-
   if (accepted) {
-    const p = MERGED_PROPOSALS.find((x) => x.id === sel);
+    const p = proposals.find((x) => x.id === sel);
     return (
       <div style={{ position: 'absolute', inset: 0, zIndex: 50, background: 'var(--surface-ground)', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '40px 24px', gap: 18 }}>
         <div style={{ width: 72, height: 72, borderRadius: 9999, background: 'var(--coral-50)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
@@ -68,7 +106,9 @@ export function MergedRecoveryScreen({ task, failReason, onAccept, onDismiss }: 
         </div>
         <div style={{ fontFamily: 'var(--font-display)', fontSize: 30, fontWeight: 500, letterSpacing: '-0.01em' }}>좋아요.</div>
         <p style={{ fontSize: 14, color: 'var(--text-2)', lineHeight: 1.6, maxWidth: 260 }}>{p?.title} — 지금 바로 시작해요. 잘 하고 있어요.</p>
-        <div style={{ background: '#E5EFE3', border: '1px solid #b4dfc8', borderRadius: 12, padding: '10px 14px', fontSize: 12, color: 'var(--success)', width: '100%' }}>캘린더 업데이트 완료. 실행 메모리에 복구 기록이 저장됐어요.</div>
+        <div style={{ background: '#E5EFE3', border: '1px solid #b4dfc8', borderRadius: 12, padding: '10px 14px', fontSize: 12, color: 'var(--success)', width: '100%' }}>
+          {fromApi ? '실행 메모리에 복구 기록이 저장됐어요. 오늘 카드에 반영됩니다.' : '캘린더 업데이트 완료. 실행 메모리에 복구 기록이 저장됐어요.'}
+        </div>
       </div>
     );
   }
@@ -90,14 +130,14 @@ export function MergedRecoveryScreen({ task, failReason, onAccept, onDismiss }: 
           )}
 
           <div style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 10, fontWeight: 700, letterSpacing: '0.08em', color: 'var(--coral-600)', marginBottom: 10, fontFamily: 'var(--font-mono)' }}>
-            <ArrowsClockwise size={12} weight="fill" /> 회복 제안
+            <ArrowsClockwise size={12} weight="fill" /> 회복 제안{fromApi && ' · RE:ACTION 분석'}
           </div>
 
           <div style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 26, letterSpacing: '-0.01em', lineHeight: 1.2, marginBottom: 6 }}>오늘은 절반쯤 왔어요.</div>
           <p style={{ fontSize: 13, color: 'var(--text-2)', marginBottom: 18, lineHeight: 1.55 }}>끝까지 가지 못해도 괜찮아요. 다시 시작할 방법이 있어요.</p>
 
           <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-            {MERGED_PROPOSALS.map((p, i) => {
+            {proposals.map((p, i) => {
               const isSel = sel === p.id;
               return (
                 <div
@@ -114,7 +154,7 @@ export function MergedRecoveryScreen({ task, failReason, onAccept, onDismiss }: 
                         <div style={{ fontSize: 13, fontWeight: 700, color: 'var(--text-1)', letterSpacing: '-0.01em' }}>{p.title}</div>
                         <div style={{ display: 'flex', gap: 8, marginTop: 3, alignItems: 'center' }}>
                           {i === 0 && <span style={{ height: 16, padding: '0 6px', background: p.bg, border: `1px solid ${p.bc}`, borderRadius: 9999, fontSize: 9, fontWeight: 700, color: p.ac, fontFamily: 'var(--font-mono)', display: 'inline-flex', alignItems: 'center', letterSpacing: '0.04em' }}>패턴 일치 ✓</span>}
-                          <span className="tnum" style={{ fontSize: 10, fontFamily: 'var(--font-mono)', fontWeight: 600, color: p.conf > 80 ? 'var(--success)' : p.conf > 65 ? 'var(--warning)' : 'var(--text-3)' }}>성공률 {p.conf}%</span>
+                          {p.conf != null && <span className="tnum" style={{ fontSize: 10, fontFamily: 'var(--font-mono)', fontWeight: 600, color: p.conf > 80 ? 'var(--success)' : p.conf > 65 ? 'var(--warning)' : 'var(--text-3)' }}>성공률 {p.conf}%</span>}
                           <span style={{ fontSize: 11, color: 'var(--text-3)' }}>{p.time}</span>
                         </div>
                       </div>
@@ -125,6 +165,9 @@ export function MergedRecoveryScreen({ task, failReason, onAccept, onDismiss }: 
                   </div>
                   {showWhy === p.id && (
                     <div style={{ marginTop: 6, padding: '8px 10px', background: 'var(--brand-soft)', borderRadius: 8, fontSize: 11, color: 'var(--coral-700)', lineHeight: 1.5 }}>{p.why}</div>
+                  )}
+                  {isSel && p.desc && (
+                    <div style={{ marginTop: 8, padding: '8px 10px', background: 'var(--surface-ground)', borderRadius: 8, fontSize: 12, color: 'var(--text-2)', lineHeight: 1.5 }}>{p.desc}</div>
                   )}
                 </div>
               );

--- a/src/screens/TodayScreen.tsx
+++ b/src/screens/TodayScreen.tsx
@@ -8,6 +8,7 @@ import {
   Trash,
 } from '@phosphor-icons/react';
 import type { Task } from '../types';
+import type { FailureTagMaster } from '../types/api';
 import { FAIL_REASONS, MERGED_PROPOSALS, MORNING_DATA } from '../data';
 import { useNavigation } from '../contexts/NavigationContext';
 import { habitsApi, todayApi } from '../lib/api';
@@ -163,6 +164,8 @@ export function ExecutionTodayScreen({ onRecovery, onEvening }: ExecutionTodaySc
 
 interface MergedTodayScreenProps {
   tasks: Task[];
+  // 13종 실패 사유 마스터 (#19-B) — 있으면 S18 칩을 실제 라벨로 교체
+  failTags?: FailureTagMaster[];
   onOpen: (id: string) => void;
   onMarkDone: (id: string) => void;
   onPartial: (id: string, pct: number) => void;
@@ -250,24 +253,14 @@ function todayShortKo(): string {
   return `${d.getMonth() + 1}월 ${d.getDate()}일 · ${days[d.getDay()]}요일`;
 }
 
-export function MergedTodayScreen({ tasks, onOpen, onMarkDone, onPartial, onFail, onOpenRecovery, onEvening }: MergedTodayScreenProps) {
+export function MergedTodayScreen({ tasks, failTags, onOpen, onMarkDone, onPartial, onFail, onOpenRecovery, onEvening }: MergedTodayScreenProps) {
+  // 실패 사유 칩 — 마스터(labelKo) 우선, 백엔드 미기동 시 mock 라벨
+  const failReasonLabels =
+    failTags && failTags.length > 0 ? failTags.map((t) => t.labelKo) : FAIL_REASONS;
   const { user } = useNavigation();
   const userName = user?.name ?? '친구';
 
-  // mock-and-replace: /today/agenda 가 현재 백엔드에서 501. 채워지면 응답을
-  // tasks 로 매핑할 자리. 실패는 조용히 — 더미 흐름을 끊지 않는다.
-  useEffect(() => {
-    let cancelled = false;
-    todayApi.agenda().then(
-      (agenda) => {
-        if (cancelled) return;
-        // TODO(backend-#19): agenda.actions → Task[] 매핑 + setTasks 갱신
-        void agenda;
-      },
-      () => { /* 501/네트워크 — 더미 그대로 */ },
-    );
-    return () => { cancelled = true; };
-  }, []);
+  // agenda → tasks 매핑은 ReActionMerged(컨트롤러)가 담당 (#19-A 연동).
 
   const [failSheet, setFailSheet] = useState<string | null>(null);
   const [partialSheet, setPartialSheet] = useState<string | null>(null);
@@ -501,7 +494,7 @@ export function MergedTodayScreen({ tasks, onOpen, onMarkDone, onPartial, onFail
             <div style={{ fontSize: 17, fontWeight: 600, marginBottom: 4, color: 'var(--text-1)' }}>지금 어떤 상태예요?</div>
             <p style={{ fontSize: 12, color: 'var(--text-3)', marginBottom: 14 }}>이유를 기록하면 더 잘 맞는 복구안을 제안해드려요.</p>
             <div style={{ display: 'flex', flexDirection: 'column', gap: 6, marginBottom: 14 }}>
-              {FAIL_REASONS.map((r) => (
+              {failReasonLabels.map((r) => (
                 <button key={r} onClick={() => setFailReason(r)} style={{ padding: '12px 14px', borderRadius: 12, textAlign: 'left', background: failReason === r ? 'var(--text-1)' : 'var(--surface-raised)', color: failReason === r ? '#FAF6EE' : 'var(--text-1)', border: `1px solid ${failReason === r ? 'var(--text-1)' : 'var(--sand-200)'}`, fontSize: 14, fontWeight: 500, cursor: 'pointer', fontFamily: 'inherit', transition: 'all 160ms' }}>{r}</button>
               ))}
             </div>

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -212,61 +212,101 @@ export interface HabitCreateRequest {
   priorityLevel: number;
 }
 
-// ── Today / Execution (S10-S13) ───────────────────────────────
-// 백엔드 /today/* 는 현재 501 이라 응답 모양이 contract 에 자세히 못박혀 있지 않다.
-// api-contract §10 + DB 설계서를 근거로 합리적 추정. 백엔드가 채워질 때 조정.
+// ── Today / Execution (S10-S13) — api-contract §10 (#19-A 조회 + #19-B 쓰기 구현 반영) ──
 
 export type ActionItemStatus =
-  | 'pending'
+  | 'planned'
   | 'in_progress'
   | 'done'
   | 'partial_done'
   | 'failed'
-  | 'recovery_pending';
+  | 'over_done'
+  | 'archived';
 
-export interface DailyBrief {
-  date: string; // YYYY-MM-DD
-  greeting: string;
-  bigRock: string | null;
+export interface MorningBriefData {
+  headline: string;
+  bigRockActionId: string | null; // action_<uuid>
   adjustmentHints: string[];
+  fallbackUsed: boolean;
 }
 
-export interface ActionItem {
-  actionItemId: string;
+export interface AgendaCard {
+  actionId: string; // action_<uuid>
   title: string;
-  goalId: string | null;
-  scheduledTime: string | null; // HH:MM
-  durationMinutes: number;
+  category: string;
   status: ActionItemStatus | string;
-  carryover?: boolean;
-  failReason?: string | null;
+  priority: number;
+  estimatedMinutes: number;
+  source: string;
+  whyNow: string | null;
+  firstStep: string | null;
+}
+
+export interface AgendaHabit {
+  instanceId: string; // hinst_<uuid>
+  habitId: string; // habit_<uuid>
+  title: string;
+  targetCount: number;
+  doneCount: number;
+}
+
+export interface AgendaFixedSchedule {
+  scheduleId: string; // fixed_<uuid>
+  title: string;
+  startTime: string; // HH:MM
+  endTime: string; // HH:MM
 }
 
 export interface TodayAgenda {
-  brief: DailyBrief;
-  actions: ActionItem[];
-  habits: HabitInstance[];
-  fixedSchedules: FixedSchedule[];
+  date: string; // YYYY-MM-DD
+  brief: MorningBriefData | null;
+  cards: AgendaCard[];
+  habits: AgendaHabit[];
+  fixedSchedules: AgendaFixedSchedule[];
+}
+
+export interface ActionDetail {
+  actionId: string;
+  title: string;
+  category: string;
+  status: string;
+  priority: number;
+  estimatedMinutes: number;
+  targetDate: string; // YYYY-MM-DD
+  source: string;
+  whyNow: string | null;
+  firstStep: string | null;
+  goalId: string | null;
 }
 
 export type CompletionStatus = 'done' | 'partial_done' | 'failed' | 'over_done';
 
-export interface ExecutionEvent {
-  executionId: string;
-  actionItemId: string;
-  startedAt: string; // KST ISO
-  endedAt: string | null;
-  status: CompletionStatus | 'started' | string;
+// POST /today/actions/{id}/start 응답 (#19-B)
+export interface ExecutionStartResponse {
+  executionId: string; // exec_<uuid>
+  actionId: string;
+  completionStatus: string; // in_progress
+  actualStartAt: string; // KST ISO
 }
 
+// POST /today/check-ins 요청 (#19-B) — Quick Check-in 4칩
 export interface CheckInRequest {
   executionId: string;
   completionStatus: CompletionStatus;
-  actualDuration?: number; // minutes
-  userFeedback?: string;
+  userRating?: number; // 1~5
+  userFeedback?: string; // 서버에서 at-rest 암호화
 }
 
-// ── Reflection (S17·S18) — 백엔드 501. api-contract §11 추정 ───
+// POST /today/check-ins 응답 — needsFailureTags=true 면 S18(실패 사유)로 이동
+export interface CheckInResponse {
+  executionId: string;
+  actionId: string;
+  completionStatus: string;
+  actualDurationMinutes: number | null;
+  needsFailureTags: boolean;
+}
+
+// ── Reflection (S17·S18) — api-contract §11 (#19-B failure-tags 구현, batch 는 501) ──
 // 13종 실패 태그 (api-contract §11)
 export type FailureTagCode =
   | 'TIME_SHORTAGE'
@@ -283,10 +323,24 @@ export type FailureTagCode =
   | 'EMERGENCY'
   | 'CONTEXT_LOSS';
 
-export interface FailureTag {
-  code: FailureTagCode | string;
-  label: string;
-  isActive: boolean;
+// GET /reflection/failure-tags 응답 row (#19-B 구현)
+export interface FailureTagMaster {
+  tagCode: FailureTagCode | string;
+  labelKo: string;
+  description: string | null;
+  sortOrder: number;
+}
+
+// POST /reflection/failure-tags/{executionId} 요청 — 0~2개. memo 는 서버 암호화
+export interface FailureTagRequest {
+  tagCodes: Array<FailureTagCode | string>;
+  memo?: string;
+}
+
+export interface FailureTagResponse {
+  executionId: string;
+  tagCodes: string[];
+  hasMemo: boolean;
 }
 
 export interface ReflectionPendingItem {
@@ -307,7 +361,7 @@ export interface ReflectionBatchRequest {
   }>;
 }
 
-// ── Recovery / Replan (S19·S20) — 백엔드 501. api-contract §12 추정 ──
+// ── Recovery / Replan (S19·S20) — api-contract §12 (#20-A 구현, replan 은 501) ──
 export type RecoveryGroup = 'DOWNSCOPE' | 'RESCHEDULE' | 'CARRY_OVER' | 'PARK';
 
 export type RecoveryStrategyCode =
@@ -321,20 +375,40 @@ export type RecoveryStrategyCode =
   | 'FREEZE_SLOT'
   | 'PARK_DEFAULT';
 
-export interface ApiRecoveryProposal {
-  proposalId: string;
-  group: RecoveryGroup;
-  strategyCode: RecoveryStrategyCode | string;
-  title: string;
-  description: string;
-  why: string;
-  estimatedMinutes: number | null;
-  confidence: number; // 0~100
+// POST /recovery/proposals/generate 응답 (#20-A 구현) — Draft Layer
+export interface RecoveryCard {
+  attemptId: string; // rec_<uuid>
+  optionGroup: RecoveryGroup;
+  strategyType: RecoveryStrategyCode | string;
+  labelKo: string;
+  suggestedActionText: string;
+  minRecoveryUnitMinutes: number;
+  allowRestMode: boolean;
+  triggerTag: string | null;
 }
 
+export interface RecoveryProposalsResponse {
+  executionId: string;
+  cards: RecoveryCard[];
+  isDraft: boolean;
+  aiSource: 'llm' | 'rule';
+}
+
+// POST /recovery/decisions 요청 (#20-A) — Idempotency-Key 필수
 export interface RecoveryDecisionRequest {
   executionId: string;
-  proposalId: string;
+  decision: 'accepted' | 'skipped';
+  acceptedAttemptId?: string;
+  decisionReason?: string;
+}
+
+export interface RecoveryDecisionResponse {
+  executionId: string;
+  acceptedAttemptId: string | null;
+  rejectedAttemptIds: string[];
+  skippedAttemptIds: string[];
+  resultingActionItemId: string | null; // action_<uuid> (DOWNSCOPE/CARRY_OVER 수락 시)
+  isDraft: boolean;
 }
 
 export interface ReplanDiffBlock {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -111,7 +111,8 @@ export interface RecoveryProposal {
   desc: string;
   why: string;
   time: string;
-  conf: number;
+  // 성공률 % — 실측 통계가 없는 실 API 카드는 표시하지 않는다 (undefined)
+  conf?: number;
 }
 
 export type ChipTone =


### PR DESCRIPTION
## 이슈
중간발표 데모 루프의 FE 구간 (G3) — 백엔드 #19-B(start/check-ins/failure-tags) + #20-A(recovery) 연동

> ⚠️ **백엔드 의존**: [reaction-backend#53](https://github.com/hanium-reaction/reaction-backend/pull/53)(Recovery) + [reaction-backend#54](https://github.com/hanium-reaction/reaction-backend/pull/54)(체크인) 머지 후 실 API가 동작합니다. 머지 전엔 기존 mock 흐름 그대로 (mock-and-replace).

## 변경
- **types/api.ts** — Today/Reflection/Recovery 의 '백엔드 501 추정' 타입을 **실제 계약**으로 전면 정렬: `TodayAgenda(cards)`, `ExecutionStartResponse`, `CheckInRequest/Response(needsFailureTags)`, `FailureTagMaster/Request`, `RecoveryCard/ProposalsResponse(isDraft·aiSource)/DecisionRequest/Response`
- **lib/api.ts** — 위 타입으로 시그니처 교체. `tagExecution` 은 `{tagCodes, memo}` (암호화는 서버 책임 — 기존 `memoEncrypted` 필드 제거)
- **ReActionMerged (컨트롤러)** — 실행 생명주기 단독 소유:
  - 마운트 시 `/today/agenda` → 카드 있으면 mock(BASE_TASKS) 교체, 13종 실패 사유 마스터 로드
  - `ensureExecution`: 시작 시 1회만 start (중복 409 방지), taskId→executionId 맵 유지
  - **[못함] 체인**: 체크인(failed) → 라벨→tagCode 매핑 태깅 → Recovery 화면에 executionId 전달
- **RecoveryScreen** — 실 API 카드 렌더(4그룹 색 매핑) + `decide`(Idempotency-Key) 확정. **성공률 %는 실측 통계 전이라 실 카드에서 미표시** (mock 카드만 유지). 조기 return 이전에 훅이 오도록 순서 정리
- **FocusScreen** — 자체 start/checkIn 제거 → 순수 UI (컨트롤러와 이중 호출 방지)
- **TodayScreen** — 실패 사유 칩을 마스터 `labelKo` 로 교체 (백엔드 미기동 시 mock 라벨 fallback)

## 어떻게 테스트했는지
- `npx tsc --noEmit` 통과, `npm run build`(vite) 통과 — CI 와 동일
- 백엔드 계약은 reaction-backend 의 E2E 테스트(`test_full_demo_loop_fail_to_recovery_action`)와 동일 시나리오·동일 camelCase 필드로 맞춤

## 리뷰어 체크 포인트
- 실행 생명주기를 컨트롤러로 모은 설계가 괜찮은지 (FocusScreen 순수화)
- 실패 라벨→tagCode 매핑이 마스터 labelKo 기준인 것 (mock 라벨일 땐 태깅 생략 — 의도된 degradation)
- 성공률 % 미표시 결정 (실측 데이터 없이 가짜 수치 노출 방지)
- PM(김종민) 작성 초안 — 장준혁(FE) 리뷰 후 머지해 주세요

🤖 Generated with [Claude Code](https://claude.com/claude-code)