### PR TITLE
fix(pwa): 모바일 노치/상태바 safe-area 대응 (상단 잘림 방지)

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,8 +2,13 @@
 <html lang="ko">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- viewport-fit=cover: 노치/홈 인디케이터 영역까지 채우고 env(safe-area-inset-*) 활성화 -->
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="theme-color" content="#C8643F" />
+    <!-- PWA standalone 상태바 처리 (iOS/Android) -->
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <link rel="manifest" href="/manifest.webmanifest" />
     <link rel="icon" type="image/svg+xml" href="/icon.svg" />
     <link rel="apple-touch-icon" href="/icon.svg" />

--- a/src/index.css
+++ b/src/index.css
@@ -222,6 +222,11 @@ body {
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  /* 노치/상태바·가로 노치 회피. box-sizing:border-box 라 100dvh 안에서 콘텐츠가 줄어든다.
+     하단은 각 화면 sticky 영역이 env(safe-area-inset-bottom) 로 처리하므로 여기선 제외. */
+  padding-top: env(safe-area-inset-top);
+  padding-left: env(safe-area-inset-left);
+  padding-right: env(safe-area-inset-right);
 }
 
 /* 태블릿 (640px~): 중앙 정렬 + 그림자 */


### PR DESCRIPTION
## 문제
standalone PWA로 설치 시 상단 네비 바가 노치/상태바 밑에 깔려 잘림. 게다가 `viewport-fit=cover`가 없어 기존 하단 `env(safe-area-inset-bottom)` 들도 실제로는 0으로 동작 안 하던 상태.

## 수정
- `viewport-fit=cover` 추가 → 모든 `env(safe-area-inset-*)` 활성화
- iOS/Android PWA 상태바 메타 추가(`mobile-web-app-capable`, `apple-mobile-web-app-status-bar-style`)
- `.app-container`에 상단·좌우 safe-area padding (border-box라 100dvh 내에서 콘텐츠 축소). 하단은 각 화면 sticky 영역이 이미 env로 처리.

## 확인
manifest `display: standalone` / tsc·build ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)