### PR TITLE
feat(ui): 컨트롤 사이즈 토큰 스케일 + Inbox 필터 세그먼트 통일

### DIFF
--- a/src/components/Segmented.tsx
+++ b/src/components/Segmented.tsx
@@ -46,9 +46,9 @@ export function Segmented<T extends string | number>({
             onClick={() => onChange(o.value)}
             style={{
               flex: fluid ? 1 : undefined,
-              minWidth: 64,
-              height: 28,
-              padding: '0 16px',
+              minWidth: fluid ? 0 : 64,
+              height: 'var(--ctrl-sm)',
+              padding: fluid ? '0 8px' : '0 16px',
               borderRadius: 9999,
               border: 'none',
               background: active ? 'var(--surface-raised)' : 'transparent',
@@ -57,7 +57,8 @@ export function Segmented<T extends string | number>({
               fontSize: 12,
               fontFamily: 'inherit',
               cursor: 'pointer',
-              boxShadow: active ? '0 1px 2px rgba(0,0,0,0.08)' : 'none',
+              whiteSpace: 'nowrap',
+              boxShadow: active ? 'var(--shadow-sm)' : 'none',
               transition: 'background 140ms, color 140ms',
             }}
           >

--- a/src/index.css
+++ b/src/index.css
@@ -124,6 +124,13 @@
   --radius-xl:   28px;
   --radius-full: 9999px;
 
+  /* CONTROL HEIGHTS — 컴포넌트 사이즈 일관성 스케일 */
+  --ctrl-xs: 20px;  /* 칩·배지 */
+  --ctrl-sm: 28px;  /* 세그먼트·필터·작은 pill */
+  --ctrl-md: 36px;  /* 아이콘 버튼·보조 액션 */
+  --ctrl-lg: 44px;  /* 주요 액션·시트 CTA */
+  --ctrl-xl: 52px;  /* 히어로 CTA */
+
   /* ELEVATION */
   --shadow-sm:  0 1px 2px rgba(54, 40, 28, 0.06);
   --shadow-md:  0 4px 12px rgba(54, 40, 28, 0.08), 0 1px 2px rgba(54, 40, 28, 0.04);

--- a/src/screens/GoalIntakeScreen.tsx
+++ b/src/screens/GoalIntakeScreen.tsx
@@ -351,7 +351,7 @@ export function GoalIntakeScreen({ onDone }: GoalIntakeScreenProps) {
         ) : (
           <button
             onClick={onDone}
-            style={{ width: '100%', height: 48, borderRadius: 12, border: 'none', background: 'var(--brand)', color: '#FFFCF6', fontWeight: 700, fontSize: 15, fontFamily: 'inherit', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8 }}
+            style={{ width: '100%', height: 'var(--ctrl-lg)', borderRadius: 12, border: 'none', background: 'var(--brand)', color: '#FFFCF6', fontWeight: 700, fontSize: 15, fontFamily: 'inherit', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8 }}
           >
             목표 분류 확인 <ArrowRight size={16} />
           </button>

--- a/src/screens/InboxScreen.tsx
+++ b/src/screens/InboxScreen.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { Sparkle, ArrowUp, Archive, TreeStructure, ListChecks } from '@phosphor-icons/react';
 import { ApiError, inboxApi } from '../lib/api';
+import { Segmented } from '../components/Segmented';
 import type { InboxItem, InboxStatus } from '../types/api';
 
 type FilterTab = 'all' | InboxStatus;
@@ -123,20 +124,15 @@ export function InboxScreen() {
         <p style={{ fontSize: 12, color: 'var(--text-2)', margin: 0 }}>AI 가 카테고리를 추정해두고, 나중에 목표로 올릴 수 있어요.</p>
       </div>
 
-      {/* Filter tabs */}
-      <div style={{ flexShrink: 0, padding: '0 18px 10px', display: 'flex', gap: 6, overflowX: 'auto' }}>
-        {(Object.keys(FILTER_LABEL) as FilterTab[]).map((f) => {
-          const active = f === filter;
-          return (
-            <button
-              key={f}
-              onClick={() => setFilter(f)}
-              style={{ height: 30, padding: '0 12px', borderRadius: 9999, border: `1px solid ${active ? 'var(--text-1)' : 'var(--sand-200)'}`, background: active ? 'var(--text-1)' : 'var(--surface-raised)', color: active ? '#FAF6EE' : 'var(--text-2)', fontWeight: 600, fontSize: 12, cursor: 'pointer', fontFamily: 'inherit', flexShrink: 0 }}
-            >
-              {FILTER_LABEL[f]}
-            </button>
-          );
-        })}
+      {/* Filter — 공용 Segmented 로 통일 (계획/리뷰·이번주/다음주 토글과 동일 스타일) */}
+      <div style={{ flexShrink: 0, padding: '0 18px 10px' }}>
+        <Segmented
+          fluid
+          ariaLabel="인박스 상태 필터"
+          value={filter}
+          onChange={(f) => setFilter(f as FilterTab)}
+          options={(Object.keys(FILTER_LABEL) as FilterTab[]).map((f) => ({ value: f, label: FILTER_LABEL[f] }))}
+        />
       </div>
 
       {/* List */}

--- a/src/screens/MorningBriefScreen.tsx
+++ b/src/screens/MorningBriefScreen.tsx
@@ -100,7 +100,7 @@ export function MorningBriefScreen({ onStart }: MorningBriefScreenProps) {
       </div>
 
       <div style={{ flexShrink: 0, padding: '12px 18px', paddingBottom: 'max(28px, env(safe-area-inset-bottom, 28px))', background: 'var(--surface-ground)' }}>
-        <button onClick={onStart} style={{ width: '100%', height: 48, borderRadius: 12, border: 'none', background: 'var(--text-1)', color: 'var(--surface-ground)', fontWeight: 700, fontSize: 15, fontFamily: 'inherit', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8 }}>
+        <button onClick={onStart} style={{ width: '100%', height: 'var(--ctrl-lg)', borderRadius: 12, border: 'none', background: 'var(--text-1)', color: 'var(--surface-ground)', fontWeight: 700, fontSize: 15, fontFamily: 'inherit', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8 }}>
           실행 시작 <ArrowRight size={16} />
         </button>
       </div>

--- a/src/screens/WeeklyCalendarScreen.tsx
+++ b/src/screens/WeeklyCalendarScreen.tsx
@@ -92,10 +92,10 @@ function BlockEditSheet({ block, onSave, onDelete, onClose }: { block: Block; on
         </div>
 
         <div style={{ display: 'flex', gap: 8 }}>
-          <button onClick={() => onDelete(block.id)} style={{ flex: 1, height: 46, borderRadius: 12, border: '1px solid var(--coral-200)', background: '#FAE2D8', color: 'var(--danger)', fontWeight: 600, fontSize: 13, fontFamily: 'inherit', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6 }}>
+          <button onClick={() => onDelete(block.id)} style={{ flex: 1, height: 'var(--ctrl-lg)', borderRadius: 12, border: '1px solid var(--coral-200)', background: '#FAE2D8', color: 'var(--danger)', fontWeight: 600, fontSize: 13, fontFamily: 'inherit', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6 }}>
             <Trash size={14} /> 삭제
           </button>
-          <button onClick={() => onSave({ ...block, title, day, time, dur, goal })} style={{ flex: 2, height: 46, borderRadius: 12, border: 'none', background: 'var(--text-1)', color: '#FAF6EE', fontWeight: 700, fontSize: 14, fontFamily: 'inherit', cursor: 'pointer' }}>저장</button>
+          <button onClick={() => onSave({ ...block, title, day, time, dur, goal })} style={{ flex: 2, height: 'var(--ctrl-lg)', borderRadius: 12, border: 'none', background: 'var(--text-1)', color: '#FAF6EE', fontWeight: 700, fontSize: 14, fontFamily: 'inherit', cursor: 'pointer' }}>저장</button>
         </div>
       </div>
     </div>

--- a/src/screens/WeeklyPlanGenerationScreen.tsx
+++ b/src/screens/WeeklyPlanGenerationScreen.tsx
@@ -79,10 +79,10 @@ function BlockEditSheet({ block, onSave, onDelete, onClose }: { block: Block; on
         </div>
 
         <div style={{ display: 'flex', gap: 8 }}>
-          <button onClick={() => onDelete(block.id)} style={{ flex: 1, height: 46, borderRadius: 12, border: '1px solid var(--coral-200)', background: '#FAE2D8', color: 'var(--danger)', fontWeight: 600, fontSize: 13, fontFamily: 'inherit', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6 }}>
+          <button onClick={() => onDelete(block.id)} style={{ flex: 1, height: 'var(--ctrl-lg)', borderRadius: 12, border: '1px solid var(--coral-200)', background: '#FAE2D8', color: 'var(--danger)', fontWeight: 600, fontSize: 13, fontFamily: 'inherit', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6 }}>
             <Trash size={14} /> 삭제
           </button>
-          <button onClick={() => onSave({ ...block, title, day, time, dur, goal })} style={{ flex: 2, height: 46, borderRadius: 12, border: 'none', background: 'var(--text-1)', color: '#FAF6EE', fontWeight: 700, fontSize: 14, fontFamily: 'inherit', cursor: 'pointer' }}>저장</button>
+          <button onClick={() => onSave({ ...block, title, day, time, dur, goal })} style={{ flex: 2, height: 'var(--ctrl-lg)', borderRadius: 12, border: 'none', background: 'var(--text-1)', color: '#FAF6EE', fontWeight: 700, fontSize: 14, fontFamily: 'inherit', cursor: 'pointer' }}>저장</button>
         </div>
       </div>
     </div>

--- a/src/screens/WeeklyReviewScreen.tsx
+++ b/src/screens/WeeklyReviewScreen.tsx
@@ -279,7 +279,7 @@ export function WeeklyReviewScreenV2() {
 
       {/* Sticky CTA */}
       <div style={{ flexShrink: 0, padding: '12px 18px', paddingBottom: 'max(28px, env(safe-area-inset-bottom, 28px))', background: 'var(--surface-ground)' }}>
-        <button onClick={goToNextWeekPlan} style={{ width: '100%', height: 46, borderRadius: 12, border: 'none', background: 'var(--brand)', color: '#FFFCF6', fontWeight: 700, fontSize: 14, fontFamily: 'inherit', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6 }}>
+        <button onClick={goToNextWeekPlan} style={{ width: '100%', height: 'var(--ctrl-lg)', borderRadius: 12, border: 'none', background: 'var(--brand)', color: '#FFFCF6', fontWeight: 700, fontSize: 14, fontFamily: 'inherit', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6 }}>
           다음 주 계획 확인 <ArrowRight size={15} />
         </button>
       </div>


### PR DESCRIPTION
Task1: 컨트롤 높이 토큰(--ctrl-xs20/sm28/md36/lg44/xl52), Segmented가 토큰+fluid 사용, 주요 CTA 아웃라이어(46/48)를 44로 정렬. Task2: Inbox 필터(5개)를 공용 Segmented(fluid)로 전환 → 앱의 모든 '하나 선택' 컨트롤이 동일 컴포넌트·사이즈. tsc/build 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)