### PR TITLE
feat(ux): 플로우 단순화 — 하단 탭 4→3 + Today 헤더 메뉴 통합

### DIFF
--- a/src/app/DesktopSidebar.tsx
+++ b/src/app/DesktopSidebar.tsx
@@ -1,16 +1,17 @@
-import { House, CalendarBlank, ChartBar, Tray, Gear, Target } from '@phosphor-icons/react';
+import { House, CalendarBlank, Tray, Gear, Target } from '@phosphor-icons/react';
 import { Wordmark } from '../components/Wordmark';
 import { useNavigation } from '../contexts/NavigationContext';
 import type { TabId, ScreenId } from '../types';
 
-// 모바일 탭바(TabBar.tsx)와 항상 동일하게 유지. 둘 중 하나만 바꾸지 말 것.
+// 하단 탭바(TabBar.tsx)와 항상 동일하게 유지. 둘 중 하나만 바꾸지 말 것.
+// review 는 '주간' 탭 안의 토글로 진입 — 버튼은 없지만 화면이 떠도 nav 는 보이도록
+// TAB_SCREENS 에는 포함.
 const TAB_SCREENS: ScreenId[] = ['today', 'weekly', 'inbox', 'review'];
 
 const NAV_ITEMS: { id: TabId; label: string; Icon: React.ElementType }[] = [
   { id: 'today',  label: '오늘 실행', Icon: House },
-  { id: 'weekly', label: '주간 계획', Icon: CalendarBlank },
+  { id: 'weekly', label: '주간',      Icon: CalendarBlank },
   { id: 'inbox',  label: '인박스',    Icon: Tray },
-  { id: 'review', label: '주간 리뷰', Icon: ChartBar },
 ];
 
 export function DesktopSidebar() {

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {
   House,
   CalendarBlank,
-  ChartBar,
   Tray,
 } from '@phosphor-icons/react';
 import type { TabId } from '../types';
@@ -12,11 +11,12 @@ interface MergedTabBarProps {
   onChange: (tab: TabId) => void;
 }
 
+// 주간 계획 + 주간 리뷰는 '주간' 탭 하나로 통합(화면 내 계획/리뷰 토글).
+// 하단 탭 4→3 으로 단순화.
 const tabs: { id: TabId; label: string; Icon: React.ElementType }[] = [
   { id: 'today',  label: '오늘 실행', Icon: House },
-  { id: 'weekly', label: '주간 계획', Icon: CalendarBlank },
+  { id: 'weekly', label: '주간',      Icon: CalendarBlank },
   { id: 'inbox',  label: '인박스',    Icon: Tray },
-  { id: 'review', label: '주간 리뷰', Icon: ChartBar },
 ];
 
 export function MergedTabBar({ active, onChange }: MergedTabBarProps) {

--- a/src/components/WeeklySwitch.tsx
+++ b/src/components/WeeklySwitch.tsx
@@ -1,0 +1,44 @@
+import { useNavigation } from '../contexts/NavigationContext';
+
+// 주간 계획 / 주간 리뷰를 한 탭 안에서 전환하는 세그먼트 컨트롤.
+// 하단 탭을 4→3 으로 줄이면서 두 '주간' 화면을 하나의 탭으로 묶는다.
+// tab 은 항상 'weekly' 로 유지해 하단 '주간' 탭 하이라이트가 떨어지지 않게 한다.
+export function WeeklySwitch() {
+  const { screen, setScreen, setTab } = useNavigation();
+  const go = (s: 'weekly' | 'review') => {
+    setTab('weekly');
+    setScreen(s);
+  };
+  const items: { s: 'weekly' | 'review'; label: string }[] = [
+    { s: 'weekly', label: '계획' },
+    { s: 'review', label: '리뷰' },
+  ];
+  return (
+    <div style={{ display: 'inline-flex', gap: 2, padding: 2, background: 'var(--sand-100)', borderRadius: 9999 }}>
+      {items.map(({ s, label }) => {
+        const active = screen === s;
+        return (
+          <button
+            key={s}
+            onClick={() => go(s)}
+            style={{
+              height: 28,
+              padding: '0 18px',
+              borderRadius: 9999,
+              border: 'none',
+              background: active ? 'var(--surface-raised)' : 'transparent',
+              color: active ? 'var(--text-1)' : 'var(--text-3)',
+              fontWeight: 700,
+              fontSize: 12,
+              cursor: 'pointer',
+              fontFamily: 'inherit',
+              boxShadow: active ? '0 1px 2px rgba(0,0,0,0.06)' : 'none',
+            }}
+          >
+            {label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/screens/TodayScreen.tsx
+++ b/src/screens/TodayScreen.tsx
@@ -11,33 +11,44 @@ import { FAIL_REASONS } from '../data';
 import { useNavigation } from '../contexts/NavigationContext';
 import { habitsApi, todayApi } from '../lib/api';
 import { DemoNotice } from '../components/DemoNotice';
-import { Gear, Target } from '@phosphor-icons/react';
+import { Gear, Target, DotsThreeVertical } from '@phosphor-icons/react';
 
-// Today 헤더 우상단 — 목표 관리(S26) 진입점.
-function GoalsButton() {
+// Today 헤더 우상단 — 목표 관리·설정을 하나의 ⋮ 메뉴로 통합 (아이콘 2개 → 1개).
+function HeaderMenu() {
   const { setScreen } = useNavigation();
+  const [open, setOpen] = useState(false);
+  const go = (s: 'goals' | 'settings') => { setOpen(false); setScreen(s); };
   return (
-    <button
-      onClick={() => setScreen('goals')}
-      aria-label="목표 관리"
-      style={{ width: 36, height: 36, borderRadius: 9999, border: 'none', background: 'var(--surface-raised)', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer', flexShrink: 0 }}
-    >
-      <Target size={16} color="var(--text-2)" />
-    </button>
-  );
-}
-
-// Today 헤더 우상단 — Settings 화면 진입점.
-function SettingsButton() {
-  const { setScreen } = useNavigation();
-  return (
-    <button
-      onClick={() => setScreen('settings')}
-      aria-label="설정"
-      style={{ width: 36, height: 36, borderRadius: 9999, border: 'none', background: 'var(--surface-raised)', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer', flexShrink: 0 }}
-    >
-      <Gear size={16} color="var(--text-2)" />
-    </button>
+    <div style={{ position: 'relative', flexShrink: 0 }}>
+      <button
+        onClick={() => setOpen((o) => !o)}
+        aria-label="메뉴"
+        aria-expanded={open}
+        style={{ width: 36, height: 36, borderRadius: 9999, border: 'none', background: open ? 'var(--sand-100)' : 'var(--surface-raised)', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer' }}
+      >
+        <DotsThreeVertical size={18} weight="bold" color="var(--text-2)" />
+      </button>
+      {open && (
+        <>
+          {/* 바깥 클릭 닫기 */}
+          <div onClick={() => setOpen(false)} style={{ position: 'fixed', inset: 0, zIndex: 30 }} />
+          <div style={{ position: 'absolute', right: 0, top: 42, zIndex: 31, minWidth: 148, background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', borderRadius: 12, boxShadow: 'var(--shadow-lg)', overflow: 'hidden', padding: 4 }}>
+            {[
+              { s: 'goals' as const, label: '목표 관리', Icon: Target },
+              { s: 'settings' as const, label: '설정', Icon: Gear },
+            ].map(({ s, label, Icon }) => (
+              <button
+                key={s}
+                onClick={() => go(s)}
+                style={{ display: 'flex', alignItems: 'center', gap: 10, width: '100%', padding: '10px 12px', borderRadius: 9, border: 'none', background: 'transparent', cursor: 'pointer', fontFamily: 'inherit', fontSize: 13, fontWeight: 600, color: 'var(--text-1)', textAlign: 'left' }}
+              >
+                <Icon size={16} color="var(--text-2)" /> {label}
+              </button>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
   );
 }
 
@@ -276,8 +287,7 @@ export function MergedTodayScreen({ tasks, onOpen, onMarkDone, onPartial, onFail
                 <span className="tnum" style={{ position: 'absolute', top: -2, right: -2, minWidth: 16, height: 16, padding: '0 4px', borderRadius: 9999, background: 'var(--brand)', color: '#FFFCF6', fontSize: 9, fontWeight: 700, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>{partialTasks.length}</span>
               </button>
             )}
-            <GoalsButton />
-            <SettingsButton />
+            <HeaderMenu />
           </div>
         </div>
 

--- a/src/screens/WeeklyCalendarScreen.tsx
+++ b/src/screens/WeeklyCalendarScreen.tsx
@@ -3,6 +3,7 @@ import { Plus, X, Trash } from '@phosphor-icons/react';
 import { WEEK_PLAN_DEFAULT, GOAL_COLORS, DAYS_KO } from '../data';
 import { ApiError, plansApi } from '../lib/api';
 import { DemoNotice } from '../components/DemoNotice';
+import { WeeklySwitch } from '../components/WeeklySwitch';
 import { useNavigation } from '../contexts/NavigationContext';
 import type { Block } from '../types';
 
@@ -378,8 +379,8 @@ export function WeeklyCalendarScreenV2() {
     <div style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column', background: 'var(--surface-ground)' }}>
       {/* Header */}
       <div style={{ flexShrink: 0, padding: '10px 14px 8px', borderBottom: '1px solid var(--sand-200)' }}>
-        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 6 }}>
-          <h2 style={{ fontFamily: 'var(--font-display)', fontSize: 18, fontWeight: 800, letterSpacing: '-0.02em', margin: 0 }}>주간 계획</h2>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8 }}>
+          <WeeklySwitch />
           <span style={{ fontSize: 9, fontFamily: 'var(--font-mono)', color: 'var(--text-3)', letterSpacing: '0.08em' }}>{weekLabel}</span>
         </div>
         {/* 이번 주 / 다음 주 전환 — 주간 리뷰의 "다음 주 계획 확인" 도 여기 다음 주로 진입 */}

--- a/src/screens/WeeklyReviewScreen.tsx
+++ b/src/screens/WeeklyReviewScreen.tsx
@@ -3,6 +3,7 @@ import { Sparkle, ArrowRight } from '@phosphor-icons/react';
 import { REVIEW_V2 } from '../data';
 import { reviewsApi } from '../lib/api';
 import { DemoNotice } from '../components/DemoNotice';
+import { WeeklySwitch } from '../components/WeeklySwitch';
 import { useNavigation } from '../contexts/NavigationContext';
 import type { FailItem } from '../types';
 
@@ -147,6 +148,10 @@ export function WeeklyReviewScreenV2() {
     <div style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column', background: 'var(--surface-ground)', overflow: 'hidden' }}>
       {/* Scrollable content */}
       <div style={{ flex: 1, overflowY: 'auto', overflowX: 'hidden', padding: '14px 18px 0', display: 'flex', flexDirection: 'column', gap: 14 }}>
+
+        <div style={{ display: 'flex', justifyContent: 'flex-start' }}>
+          <WeeklySwitch />
+        </div>
 
         {/* Header */}
         <div>


### PR DESCRIPTION
## 요약
플로우를 더 단순하게: 하단 탭과 Today 헤더를 정리.

## 변경
- **하단 탭 4→3**: 주간 계획 + 주간 리뷰를 '주간' 탭 하나로 통합. 화면 안 [계획 | 리뷰] 세그먼트(`WeeklySwitch`)로 전환. tab 은 'weekly' 로 유지해 하단 하이라이트 보존, 바 노출 목록(showTabs/showNav)엔 review 유지.
- **Today 헤더 통합**: 목표·설정 아이콘 2개 → ⋮ 드롭다운 메뉴 1개(`HeaderMenu`).
- 온보딩 진행률은 이미 1/4~4/4 로 일관 → 변경 없음.

## 검증
tsc ✅ / build ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)