### PR TITLE
refactor(ui): 세그먼트 토글 사이즈 통일 (공용 Segmented)

### DIFF
--- a/src/components/Segmented.tsx
+++ b/src/components/Segmented.tsx
@@ -1,0 +1,70 @@
+// 앱 공용 세그먼트 컨트롤(토글). 화면별로 제각각이던 토글 크기/스타일을 하나로 통일.
+// 디자인 근거(연구): 2~5개 상호배타 옵션에 적합, 선택 상태를 시각적으로 분명히,
+// 세그먼트는 등폭 유지. (Apple HIG, NN/g, Mobbin 2,600+ 컴포넌트 분석)
+
+interface SegmentedOption<T extends string | number> {
+  value: T;
+  label: string;
+}
+
+interface SegmentedProps<T extends string | number> {
+  options: SegmentedOption<T>[];
+  value: T;
+  onChange: (value: T) => void;
+  // 등폭으로 꽉 채울지 (전체폭). false 면 내용 폭.
+  fluid?: boolean;
+  ariaLabel?: string;
+}
+
+export function Segmented<T extends string | number>({
+  options,
+  value,
+  onChange,
+  fluid = false,
+  ariaLabel,
+}: SegmentedProps<T>) {
+  return (
+    <div
+      role="tablist"
+      aria-label={ariaLabel}
+      style={{
+        display: fluid ? 'flex' : 'inline-flex',
+        width: fluid ? '100%' : undefined,
+        gap: 2,
+        padding: 3,
+        background: 'var(--sand-100)',
+        borderRadius: 9999,
+      }}
+    >
+      {options.map((o) => {
+        const active = o.value === value;
+        return (
+          <button
+            key={String(o.value)}
+            role="tab"
+            aria-selected={active}
+            onClick={() => onChange(o.value)}
+            style={{
+              flex: fluid ? 1 : undefined,
+              minWidth: 64,
+              height: 28,
+              padding: '0 16px',
+              borderRadius: 9999,
+              border: 'none',
+              background: active ? 'var(--surface-raised)' : 'transparent',
+              color: active ? 'var(--text-1)' : 'var(--text-3)',
+              fontWeight: 700,
+              fontSize: 12,
+              fontFamily: 'inherit',
+              cursor: 'pointer',
+              boxShadow: active ? '0 1px 2px rgba(0,0,0,0.08)' : 'none',
+              transition: 'background 140ms, color 140ms',
+            }}
+          >
+            {o.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/WeeklySwitch.tsx
+++ b/src/components/WeeklySwitch.tsx
@@ -1,44 +1,21 @@
 import { useNavigation } from '../contexts/NavigationContext';
+import { Segmented } from './Segmented';
 
 // 주간 계획 / 주간 리뷰를 한 탭 안에서 전환하는 세그먼트 컨트롤.
 // 하단 탭을 4→3 으로 줄이면서 두 '주간' 화면을 하나의 탭으로 묶는다.
 // tab 은 항상 'weekly' 로 유지해 하단 '주간' 탭 하이라이트가 떨어지지 않게 한다.
 export function WeeklySwitch() {
   const { screen, setScreen, setTab } = useNavigation();
-  const go = (s: 'weekly' | 'review') => {
-    setTab('weekly');
-    setScreen(s);
-  };
-  const items: { s: 'weekly' | 'review'; label: string }[] = [
-    { s: 'weekly', label: '계획' },
-    { s: 'review', label: '리뷰' },
-  ];
+  const value: 'weekly' | 'review' = screen === 'review' ? 'review' : 'weekly';
   return (
-    <div style={{ display: 'inline-flex', gap: 2, padding: 2, background: 'var(--sand-100)', borderRadius: 9999 }}>
-      {items.map(({ s, label }) => {
-        const active = screen === s;
-        return (
-          <button
-            key={s}
-            onClick={() => go(s)}
-            style={{
-              height: 28,
-              padding: '0 18px',
-              borderRadius: 9999,
-              border: 'none',
-              background: active ? 'var(--surface-raised)' : 'transparent',
-              color: active ? 'var(--text-1)' : 'var(--text-3)',
-              fontWeight: 700,
-              fontSize: 12,
-              cursor: 'pointer',
-              fontFamily: 'inherit',
-              boxShadow: active ? '0 1px 2px rgba(0,0,0,0.06)' : 'none',
-            }}
-          >
-            {label}
-          </button>
-        );
-      })}
-    </div>
+    <Segmented
+      ariaLabel="주간 계획/리뷰 전환"
+      value={value}
+      onChange={(s) => { setTab('weekly'); setScreen(s); }}
+      options={[
+        { value: 'weekly', label: '계획' },
+        { value: 'review', label: '리뷰' },
+      ]}
+    />
   );
 }

--- a/src/screens/WeeklyCalendarScreen.tsx
+++ b/src/screens/WeeklyCalendarScreen.tsx
@@ -4,6 +4,7 @@ import { WEEK_PLAN_DEFAULT, GOAL_COLORS, DAYS_KO } from '../data';
 import { ApiError, plansApi } from '../lib/api';
 import { DemoNotice } from '../components/DemoNotice';
 import { WeeklySwitch } from '../components/WeeklySwitch';
+import { Segmented } from '../components/Segmented';
 import { useNavigation } from '../contexts/NavigationContext';
 import type { Block } from '../types';
 
@@ -384,19 +385,16 @@ export function WeeklyCalendarScreenV2() {
           <span style={{ fontSize: 9, fontFamily: 'var(--font-mono)', color: 'var(--text-3)', letterSpacing: '0.08em' }}>{weekLabel}</span>
         </div>
         {/* 이번 주 / 다음 주 전환 — 주간 리뷰의 "다음 주 계획 확인" 도 여기 다음 주로 진입 */}
-        <div style={{ display: 'inline-flex', gap: 2, padding: 2, background: 'var(--sand-100)', borderRadius: 9999, marginBottom: 8 }}>
-          {[{ o: 0, label: '이번 주' }, { o: 1, label: '다음 주' }].map(({ o, label }) => {
-            const active = weekOffset === o;
-            return (
-              <button
-                key={o}
-                onClick={() => setWeekOffset(o)}
-                style={{ height: 26, padding: '0 14px', borderRadius: 9999, border: 'none', background: active ? 'var(--surface-raised)' : 'transparent', color: active ? 'var(--text-1)' : 'var(--text-3)', fontWeight: 700, fontSize: 11, cursor: 'pointer', fontFamily: 'inherit', boxShadow: active ? 'var(--shadow-sm, 0 1px 2px rgba(0,0,0,0.06))' : 'none' }}
-              >
-                {label}
-              </button>
-            );
-          })}
+        <div style={{ marginBottom: 8 }}>
+          <Segmented
+            ariaLabel="이번 주/다음 주 전환"
+            value={weekOffset}
+            onChange={(o) => setWeekOffset(o)}
+            options={[
+              { value: 0, label: '이번 주' },
+              { value: 1, label: '다음 주' },
+            ]}
+          />
         </div>
         <p style={{ fontSize: 11, color: 'var(--text-3)', margin: '0 0 8px' }}>블록을 탭하면 수정, 길게 누른 채 끌면 15분 단위로 이동돼요.</p>
         <div style={{ marginBottom: 8 }}>


### PR DESCRIPTION
## 문제
페이지 내 세그먼트 토글들의 크기가 제각각.
- WeeklySwitch(계획/리뷰): 높이 28 / 패딩 18
- 주간 캘린더 이번주/다음주: 높이 26 / 패딩 14

## 수정
- 공용 `Segmented` 컴포넌트 신설 후 두 토글 모두 적용 → 크기·간격·선택상태 일치
- 선택 상태를 시각적으로 분명히(raised 배경 + 그림자 + text-1 bold), 등폭(minWidth) 유지
- `role=tablist/tab`, `aria-selected` 접근성

## 근거(리서치)
세그먼트 컨트롤은 2~5개 상호배타 옵션에 적합하고, 선택 상태를 분명히·등폭으로 두라는 게 공통 권고 (Apple HIG, NN/g, Mobbin 2,600+ 컴포넌트 분석). 본 앱의 토글(2개 옵션, 같은 맥락의 뷰 전환)은 이 패턴의 정석 사용처라 유지가 타당.

## 검증
tsc / build ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)