### PR TITLE
fix(ui): 계획/리뷰 토글 위치 고정 + 배지 사이즈 통일(--ctrl-xs)

### DIFF
--- a/src/app/ReActionMerged.tsx
+++ b/src/app/ReActionMerged.tsx
@@ -14,6 +14,7 @@ import { MergedTodayScreen } from '../screens/TodayScreen';
 import { FocusScreen } from '../screens/FocusScreen';
 import { MergedRecoveryScreen } from '../screens/RecoveryScreen';
 import { RecoveredScreen, type AppliedRecovery } from '../screens/RecoveredScreen';
+import { WeeklySwitch } from '../components/WeeklySwitch';
 import { EveningCheckInScreen } from '../screens/EveningCheckInScreen';
 import { WeeklyCalendarScreenV2 } from '../screens/WeeklyCalendarScreen';
 import { WeeklyReviewScreenV2 } from '../screens/WeeklyReviewScreen';
@@ -65,14 +66,19 @@ function MergedTopNav({ screen, onBack }: { screen: ScreenId; onBack: () => void
           <CaretLeft size={14} color="var(--text-2)" />
         </button>
       ) : <div style={{ width: 44 }} />}
-      <div style={{
-        display: 'flex', alignItems: 'center', gap: 6,
-        fontSize: 10, fontFamily: 'var(--font-mono)',
-        letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--text-2)',
-      }}>
-        <div style={{ width: 5, height: 5, borderRadius: 9999, background: 'var(--brand)' }} />
-        {meta.label}
-      </div>
+      {screen === 'weekly' || screen === 'review' ? (
+        // 주간 탭: 계획/리뷰 토글을 상단 바 중앙에 고정 — 전환해도 위치가 안 움직인다.
+        <WeeklySwitch />
+      ) : (
+        <div style={{
+          display: 'flex', alignItems: 'center', gap: 6,
+          fontSize: 10, fontFamily: 'var(--font-mono)',
+          letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--text-2)',
+        }}>
+          <div style={{ width: 5, height: 5, borderRadius: 9999, background: 'var(--brand)' }} />
+          {meta.label}
+        </div>
+      )}
       <div style={{ width: 44 }} />
     </div>
   );

--- a/src/screens/EveningCheckInScreen.tsx
+++ b/src/screens/EveningCheckInScreen.tsx
@@ -69,7 +69,7 @@ export function EveningCheckInScreen({ onDone }: EveningCheckInScreenProps) {
               <div key={i} style={{ display: 'flex', gap: 10, alignItems: 'center' }}>
                 <div className="tnum" style={{ width: 38, fontSize: 10, fontFamily: 'var(--font-mono)', color: 'var(--text-3)' }}>{b.time}</div>
                 <div style={{ flex: 1, fontSize: 13, fontWeight: 500, color: b.carry ? 'var(--warning)' : 'var(--text-1)' }}>{b.t}</div>
-                <span style={{ height: 20, padding: '0 7px', background: 'var(--sand-100)', border: '1px solid var(--sand-200)', borderRadius: 9999, fontSize: 10, color: 'var(--text-2)', display: 'inline-flex', alignItems: 'center' }}>{b.dur}</span>
+                <span style={{ height: 'var(--ctrl-xs)', padding: '0 7px', background: 'var(--sand-100)', border: '1px solid var(--sand-200)', borderRadius: 9999, fontSize: 10, color: 'var(--text-2)', display: 'inline-flex', alignItems: 'center' }}>{b.dur}</span>
               </div>
             ))}
           </div>

--- a/src/screens/GoalClassificationScreen.tsx
+++ b/src/screens/GoalClassificationScreen.tsx
@@ -126,18 +126,18 @@ export function GoalClassificationScreen({ onNext }: GoalClassificationScreenPro
                 <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10 }}>
                   <div style={{ flex: 1 }}>
                     <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 6, flexWrap: 'wrap' }}>
