### PR TITLE
ci(api): sync-api PR 생성 PAT 폴백

### DIFF
--- a/.github/workflows/sync-api.yml
+++ b/.github/workflows/sync-api.yml
@@ -67,6 +67,9 @@ jobs:
       - name: Open PR if changed
         uses: peter-evans/create-pull-request@v6
         with:
+          # 조직이 기본 GITHUB_TOKEN 의 쓰기를 막아둠 → PAT 시크릿(SYNC_API_TOKEN) 필요.
+          # 없으면 기본 토큰으로 시도(조직 설정에서 'Actions가 PR 생성' 허용 시 동작).
+          token: ${{ secrets.SYNC_API_TOKEN || github.token }}
           branch: auto/api-sync
           commit-message: "chore(api): 백엔드 OpenAPI 변경 반영 (자동 생성)"
           title: "chore(api): 백엔드 OpenAPI 동기화"


### PR DESCRIPTION
조직이 기본 토큰 쓰기를 막아 PR 생성이 실패했음. SYNC_API_TOKEN 시크릿 폴백 추가. codegen(openapi 덤프→타입 생성) 단계는 실제 실행으로 검증 완료. 🤖 Generated with Claude Code