### PR TITLE
fix(weekly): 다음 주가 이번 주와 동일하게 보이던 문제 수정

### DIFF
--- a/src/screens/WeeklyCalendarScreen.tsx
+++ b/src/screens/WeeklyCalendarScreen.tsx
@@ -133,13 +133,22 @@ export function WeeklyCalendarScreenV2() {
     return () => { cancelled = true; };
   }, [weekStartStr]);
 
-  const [blocks, setBlocks] = useState<BlockWithStatus[]>(
+  // 이번 주: 실행이 진행 중 — 완료/실패/이월 상태가 섞여 있다.
+  const [thisWeekBlocks, setThisWeekBlocks] = useState<BlockWithStatus[]>(
     WEEK_PLAN_DEFAULT.map((b, i) => ({
       ...b,
       status: i === 0 ? 'done' : i === 1 ? 'done' : i === 2 ? 'failed' : 'pending',
       carryover: i === 4,
     }))
   );
+  // 다음 주: 같은 주간 계획이되 아직 실행 전 — 전부 '대기', 이월 없음.
+  // (백엔드 #21 이 weekStart 별 실제 계획을 주면 이 자리를 교체)
+  const [nextWeekBlocks, setNextWeekBlocks] = useState<BlockWithStatus[]>(
+    WEEK_PLAN_DEFAULT.map((b) => ({ ...b, status: 'pending', carryover: false }))
+  );
+  // 활성 주차의 블록/세터로 별칭 — 아래 편집 로직(setBlocks)이 그대로 동작.
+  const blocks = isThisWeek ? thisWeekBlocks : nextWeekBlocks;
+  const setBlocks = isThisWeek ? setThisWeekBlocks : setNextWeekBlocks;
   const [editing, setEditing] = useState<Block | null>(null);
   // 두 종류 토스트: 성공(success) / 에러(error). 인라인 표시는 색만 다름.
   const [toast, setToast] = useState<{ msg: string; tone: 'success' | 'error' } | null>(null);


### PR DESCRIPTION
## 문제
주간 계획에서 이번 주/다음 주 토글 시 **날짜·라벨만 바뀌고 달력 블록(계획 내용)은 동일**했음. 단일 `blocks` 더미를 양쪽이 공유했기 때문.

## 수정
- 이번 주 블록(완료/실패/이월 섞임)과 다음 주 블록(아직 실행 전 — 전부 대기, 이월 없음)을 **별도 state 로 분리**
- `setBlocks` 를 활성 주차 세터 별칭으로 둬 기존 편집(드래그·수정·삭제) 로직은 그대로
- 결과: 다음 주는 실행 배지 없는 깔끔한 계획 + 통계(완료0/이월0)로 이번 주와 구분됨

## 한계
블록 스케줄 자체는 동일(반복 주간 템플릿). `weekStart` 별 실제 다른 계획은 백엔드 #21 연동 후 이 자리 교체.

## 검증
tsc ✅ / build ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)