-                      <div style={{ height: 20, padding: '0 8px', borderRadius: 9999, background: m.bg, border: `1px solid ${m.border}`, fontSize: 10, fontWeight: 700, color: m.color, letterSpacing: '0.04em', fontFamily: 'var(--font-mono)', display: 'inline-flex', alignItems: 'center' }}>{m.label}</div>
+                      <div style={{ height: 'var(--ctrl-xs)', padding: '0 8px', borderRadius: 9999, background: m.bg, border: `1px solid ${m.border}`, fontSize: 10, fontWeight: 700, color: m.color, letterSpacing: '0.04em', fontFamily: 'var(--font-mono)', display: 'inline-flex', alignItems: 'center' }}>{m.label}</div>
                       {g.status === 'focus' && (
-                        <div style={{ height: 18, padding: '0 7px', borderRadius: 9999, background: 'var(--brand)', color: '#FFFCF6', fontSize: 9, fontWeight: 700, display: 'inline-flex', alignItems: 'center', fontFamily: 'var(--font-mono)' }}>ACTIVE</div>
+                        <div style={{ height: 'var(--ctrl-xs)', padding: '0 7px', borderRadius: 9999, background: 'var(--brand)', color: '#FFFCF6', fontSize: 9, fontWeight: 700, display: 'inline-flex', alignItems: 'center', fontFamily: 'var(--font-mono)' }}>ACTIVE</div>
                       )}
                     </div>
                     <div style={{ fontWeight: 700, fontSize: 13, color: 'var(--text-1)', marginBottom: 4, letterSpacing: '-0.01em' }}>{g.name}</div>
                     <div style={{ display: 'flex', gap: 5, flexWrap: 'wrap' }}>
                       {g.deadline !== 'ongoing' && g.deadline !== '—' && (
-                        <span style={{ height: 20, padding: '0 7px', background: 'var(--sand-100)', border: '1px solid var(--sand-200)', borderRadius: 9999, fontSize: 10, color: 'var(--text-2)', fontWeight: 500, display: 'inline-flex', alignItems: 'center' }}>{g.deadline}</span>
+                        <span style={{ height: 'var(--ctrl-xs)', padding: '0 7px', background: 'var(--sand-100)', border: '1px solid var(--sand-200)', borderRadius: 9999, fontSize: 10, color: 'var(--text-2)', fontWeight: 500, display: 'inline-flex', alignItems: 'center' }}>{g.deadline}</span>
                       )}
                       {g.weeklyH > 0 && (
-                        <span className="tnum" style={{ height: 20, padding: '0 7px', background: 'var(--sand-100)', border: '1px solid var(--sand-200)', borderRadius: 9999, fontSize: 10, color: 'var(--text-2)', fontWeight: 500, display: 'inline-flex', alignItems: 'center' }}>{g.weeklyH}h/주</span>
+                        <span className="tnum" style={{ height: 'var(--ctrl-xs)', padding: '0 7px', background: 'var(--sand-100)', border: '1px solid var(--sand-200)', borderRadius: 9999, fontSize: 10, color: 'var(--text-2)', fontWeight: 500, display: 'inline-flex', alignItems: 'center' }}>{g.weeklyH}h/주</span>
                       )}
                     </div>
                     {g.status !== 'parked' && g.progress > 0 && (
@@ -205,7 +205,7 @@ export function GoalClassificationScreen({ onNext }: GoalClassificationScreenPro
               const n = tierCount[s];
               if (n === 0) return null;
               return (
-                <span key={s} className="tnum" style={{ height: 24, padding: '0 10px', background: m.bg, border: `1px solid ${m.border}`, color: m.color, borderRadius: 9999, fontSize: 11, fontWeight: 600, display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+                <span key={s} className="tnum" style={{ height: 'var(--ctrl-xs)', padding: '0 10px', background: m.bg, border: `1px solid ${m.border}`, color: m.color, borderRadius: 9999, fontSize: 11, fontWeight: 600, display: 'inline-flex', alignItems: 'center', gap: 4 }}>
                   {m.label} <span>{n}</span>
                 </span>
               );

--- a/src/screens/GoalIntakeScreen.tsx
+++ b/src/screens/GoalIntakeScreen.tsx
@@ -220,7 +220,7 @@ export function GoalIntakeScreen({ onDone }: GoalIntakeScreenProps) {
             <div style={{ fontWeight: 700, fontSize: 14, color: 'var(--text-1)' }}>목표 파악 AI</div>
             <div style={{ fontSize: 11, color: 'var(--text-3)' }}>질문에 답하면 자동으로 목표를 분류해요</div>
           </div>
-          <div style={{ height: 20, padding: '0 8px', background: 'var(--brand-soft)', border: '1px solid var(--coral-200)', borderRadius: 9999, fontSize: 9, fontWeight: 700, color: 'var(--coral-700)', fontFamily: 'var(--font-mono)', display: 'flex', alignItems: 'center' }}>
+          <div style={{ height: 'var(--ctrl-xs)', padding: '0 8px', background: 'var(--brand-soft)', border: '1px solid var(--coral-200)', borderRadius: 9999, fontSize: 9, fontWeight: 700, color: 'var(--coral-700)', fontFamily: 'var(--font-mono)', display: 'flex', alignItems: 'center' }}>
             {currentCategory ? (CATEGORY_LABEL[currentCategory] ?? '목표 파악') : '목표 파악'}
           </div>
         </div>

--- a/src/screens/GoalsScreen.tsx
+++ b/src/screens/GoalsScreen.tsx
@@ -233,7 +233,7 @@ export function GoalsScreen() {
               const n = count(t);
               const full = limit != null && n >= limit;
               return (
-                <span key={t} className="tnum" style={{ height: 24, padding: '0 10px', background: m.bg, border: `1px solid ${m.border}`, color: m.color, borderRadius: 9999, fontSize: 11, fontWeight: 700, display: 'inline-flex', alignItems: 'center', gap: 4, opacity: full ? 1 : 0.92 }}>
+                <span key={t} className="tnum" style={{ height: 'var(--ctrl-xs)', padding: '0 10px', background: m.bg, border: `1px solid ${m.border}`, color: m.color, borderRadius: 9999, fontSize: 11, fontWeight: 700, display: 'inline-flex', alignItems: 'center', gap: 4, opacity: full ? 1 : 0.92 }}>
                   {m.label} {n}/{limit}{full ? ' · 가득참' : ''}
                 </span>
               );
@@ -266,15 +266,15 @@ export function GoalsScreen() {
                     <div onClick={() => { setExpandedId(isExp ? null : g.goalId); setConfirmDeleteId(null); }} style={{ display: 'flex', alignItems: 'flex-start', gap: 10, cursor: 'pointer' }}>
                       <div style={{ flex: 1, minWidth: 0 }}>
                         <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 5, flexWrap: 'wrap' }}>
-                          <span style={{ height: 20, padding: '0 8px', borderRadius: 9999, background: m.bg, border: `1px solid ${m.border}`, fontSize: 10, fontWeight: 700, color: m.color, fontFamily: 'var(--font-mono)', display: 'inline-flex', alignItems: 'center' }}>{m.label}</span>
-                          <span style={{ height: 20, padding: '0 7px', background: 'var(--sand-100)', border: '1px solid var(--sand-200)', borderRadius: 9999, fontSize: 10, color: 'var(--text-2)', display: 'inline-flex', alignItems: 'center' }}>{CATEGORY_LABEL[g.category] ?? g.category}</span>
+                          <span style={{ height: 'var(--ctrl-xs)', padding: '0 8px', borderRadius: 9999, background: m.bg, border: `1px solid ${m.border}`, fontSize: 10, fontWeight: 700, color: m.color, fontFamily: 'var(--font-mono)', display: 'inline-flex', alignItems: 'center' }}>{m.label}</span>
+                          <span style={{ height: 'var(--ctrl-xs)', padding: '0 7px', background: 'var(--sand-100)', border: '1px solid var(--sand-200)', borderRadius: 9999, fontSize: 10, color: 'var(--text-2)', display: 'inline-flex', alignItems: 'center' }}>{CATEGORY_LABEL[g.category] ?? g.category}</span>
                         </div>
                         <div style={{ fontWeight: 700, fontSize: 14, color: 'var(--text-1)', letterSpacing: '-0.01em' }}>{g.title}</div>
                         <div style={{ display: 'flex', gap: 5, flexWrap: 'wrap', marginTop: 4 }}>
                           {g.deadline && (
-                            <span className="tnum" style={{ height: 20, padding: '0 7px', background: 'var(--sand-100)', border: '1px solid var(--sand-200)', borderRadius: 9999, fontSize: 10, color: 'var(--text-2)', display: 'inline-flex', alignItems: 'center' }}>~{g.deadline}</span>
+                            <span className="tnum" style={{ height: 'var(--ctrl-xs)', padding: '0 7px', background: 'var(--sand-100)', border: '1px solid var(--sand-200)', borderRadius: 9999, fontSize: 10, color: 'var(--text-2)', display: 'inline-flex', alignItems: 'center' }}>~{g.deadline}</span>
                           )}
-                          <span className="tnum" style={{ height: 20, padding: '0 7px', background: 'var(--sand-100)', border: '1px solid var(--sand-200)', borderRadius: 9999, fontSize: 10, color: 'var(--text-3)', display: 'inline-flex', alignItems: 'center' }}>우선순위 {g.priorityLevel}</span>
+                          <span className="tnum" style={{ height: 'var(--ctrl-xs)', padding: '0 7px', background: 'var(--sand-100)', border: '1px solid var(--sand-200)', borderRadius: 9999, fontSize: 10, color: 'var(--text-3)', display: 'inline-flex', alignItems: 'center' }}>우선순위 {g.priorityLevel}</span>
                         </div>
                       </div>
                     </div>

--- a/src/screens/InboxScreen.tsx
+++ b/src/screens/InboxScreen.tsx
@@ -158,11 +158,11 @@ export function InboxScreen() {
             >
               <div style={{ fontSize: 13, color: 'var(--text-1)', lineHeight: 1.5 }}>{it.rawText}</div>
               <div style={{ display: 'flex', gap: 5, flexWrap: 'wrap', alignItems: 'center' }}>
-                <span style={{ height: 20, padding: '0 8px', borderRadius: 9999, background: meta.bg, border: `1px solid ${meta.bd}`, fontSize: 10, fontWeight: 700, color: meta.fg, fontFamily: 'var(--font-mono)', display: 'inline-flex', alignItems: 'center' }}>
+                <span style={{ height: 'var(--ctrl-xs)', padding: '0 8px', borderRadius: 9999, background: meta.bg, border: `1px solid ${meta.bd}`, fontSize: 10, fontWeight: 700, color: meta.fg, fontFamily: 'var(--font-mono)', display: 'inline-flex', alignItems: 'center' }}>
                   {meta.label}
                 </span>
                 {it.aiCategoryGuess && (
-                  <span style={{ height: 20, padding: '0 8px', borderRadius: 9999, background: 'var(--sand-100)', border: '1px solid var(--sand-200)', fontSize: 10, color: 'var(--text-2)', fontWeight: 500, display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+                  <span style={{ height: 'var(--ctrl-xs)', padding: '0 8px', borderRadius: 9999, background: 'var(--sand-100)', border: '1px solid var(--sand-200)', fontSize: 10, color: 'var(--text-2)', fontWeight: 500, display: 'inline-flex', alignItems: 'center', gap: 4 }}>
                     <Sparkle size={9} weight="fill" /> {it.aiCategoryGuess}
                   </span>
                 )}

--- a/src/screens/MorningBriefScreen.tsx
+++ b/src/screens/MorningBriefScreen.tsx
@@ -83,10 +83,10 @@ export function MorningBriefScreen({ onStart }: MorningBriefScreenProps) {
                   <div style={{ flex: 1 }}>
                     <div style={{ display: 'flex', gap: 6, marginBottom: 5, flexWrap: 'wrap' }}>
                       {b.carryover && (
-                        <span style={{ height: 20, padding: '0 8px', background: '#FBEEDA', border: '1px solid #F2D29A', borderRadius: 9999, fontSize: 9, color: 'var(--warning)', fontWeight: 600, fontFamily: 'var(--font-mono)', display: 'inline-flex', alignItems: 'center' }}>이월</span>
+                        <span style={{ height: 'var(--ctrl-xs)', padding: '0 8px', background: '#FBEEDA', border: '1px solid #F2D29A', borderRadius: 9999, fontSize: 9, color: 'var(--warning)', fontWeight: 600, fontFamily: 'var(--font-mono)', display: 'inline-flex', alignItems: 'center' }}>이월</span>
                       )}
-                      <span className="tnum" style={{ height: 20, padding: '0 8px', background: 'var(--sand-100)', border: '1px solid var(--sand-200)', borderRadius: 9999, fontSize: 10, color: 'var(--text-2)', fontWeight: 500, display: 'inline-flex', alignItems: 'center' }}>{b.time}</span>
-                      <span style={{ height: 20, padding: '0 8px', background: 'var(--sand-100)', border: '1px solid var(--sand-200)', borderRadius: 9999, fontSize: 10, color: 'var(--text-2)', fontWeight: 500, display: 'inline-flex', alignItems: 'center' }}>{b.dur}</span>
+                      <span className="tnum" style={{ height: 'var(--ctrl-xs)', padding: '0 8px', background: 'var(--sand-100)', border: '1px solid var(--sand-200)', borderRadius: 9999, fontSize: 10, color: 'var(--text-2)', fontWeight: 500, display: 'inline-flex', alignItems: 'center' }}>{b.time}</span>
+                      <span style={{ height: 'var(--ctrl-xs)', padding: '0 8px', background: 'var(--sand-100)', border: '1px solid var(--sand-200)', borderRadius: 9999, fontSize: 10, color: 'var(--text-2)', fontWeight: 500, display: 'inline-flex', alignItems: 'center' }}>{b.dur}</span>
                     </div>
                     <div style={{ fontSize: 14, fontWeight: 700, letterSpacing: '-0.01em', color: 'var(--text-1)' }}>{b.title}</div>
                     {b.note && <div style={{ fontSize: 11, color: 'var(--text-3)', marginTop: 3 }}>{b.note}</div>}

--- a/src/screens/RecoveredScreen.tsx
+++ b/src/screens/RecoveredScreen.tsx
@@ -68,7 +68,7 @@ export function RecoveredScreen({ recoveryCount, applied, onDone }: RecoveredScr
               <div style={{ fontSize: 14, fontWeight: 700, color: 'var(--text-1)' }}>{applied.proposalTitle}</div>
               {applied.proposalDesc && <div style={{ fontSize: 12, color: 'var(--coral-700)', marginTop: 2, lineHeight: 1.5 }}>{applied.proposalDesc}</div>}
               {applied.proposalTime && applied.proposalTime !== '—' && (
-                <div style={{ display: 'inline-flex', alignItems: 'center', gap: 4, marginTop: 6, height: 20, padding: '0 8px', background: 'var(--surface-raised)', border: '1px solid var(--coral-200)', borderRadius: 9999, fontSize: 10, fontWeight: 600, color: 'var(--coral-700)' }}>
+                <div style={{ display: 'inline-flex', alignItems: 'center', gap: 4, marginTop: 6, height: 'var(--ctrl-xs)', padding: '0 8px', background: 'var(--surface-raised)', border: '1px solid var(--coral-200)', borderRadius: 9999, fontSize: 10, fontWeight: 600, color: 'var(--coral-700)' }}>
                   <Clock size={10} weight="fill" /> {applied.proposalTime}
                 </div>
               )}

--- a/src/screens/RecoveryScreen.tsx
+++ b/src/screens/RecoveryScreen.tsx
@@ -119,7 +119,7 @@ export function MergedRecoveryScreen({ task, failReason, onAccept, onDismiss }: 
                       <div style={{ flex: 1, minWidth: 0 }}>
                         <div style={{ fontSize: 13, fontWeight: 700, color: 'var(--text-1)', letterSpacing: '-0.01em' }}>{p.title}</div>
                         <div style={{ display: 'flex', gap: 8, marginTop: 3, alignItems: 'center' }}>
-                          {i === 0 && <span style={{ height: 16, padding: '0 6px', background: p.bg, border: `1px solid ${p.bc}`, borderRadius: 9999, fontSize: 9, fontWeight: 700, color: p.ac, fontFamily: 'var(--font-mono)', display: 'inline-flex', alignItems: 'center', letterSpacing: '0.04em' }}>패턴 일치 ✓</span>}
+                          {i === 0 && <span style={{ height: 'var(--ctrl-xs)', padding: '0 6px', background: p.bg, border: `1px solid ${p.bc}`, borderRadius: 9999, fontSize: 9, fontWeight: 700, color: p.ac, fontFamily: 'var(--font-mono)', display: 'inline-flex', alignItems: 'center', letterSpacing: '0.04em' }}>패턴 일치 ✓</span>}
                           <span className="tnum" style={{ fontSize: 10, fontFamily: 'var(--font-mono)', fontWeight: 600, color: p.conf > 80 ? 'var(--success)' : p.conf > 65 ? 'var(--warning)' : 'var(--text-3)' }}>성공률 {p.conf}%</span>
                           <span style={{ fontSize: 11, color: 'var(--text-3)' }}>{p.time}</span>
                         </div>

--- a/src/screens/SetupScreen.tsx
+++ b/src/screens/SetupScreen.tsx
@@ -206,7 +206,7 @@ export function SetupScreen({ onDone }: SetupScreenProps) {
           <div style={{ flex: 1 }}>
             <div style={{ fontWeight: 600, fontSize: 12, color: 'var(--text-2)', display: 'flex', alignItems: 'center', gap: 5 }}>
               Google 캘린더 자동 가져오기
-              <span style={{ height: 14, padding: '0 5px', borderRadius: 9999, background: 'var(--sand-200)', fontSize: 8, fontWeight: 700, color: 'var(--text-3)', fontFamily: 'var(--font-mono)', display: 'inline-flex', alignItems: 'center' }}>준비 중</span>
+              <span style={{ height: 'var(--ctrl-xs)', padding: '0 5px', borderRadius: 9999, background: 'var(--sand-200)', fontSize: 8, fontWeight: 700, color: 'var(--text-3)', fontFamily: 'var(--font-mono)', display: 'inline-flex', alignItems: 'center' }}>준비 중</span>
             </div>
             <div style={{ fontSize: 10, color: 'var(--text-3)', marginTop: 1 }}>지금은 아래에서 직접 추가해 주세요</div>
           </div>

--- a/src/screens/SystemIntroScreen.tsx
+++ b/src/screens/SystemIntroScreen.tsx
@@ -137,7 +137,7 @@ function RecoveryDiagram() {
     <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
       {items.map((r, i) => (
         <div key={i} style={{ background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', borderRadius: 10, padding: '9px 12px' }}>
-          <div style={{ display: 'inline-flex', alignItems: 'center', height: 18, padding: '0 7px', background: r.bg, border: `1px solid ${r.bc}`, borderRadius: 9999, fontSize: 9, fontWeight: 700, color: r.tc, letterSpacing: '0.06em', marginBottom: 4, fontFamily: 'var(--font-mono)' }}>{r.type}</div>
+          <div style={{ display: 'inline-flex', alignItems: 'center', height: 'var(--ctrl-xs)', padding: '0 7px', background: r.bg, border: `1px solid ${r.bc}`, borderRadius: 9999, fontSize: 9, fontWeight: 700, color: r.tc, letterSpacing: '0.06em', marginBottom: 4, fontFamily: 'var(--font-mono)' }}>{r.type}</div>
           <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--text-1)', marginBottom: 1 }}>{r.t}</div>
           <div style={{ fontSize: 10, color: 'var(--text-3)' }}>{r.w}</div>
         </div>

--- a/src/screens/TodayScreen.tsx
+++ b/src/screens/TodayScreen.tsx
@@ -284,7 +284,7 @@ export function MergedTodayScreen({ tasks, onOpen, onMarkDone, onPartial, onFail
                 style={{ position: 'relative', width: 36, height: 36, borderRadius: 9999, border: 'none', background: 'var(--brand-soft)', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer' }}
               >
                 <ArrowsClockwise size={16} color="var(--brand)" weight="fill" />
-                <span className="tnum" style={{ position: 'absolute', top: -2, right: -2, minWidth: 16, height: 16, padding: '0 4px', borderRadius: 9999, background: 'var(--brand)', color: '#FFFCF6', fontSize: 9, fontWeight: 700, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>{partialTasks.length}</span>
+                <span className="tnum" style={{ position: 'absolute', top: -2, right: -2, minWidth: 16, height: 'var(--ctrl-xs)', padding: '0 4px', borderRadius: 9999, background: 'var(--brand)', color: '#FFFCF6', fontSize: 9, fontWeight: 700, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>{partialTasks.length}</span>
               </button>
             )}
             <HeaderMenu />
@@ -466,7 +466,7 @@ function HeroTaskCard({
         <h2 style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 26, letterSpacing: '-0.02em', lineHeight: 1.2, margin: 0, color: 'var(--text-1)' }}>{task.title}</h2>
         <div style={{ display: 'flex', gap: 6, marginTop: 8, alignItems: 'center', flexWrap: 'wrap' }}>
           {task.carryover && (
-            <span style={{ height: 18, padding: '0 6px', background: '#FBEEDA', border: '1px solid #F2D29A', borderRadius: 9999, fontSize: 10, color: 'var(--warning)', fontWeight: 600, display: 'inline-flex', alignItems: 'center' }}>↩ 이월</span>
+            <span style={{ height: 'var(--ctrl-xs)', padding: '0 6px', background: '#FBEEDA', border: '1px solid #F2D29A', borderRadius: 9999, fontSize: 10, color: 'var(--warning)', fontWeight: 600, display: 'inline-flex', alignItems: 'center' }}>↩ 이월</span>
           )}
           {task.time && <span className="tnum" style={{ fontSize: 12, color: 'var(--text-2)' }}>{task.time}{task.dur ? ` · ${task.dur}` : ''}</span>}
         </div>

--- a/src/screens/WeeklyCalendarScreen.tsx
+++ b/src/screens/WeeklyCalendarScreen.tsx
@@ -3,7 +3,6 @@ import { Plus, X, Trash } from '@phosphor-icons/react';
 import { WEEK_PLAN_DEFAULT, GOAL_COLORS, DAYS_KO } from '../data';
 import { ApiError, plansApi } from '../lib/api';
 import { DemoNotice } from '../components/DemoNotice';
-import { WeeklySwitch } from '../components/WeeklySwitch';
 import { Segmented } from '../components/Segmented';
 import { useNavigation } from '../contexts/NavigationContext';
 import type { Block } from '../types';
@@ -380,12 +379,8 @@ export function WeeklyCalendarScreenV2() {
     <div style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column', background: 'var(--surface-ground)' }}>
       {/* Header */}
       <div style={{ flexShrink: 0, padding: '10px 14px 8px', borderBottom: '1px solid var(--sand-200)' }}>
-        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8 }}>
-          <WeeklySwitch />
-          <span style={{ fontSize: 9, fontFamily: 'var(--font-mono)', color: 'var(--text-3)', letterSpacing: '0.08em' }}>{weekLabel}</span>
-        </div>
         {/* 이번 주 / 다음 주 전환 — 주간 리뷰의 "다음 주 계획 확인" 도 여기 다음 주로 진입 */}
-        <div style={{ marginBottom: 8 }}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8 }}>
           <Segmented
             ariaLabel="이번 주/다음 주 전환"
             value={weekOffset}
@@ -395,6 +390,7 @@ export function WeeklyCalendarScreenV2() {
               { value: 1, label: '다음 주' },
             ]}
           />
+          <span style={{ fontSize: 9, fontFamily: 'var(--font-mono)', color: 'var(--text-3)', letterSpacing: '0.08em' }}>{weekLabel}</span>
         </div>
         <p style={{ fontSize: 11, color: 'var(--text-3)', margin: '0 0 8px' }}>블록을 탭하면 수정, 길게 누른 채 끌면 15분 단위로 이동돼요.</p>
         <div style={{ marginBottom: 8 }}>
@@ -408,7 +404,7 @@ export function WeeklyCalendarScreenV2() {
             { label: '이월', n: blocks.filter((b) => b.carryover).length, bg: '#FBEEDA', bd: '#F2D29A', fg: 'var(--warning)' },
             { label: '대기', n: blocks.filter((b) => b.status === 'pending' && !b.carryover).length, bg: 'var(--sand-100)', bd: 'var(--sand-200)', fg: 'var(--text-2)' },
           ].map((c, i) => (
-            <span key={i} className="tnum" style={{ height: 22, padding: '0 9px', background: c.bg, border: `1px solid ${c.bd}`, borderRadius: 9999, fontSize: 10, color: c.fg, fontWeight: 600, display: 'inline-flex', alignItems: 'center', fontFamily: 'var(--font-mono)' }}>{c.label} {c.n}</span>
+            <span key={i} className="tnum" style={{ height: 'var(--ctrl-xs)', padding: '0 9px', background: c.bg, border: `1px solid ${c.bd}`, borderRadius: 9999, fontSize: 10, color: c.fg, fontWeight: 600, display: 'inline-flex', alignItems: 'center', fontFamily: 'var(--font-mono)' }}>{c.label} {c.n}</span>
           ))}
         </div>
       </div>

--- a/src/screens/WeeklyPlanGenerationScreen.tsx
+++ b/src/screens/WeeklyPlanGenerationScreen.tsx
@@ -232,13 +232,13 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
           rejectLabel="재생성"
         >
           <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
-            <span className="tnum" style={{ height: 24, padding: '0 10px', background: 'var(--text-1)', color: '#FAF6EE', borderRadius: 9999, fontSize: 11, fontWeight: 600, display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+            <span className="tnum" style={{ height: 'var(--ctrl-xs)', padding: '0 10px', background: 'var(--text-1)', color: '#FAF6EE', borderRadius: 9999, fontSize: 11, fontWeight: 600, display: 'inline-flex', alignItems: 'center', gap: 4 }}>
               <Clock size={11} weight="fill" /> 총 {totalH.toFixed(1)}h
             </span>
             {Object.entries(goalCount).map(([g, mins]) => {
               const c = GOAL_COLORS[g] || GOAL_COLORS['SQLD'];
               return (
-                <span key={g} style={{ height: 24, padding: '0 10px', background: c.bg, border: `1px solid ${c.bd}`, color: c.fg, borderRadius: 9999, fontSize: 11, fontWeight: 600, display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+                <span key={g} style={{ height: 'var(--ctrl-xs)', padding: '0 10px', background: c.bg, border: `1px solid ${c.bd}`, color: c.fg, borderRadius: 9999, fontSize: 11, fontWeight: 600, display: 'inline-flex', alignItems: 'center', gap: 4 }}>
                   <span style={{ width: 6, height: 6, borderRadius: 9999, background: c.fg }} />
                   {g} <span className="tnum">{(mins / 60).toFixed(1)}h</span>
                 </span>

--- a/src/screens/WeeklyReviewScreen.tsx
+++ b/src/screens/WeeklyReviewScreen.tsx
@@ -3,7 +3,6 @@ import { Sparkle, ArrowRight } from '@phosphor-icons/react';
 import { REVIEW_V2 } from '../data';
 import { reviewsApi } from '../lib/api';
 import { DemoNotice } from '../components/DemoNotice';
-import { WeeklySwitch } from '../components/WeeklySwitch';
 import { useNavigation } from '../contexts/NavigationContext';
 import type { FailItem } from '../types';
 
@@ -149,10 +148,6 @@ export function WeeklyReviewScreenV2() {
       {/* Scrollable content */}
       <div style={{ flex: 1, overflowY: 'auto', overflowX: 'hidden', padding: '14px 18px 0', display: 'flex', flexDirection: 'column', gap: 14 }}>
 
-        <div style={{ display: 'flex', justifyContent: 'flex-start' }}>
-          <WeeklySwitch />
-        </div>
-
         {/* Header */}
         <div>
           <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--text-3)', fontFamily: 'var(--font-mono)', marginBottom: 3 }}>{week}</div>
@@ -202,7 +197,7 @@ export function WeeklyReviewScreenV2() {
                   <div style={{ fontSize: 16, color: k.ok ? 'var(--success)' : 'var(--warning)' }}>
                     {k.ok ? '●' : '◎'}
                   </div>
-                  <span style={{ height: 17, padding: '0 6px', borderRadius: 9999, fontSize: 9, fontWeight: 700, background: k.ok ? '#E5EFE3' : '#FBEEDA', color: k.ok ? 'var(--success)' : 'var(--warning)', border: `1px solid ${k.ok ? '#b4dfc8' : '#F2D29A'}`, display: 'inline-flex', alignItems: 'center', fontFamily: 'var(--font-mono)' }}>{k.trend}</span>
+                  <span style={{ height: 'var(--ctrl-xs)', padding: '0 6px', borderRadius: 9999, fontSize: 9, fontWeight: 700, background: k.ok ? '#E5EFE3' : '#FBEEDA', color: k.ok ? 'var(--success)' : 'var(--warning)', border: `1px solid ${k.ok ? '#b4dfc8' : '#F2D29A'}`, display: 'inline-flex', alignItems: 'center', fontFamily: 'var(--font-mono)' }}>{k.trend}</span>
                 </div>
                 <div>
                   <div style={{ fontSize: 9, fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--text-3)', fontFamily: 'var(--font-mono)' }}>{k.label}</div>
@@ -238,7 +233,7 @@ export function WeeklyReviewScreenV2() {
               { tone: 'var(--coral-50)', border: 'var(--coral-200)', label: '다음 주', color: 'var(--coral-700)', title: '새 "만약-그땐" 제안', body: '만약 화요일 오후 3시라면, 15분 산책부터 한다.' },
             ].map((c, i) => (
               <div key={i} style={{ background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', borderRadius: 14, padding: '12px 14px' }}>
-                <div style={{ display: 'inline-flex', height: 18, padding: '0 8px', background: c.tone, border: `1px solid ${c.border}`, borderRadius: 9999, fontSize: 9, fontWeight: 700, color: c.color, letterSpacing: '0.06em', fontFamily: 'var(--font-mono)', alignItems: 'center', marginBottom: 6 }}>{c.label}</div>
+                <div style={{ display: 'inline-flex', height: 'var(--ctrl-xs)', padding: '0 8px', background: c.tone, border: `1px solid ${c.border}`, borderRadius: 9999, fontSize: 9, fontWeight: 700, color: c.color, letterSpacing: '0.06em', fontFamily: 'var(--font-mono)', alignItems: 'center', marginBottom: 6 }}>{c.label}</div>
                 <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--text-1)', marginBottom: 3 }}>{c.title}</div>
                 <p style={{ fontSize: 12, color: 'var(--text-3)', margin: 0, lineHeight: 1.5 }}>{c.body}</p>
               </div>
@@ -253,7 +248,7 @@ export function WeeklyReviewScreenV2() {
             <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 5 }}>
               <Sparkle size={13} color="#F4B89E" weight="fill" />
               <span style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 14, color: '#FAF6EE', letterSpacing: '-0.01em', flex: 1, minWidth: 0 }}>다음 주 정책 자동 보정</span>
-              <span style={{ height: 17, padding: '0 7px', background: 'var(--brand)', color: '#FFFCF6', borderRadius: 9999, fontSize: 9, fontWeight: 700, display: 'inline-flex', alignItems: 'center', fontFamily: 'var(--font-mono)', flexShrink: 0 }}>AI</span>
+              <span style={{ height: 'var(--ctrl-xs)', padding: '0 7px', background: 'var(--brand)', color: '#FFFCF6', borderRadius: 9999, fontSize: 9, fontWeight: 700, display: 'inline-flex', alignItems: 'center', fontFamily: 'var(--font-mono)', flexShrink: 0 }}>AI</span>
             </div>
             <p style={{ fontSize: 11, color: 'rgba(250,246,238,.55)', marginBottom: 10, lineHeight: 1.5 }}>이번 주 패턴 분석으로 다음 주 계획에 자동 적용돼요.</p>
             <div style={{ display: 'flex', flexDirection: 'column', gap: 7 }}>


### PR DESCRIPTION
## 토글 위치
계획/리뷰가 다른 화면이라 토글이 각 화면의 다른 위치에 그려져 **전환 시 점프**. WeeklySwitch 를 상단 네비 바 중앙(공통·고정)으로 이동 → 위치 불변. 각 화면 본문 토글 제거.

## 배지 사이즈
텍스트 패딩 있는 pill 배지 29곳을 `--ctrl-xs`(20)로 통일. 토글 손잡이·날짜 원·라디오 원(패딩 없는 원형)은 제외해 오작동 방지.

tsc / build ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)