### PR TITLE
chore(api): 백엔드 API 동기화 (routine)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -100,6 +100,42 @@
         "title": "ActionDetail",
         "type": "object"
       },
+      "ActionItemDraft": {
+        "description": "leaf 노드에 매달리는 실행 항목 — SMART + tiny_first_step.",
+        "properties": {
+          "category": {
+            "title": "Category",
+            "type": "string"
+          },
+          "estimatedMinutes": {
+            "exclusiveMinimum": 0.0,
+            "maximum": 60.0,
+            "title": "Estimatedminutes",
+            "type": "integer"
+          },
+          "firstStep": {
+            "title": "Firststep",
+            "type": "string"
+          },
+          "nodeId": {
+            "title": "Nodeid",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "nodeId",
+          "title",
+          "estimatedMinutes",
+          "category",
+          "firstStep"
+        ],
+        "title": "ActionItemDraft",
+        "type": "object"
+      },
       "AgendaCard": {
         "description": "S10 어젠다의 ActionItem 카드 (조회 표현).",
         "properties": {
@@ -397,6 +433,97 @@
         "title": "CalendarEventPreview",
         "type": "object"
       },
+      "CheckInRequest": {
+        "description": "POST /today/check-ins 요청 — Quick Check-in 4칩 (S13/S17).",
+        "properties": {
+          "completionStatus": {
+            "enum": [
+              "done",
+              "partial_done",
+              "failed",
+              "over_done"
+            ],
+            "title": "Completionstatus",
+            "type": "string"
+          },
+          "executionId": {
+            "title": "Executionid",
+            "type": "string"
+          },
+          "userFeedback": {
+            "anyOf": [
+              {
+                "maxLength": 500,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Userfeedback"
+          },
+          "userRating": {
+            "anyOf": [
+              {
+                "maximum": 5.0,
+                "minimum": 1.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Userrating"
+          }
+        },
+        "required": [
+          "executionId",
+          "completionStatus"
+        ],
+        "title": "CheckInRequest",
+        "type": "object"
+      },
+      "CheckInResponse": {
+        "description": "체크인 결과. `needs_failure_tags=True` 면 FE 는 S18(실패 사유)로 이동.",
+        "properties": {
+          "actionId": {
+            "title": "Actionid",
+            "type": "string"
+          },
+          "actualDurationMinutes": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Actualdurationminutes"
+          },
+          "completionStatus": {
+            "title": "Completionstatus",
+            "type": "string"
+          },
+          "executionId": {
+            "title": "Executionid",
+            "type": "string"
+          },
+          "needsFailureTags": {
+            "title": "Needsfailuretags",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "executionId",
+          "actionId",
+          "completionStatus",
+          "actualDurationMinutes",
+          "needsFailureTags"
+        ],
+        "title": "CheckInResponse",
+        "type": "object"
+      },
       "DbStatus": {
         "description": "DB 헬스 정보 (health 응답에 포함).",
         "properties": {
@@ -431,6 +558,303 @@
           "ok"
         ],
         "title": "DbStatus",
+        "type": "object"
+      },
+      "ExecutionStartResponse": {
+        "description": "POST /today/actions/{id}/start 응답 — [▶ 시작] (#19-B).\n\nscheduled_block 이 없으면 즉석(ad-hoc) 블록을 생성해 연결한다 (source='user_edit').",
+        "properties": {
+          "actionId": {
+            "title": "Actionid",
+            "type": "string"
+          },
+          "actualStartAt": {
+            "format": "date-time",
+            "title": "Actualstartat",
+            "type": "string"
+          },
+          "completionStatus": {
+            "title": "Completionstatus",
+            "type": "string"
+          },
+          "executionId": {
+            "title": "Executionid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "executionId",
+          "actionId",
+          "completionStatus",
+          "actualStartAt"
+        ],
+        "title": "ExecutionStartResponse",
+        "type": "object"
+      },
+      "FailureTagMaster": {
+        "description": "GET /reflection/failure-tags 응답 row — S18 칩의 원본 (13종, is_active=true).",
+        "properties": {
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "labelKo": {
+            "title": "Labelko",
+            "type": "string"
+          },
+          "sortOrder": {
+            "title": "Sortorder",
+            "type": "integer"
+          },
+          "tagCode": {
+            "title": "Tagcode",
+            "type": "string"
+          }
+        },
+        "required": [
+          "tagCode",
+          "labelKo",
+          "description",
+          "sortOrder"
+        ],
+        "title": "FailureTagMaster",
+        "type": "object"
+      },
+      "FailureTagRequest": {
+        "description": "POST /reflection/failure-tags/{executionId} — 실패 사유 0~2개 + 메모.",
+        "properties": {
+          "memo": {
+            "anyOf": [
+              {
+                "maxLength": 300,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Memo"
+          },
+          "tagCodes": {
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 2,
+            "title": "Tagcodes",
+            "type": "array"
+          }
+        },
+        "required": [
+          "tagCodes"
+        ],
+        "title": "FailureTagRequest",
+        "type": "object"
+      },
+      "FailureTagResponse": {
+        "description": "태깅 결과.",
+        "properties": {
+          "executionId": {
+            "title": "Executionid",
+            "type": "string"
+          },
+          "hasMemo": {
+            "title": "Hasmemo",
+            "type": "boolean"
+          },
+          "tagCodes": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Tagcodes",
+            "type": "array"
+          }
+        },
+        "required": [
+          "executionId",
+          "tagCodes",
+          "hasMemo"
+        ],
+        "title": "FailureTagResponse",
+        "type": "object"
+      },
+      "FirstPlanApproveResponse": {
+        "description": "승인 결과 — 활성화 완료. 명시 승인 endpoint 이므로 `is_draft=False` (ADR-0005 §7.2).\n\n#62: `plan_id` 로 저장된 Draft 를 로드해 goal 트리까지 영속화한 결과 카운트.",
+        "properties": {
+          "activatedActionItems": {
+            "title": "Activatedactionitems",
+            "type": "integer"
+          },
+          "activatedAt": {
+            "format": "date-time",
+            "title": "Activatedat",
+            "type": "string"
+          },
+          "activatedBlocks": {
+            "title": "Activatedblocks",
+            "type": "integer"
+          },
+          "activatedGoalNodes": {
+            "title": "Activatedgoalnodes",
+            "type": "integer"
+          },
+          "activatedGoals": {
+            "title": "Activatedgoals",
+            "type": "integer"
+          },
+          "isDraft": {
+            "const": false,
+            "default": false,
+            "title": "Isdraft",
+            "type": "boolean"
+          },
+          "planId": {
+            "title": "Planid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "planId",
+          "activatedGoals",
+          "activatedGoalNodes",
+          "activatedActionItems",
+          "activatedBlocks",
+          "activatedAt"
+        ],
+        "title": "FirstPlanApproveResponse",
+        "type": "object"
+      },
+      "FirstPlanGenerateRequest": {
+        "description": "POST /plans/generate (첫 계획) 요청.\n\n`interview_session_id` 로 확정된 `InterviewOutcome` 을 참조하거나(서버가 로드),\n온보딩 흐름에서 outcome 을 인라인 전달할 수 있다(`outcome`). 둘 중 하나는 필수 —\n검증은 라우터/오케스트레이터 VALIDATING 단계에서 수행.",
+        "properties": {
+          "interviewSessionId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Interviewsessionid"
+          },
+          "outcome": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/InterviewOutcome"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "targetDate": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Targetdate"
+          }
+        },
+        "title": "FirstPlanGenerateRequest",
+        "type": "object"
+      },
+      "FirstPlanResponse": {
+        "description": "First Plan 미리보기 응답 — 항상 Draft (사용자 [수락] 전).\n\n`is_draft=True` 고정, `ai_source` 는 오케스트레이터 `used_fallback` 에 따라 라우터가 set.",
+        "properties": {
+          "actionItems": {
+            "items": {
+              "$ref": "#/components/schemas/ActionItemDraft"
+            },
+            "title": "Actionitems",
+            "type": "array"
+          },
+          "aiSource": {
+            "default": "llm",
+            "enum": [
+              "llm",
+              "rule"
+            ],
+            "title": "Aisource",
+            "type": "string"
+          },
+          "blocks": {
+            "items": {
+              "$ref": "#/components/schemas/ScheduledBlockPreview"
+            },
+            "title": "Blocks",
+            "type": "array"
+          },
+          "generatedAt": {
+            "format": "date-time",
+            "title": "Generatedat",
+            "type": "string"
+          },
+          "goalNodes": {
+            "items": {
+              "$ref": "#/components/schemas/GoalNodeDraft"
+            },
+            "title": "Goalnodes",
+            "type": "array"
+          },
+          "horizon": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Horizon"
+          },
+          "isDraft": {
+            "default": true,
+            "title": "Isdraft",
+            "type": "boolean"
+          },
+          "planId": {
+            "title": "Planid",
+            "type": "string"
+          },
+          "policyViolations": {
+            "items": {
+              "$ref": "#/components/schemas/PolicyViolation"
+            },
+            "title": "Policyviolations",
+            "type": "array"
+          },
+          "targetDate": {
+            "title": "Targetdate",
+            "type": "string"
+          },
+          "warnings": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Warnings",
+            "type": "array"
+          }
+        },
+        "required": [
+          "planId",
+          "targetDate",
+          "horizon",
+          "goalNodes",
+          "actionItems",
+          "blocks",
+          "generatedAt"
+        ],
+        "title": "FirstPlanResponse",
         "type": "object"
       },
       "FixedSchedule": {
@@ -832,6 +1256,58 @@
           "depth"
         ],
         "title": "GoalNode",
+        "type": "object"
+      },
+      "GoalNodeDraft": {
+        "description": "분해된 goal_node 한 개 (root → branch → leaf 트리).",
+        "properties": {
+          "isLeaf": {
+            "title": "Isleaf",
+            "type": "boolean"
+          },
+          "nodeId": {
+            "title": "Nodeid",
+            "type": "string"
+          },
+          "nodeType": {
+            "enum": [
+              "root",
+              "branch",
+              "leaf"
+            ],
+            "title": "Nodetype",
+            "type": "string"
+          },
+          "orderIndex": {
+            "minimum": 0.0,
+            "title": "Orderindex",
+            "type": "integer"
+          },
+          "parentId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Parentid"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "nodeId",
+          "parentId",
+          "title",
+          "nodeType",
+          "orderIndex",
+          "isLeaf"
+        ],
+        "title": "GoalNodeDraft",
         "type": "object"
       },
       "GoalUpdateRequest": {
@@ -1695,6 +2171,25 @@
         "title": "OnboardingStatus",
         "type": "object"
       },
+      "PolicyViolation": {
+        "description": "정책 위반으로 제외된 노드 + 사유 (cap / 충돌 등).",
+        "properties": {
+          "nodeId": {
+            "title": "Nodeid",
+            "type": "string"
+          },
+          "reason": {
+            "title": "Reason",
+            "type": "string"
+          }
+        },
+        "required": [
+          "nodeId",
+          "reason"
+        ],
+        "title": "PolicyViolation",
+        "type": "object"
+      },
       "PreferenceProfile": {
         "description": "선호 방식 (recovery.* + energy.* 슬롯군).\n\nFirst Plan 이 behavioral_profile / interaction_style 컨텍스트로 사용.",
         "properties": {
@@ -1807,6 +2302,223 @@
         "title": "Question",
         "type": "object"
       },
+      "RecoveryCard": {
+        "description": "회복 옵션 카드 1장 — recovery_attempts 1행과 대응 (user_decision='pending').",
+        "properties": {
+          "allowRestMode": {
+            "title": "Allowrestmode",
+            "type": "boolean"
+          },
+          "attemptId": {
+            "title": "Attemptid",
+            "type": "string"
+          },
+          "labelKo": {
+            "title": "Labelko",
+            "type": "string"
+          },
+          "minRecoveryUnitMinutes": {
+            "title": "Minrecoveryunitminutes",
+            "type": "integer"
+          },
+          "optionGroup": {
+            "enum": [
+              "DOWNSCOPE",
+              "RESCHEDULE",
+              "CARRY_OVER",
+              "PARK"
+            ],
+            "title": "Optiongroup",
+            "type": "string"
+          },
+          "strategyType": {
+            "title": "Strategytype",
+            "type": "string"
+          },
+          "suggestedActionText": {
+            "title": "Suggestedactiontext",
+            "type": "string"
+          },
+          "triggerTag": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Triggertag"
+          }
+        },
+        "required": [
+          "attemptId",
+          "optionGroup",
+          "strategyType",
+          "labelKo",
+          "suggestedActionText",
+          "minRecoveryUnitMinutes",
+          "allowRestMode",
+          "triggerTag"
+        ],
+        "title": "RecoveryCard",
+        "type": "object"
+      },
+      "RecoveryDecisionRequest": {
+        "description": "POST /recovery/decisions 요청 (Idempotency-Key 필수, §1.7).\n\n- `decision=\"accepted\"` → `accepted_attempt_id` 필수, 나머지 pending 카드는 rejected.\n- `decision=\"skipped\"` → 모든 pending 카드 skipped (\"오늘은 쉬기\").",
+        "properties": {
+          "acceptedAttemptId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Acceptedattemptid"
+          },
+          "decision": {
+            "enum": [
+              "accepted",
+              "skipped"
+            ],
+            "title": "Decision",
+            "type": "string"
+          },
+          "decisionReason": {
+            "anyOf": [
+              {
+                "maxLength": 200,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Decisionreason"
+          },
+          "executionId": {
+            "title": "Executionid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "executionId",
+          "decision"
+        ],
+        "title": "RecoveryDecisionRequest",
+        "type": "object"
+      },
+      "RecoveryDecisionResponse": {
+        "description": "결정 결과 — 명시 승인 endpoint 이므로 `is_draft=False` (ADR-0005 §7.2).",
+        "properties": {
+          "acceptedAttemptId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Acceptedattemptid"
+          },
+          "executionId": {
+            "title": "Executionid",
+            "type": "string"
+          },
+          "isDraft": {
+            "default": false,
+            "title": "Isdraft",
+            "type": "boolean"
+          },
+          "rejectedAttemptIds": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Rejectedattemptids",
+            "type": "array"
+          },
+          "resultingActionItemId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Resultingactionitemid"
+          },
+          "skippedAttemptIds": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Skippedattemptids",
+            "type": "array"
+          }
+        },
+        "required": [
+          "executionId",
+          "acceptedAttemptId",
+          "rejectedAttemptIds",
+          "skippedAttemptIds",
+          "resultingActionItemId"
+        ],
+        "title": "RecoveryDecisionResponse",
+        "type": "object"
+      },
+      "RecoveryGenerateRequest": {
+        "description": "POST /recovery/proposals/generate 요청.",
+        "properties": {
+          "executionId": {
+            "title": "Executionid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "executionId"
+        ],
+        "title": "RecoveryGenerateRequest",
+        "type": "object"
+      },
+      "RecoveryProposalsResponse": {
+        "description": "후보 2~4장 — Draft Layer (`is_draft=True` 강제, 라우터 책임).",
+        "properties": {
+          "aiSource": {
+            "default": "llm",
+            "enum": [
+              "llm",
+              "rule"
+            ],
+            "title": "Aisource",
+            "type": "string"
+          },
+          "cards": {
+            "items": {
+              "$ref": "#/components/schemas/RecoveryCard"
+            },
+            "title": "Cards",
+            "type": "array"
+          },
+          "executionId": {
+            "title": "Executionid",
+            "type": "string"
+          },
+          "isDraft": {
+            "default": true,
+            "title": "Isdraft",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "executionId",
+          "cards"
+        ],
+        "title": "RecoveryProposalsResponse",
+        "type": "object"
+      },
       "RefreshRequest": {
         "description": "POST /auth/refresh 요청.",
         "properties": {
@@ -1820,6 +2532,57 @@
           "refreshToken"
         ],
         "title": "RefreshRequest",
+        "type": "object"
+      },
+      "ScheduledBlockPreview": {
+        "description": "미리보기용 스케줄 블록 — DB scheduled_blocks 대응(미영속). 시각은 KST 응답.",
+        "properties": {
+          "category": {
+            "title": "Category",
+            "type": "string"
+          },
+          "end": {
+            "format": "date-time",
+            "title": "End",
+            "type": "string"
+          },
+          "origin": {
+            "enum": [
+              "habit",
+              "goal"
+            ],
+            "title": "Origin",
+            "type": "string"
+          },
+          "originId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Originid"
+          },
+          "start": {
+            "format": "date-time",
+            "title": "Start",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "start",
+          "end",
+          "title",
+          "category",
+          "origin"
+        ],
+        "title": "ScheduledBlockPreview",
         "type": "object"
       },
       "SettingsResponse": {
@@ -4606,7 +5369,7 @@
     },
     "/plans/generate": {
       "post": {
-        "description": "주간/horizon 계획 생성 — Goal Structuring orchestrator 실행.",
+        "description": "첫 주간/horizon 계획 생성 — First Plan orchestrator(LangGraph) 실행 → Draft 저장.\n\n흐름: VALIDATING(tier 게이트) → decompose(LLM) → schedule(룰) → review(LLM) → Draft 저장.\nFocus≤3 / Maintain≤5 초과 시 LLM 분해 전에 422 `GOAL_TIER_LIMIT_EXCEEDED`.\nDraft 를 `plan_drafts`(72h 만료)에 저장하고 실제 `planId` 를 반환. 항상 `is_draft=true`.\n\n동시성 lock(ADR-0005 §7.6): 다중 디바이스 동시 생성으로 인한 state race 방지.",
         "operationId": "generate_plan_plans_generate_post",
         "parameters": [
           {
@@ -4626,7 +5389,27 @@
             }
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FirstPlanGenerateRequest"
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FirstPlanResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
           "422": {
             "content": {
               "application/json": {
@@ -4636,17 +5419,127 @@
               }
             },
             "description": "Validation Error"
-          },
-          "501": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": "Successful Response"
           }
         },
         "summary": "Generate Plan",
+        "tags": [
+          "planning"
+        ]
+      }
+    },
+    "/plans/{plan_id}": {
+      "get": {
+        "description": "저장된 First Plan Draft 미리보기 — LLM 재호출 없이 스냅샷 재구성.",
+        "operationId": "get_plan_plans__plan_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "plan_id",
+            "required": true,
+            "schema": {
+              "title": "Plan Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FirstPlanResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Plan",
+        "tags": [
+          "planning"
+        ]
+      }
+    },
+    "/plans/{plan_id}/approve": {
+      "post": {
+        "description": "First Plan Draft 승인 → SAVING (goal 트리 단일 가드 트랜잭션 영속화, ADR-0005 §2.5.1).\n\n`plan_id` 로 저장된 Draft 를 로드해 goals/goal_nodes/action_items/scheduled_blocks 를\n단일 트랜잭션으로 영속화(+최대 3회 재시도). `policy_guarded_transaction`(PR #30 재사용)이\n절대 시간 정책 위반 시 롤백 → 422 `PLAN_POLICY_VIOLATION`, 그 외 실패는 롤백 후 500\n`PLAN_SAVE_FAILED`. 만료된 Draft 는 410 `PLAN_DRAFT_EXPIRED`. 이미 승인된 Draft 는 멱등.\n\n부수 효과: onboarding `ONBOARDING_FIRST_PLAN → ONBOARDING_NOTIFICATIONS` 전이(멱등) —\nIssue #17 이 \"#9(First Plan) 다음에\" 로 First Plan 에 위임 (api-contract §3).\n응답은 명시 승인이므로 `is_draft=false` (ADR-0005 §7.2).",
+        "operationId": "approve_plan_plans__plan_id__approve_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "plan_id",
+            "required": true,
+            "schema": {
+              "title": "Plan Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FirstPlanApproveResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Approve Plan",
         "tags": [
           "planning"
         ]
@@ -4794,9 +5687,69 @@
         ]
       }
     },
+    "/recovery/decisions": {
+      "post": {
+        "description": "사용자 선택 저장 (Idempotency-Key 필수 — §1.7 미들웨어 enforce).\n\n- `accepted` → 선택 카드 accepted, 나머지 pending 은 rejected.\n  그룹이 DOWNSCOPE/CARRY_OVER 면 새 ActionItem(source=recovery_*) 생성 — 원본\n  카드 status 는 변경하지 않는다 (혈통: parent_action_item_id).\n- `skipped` → 모든 pending 카드 skipped (\"오늘은 쉬기\").",
+        "operationId": "decide_recovery_recovery_decisions_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RecoveryDecisionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RecoveryDecisionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Decide Recovery",
+        "tags": [
+          "recovery"
+        ]
+      }
+    },
     "/recovery/proposals/generate": {
       "post": {
-        "description": "실패 컨텍스트 기반 회복 옵션 2~4개 생성 (LLM + heuristic fallback).",
+        "description": "실패 컨텍스트 기반 회복 옵션 2~4개 생성 (LLM ≤ 8s + heuristic fallback).\n\n이미 pending 카드가 있으면 재생성하지 않고 그대로 반환한다 (중복 INSERT 방지).",
         "operationId": "generate_recovery_proposals_recovery_proposals_generate_post",
         "parameters": [
           {
@@ -4816,7 +5769,27 @@
             }
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RecoveryGenerateRequest"
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RecoveryProposalsResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
           "422": {
             "content": {
               "application/json": {
@@ -4826,14 +5799,6 @@
               }
             },
             "description": "Validation Error"
-          },
-          "501": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": "Successful Response"
           }
         },
         "summary": "Generate Recovery Proposals",
@@ -4887,6 +5852,243 @@
         "summary": "Batch Reflect",
         "tags": [
           "reflection"
+        ]
+      }
+    },
+    "/reflection/failure-tags": {
+      "get": {
+        "description": "S18 칩 마스터 — 13종 (is_active=true, sort_order 순).",
+        "operationId": "list_failure_tags_reflection_failure_tags_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/FailureTagMaster"
+                  },
+                  "title": "Response List Failure Tags Reflection Failure Tags Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Failure Tags",
+        "tags": [
+          "reflection"
+        ]
+      }
+    },
+    "/reflection/failure-tags/{execution_id}": {
+      "post": {
+        "description": "실패 사유 태깅 (0~2개) + memo at-rest 암호화 (#19-B).\n\n이 태그가 Recovery 룰 엔진(§12)의 `primary_trigger_tags` 매칭 입력이 된다.",
+        "operationId": "tag_failure_reasons_reflection_failure_tags__execution_id__post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "execution_id",
+            "required": true,
+            "schema": {
+              "title": "Execution Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FailureTagRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FailureTagResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Tag Failure Reasons",
+        "tags": [
+          "reflection"
+        ]
+      }
+    },
+    "/replan/{execution_id}": {
+      "get": {
+        "description": "S20 before/after diff — #20-B 후속.",
+        "operationId": "get_replan_diff_replan__execution_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "execution_id",
+            "required": true,
+            "schema": {
+              "title": "Execution Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "501": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Replan Diff",
+        "tags": [
+          "recovery"
+        ]
+      }
+    },
+    "/replan/{execution_id}/approve": {
+      "post": {
+        "description": "S20 최종 적용 (Idempotency) — #20-B 후속.",
+        "operationId": "approve_replan_replan__execution_id__approve_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "execution_id",
+            "required": true,
+            "schema": {
+              "title": "Execution Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "501": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Approve Replan",
+        "tags": [
+          "recovery"
         ]
       }
     },
@@ -5440,6 +6642,65 @@
         ]
       }
     },
+    "/today/actions/{action_id}/start": {
+      "post": {
+        "description": "[▶ 시작] → execution_events 생성 (#19-B).\n\n카드의 미종결 scheduled_block 이 있으면 사용, 없으면 즉석 블록 생성\n(source='user_edit'). 같은 카드의 in_progress 실행이 있으면 409.",
+        "operationId": "start_action_today_actions__action_id__start_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "action_id",
+            "required": true,
+            "schema": {
+              "title": "Action Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExecutionStartResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Start Action",
+        "tags": [
+          "today"
+        ]
+      }
+    },
     "/today/agenda": {
       "get": {
         "description": "오늘 어젠다 단일 조회 — daily_brief + cards + habits + fixed (모두 read).",
@@ -5485,6 +6746,66 @@
           }
         },
         "summary": "Today Agenda",
+        "tags": [
+          "today"
+        ]
+      }
+    },
+    "/today/check-ins": {
+      "post": {
+        "description": "Quick Check-in 4칩 (S13/S17) — 완료/조금함/못함/더함 (#19-B).\n\nexecution 종결 + 블록 finished + `action_item.status` 전이.\n`needs_failure_tags=True`(failed/partial_done) 면 FE 는 S18 실패 사유로 이동\n→ `POST /reflection/failure-tags/{executionId}` → Recovery(§12) 로 이어진다.",
+        "operationId": "quick_check_in_today_check_ins_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CheckInRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CheckInResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Quick Check In",
         "tags": [
           "today"
         ]

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -6,14 +6,20 @@ import type {
   AnonymizeRequest,
   ApiErrorPayload,
   ApiGoal,
-  ApiRecoveryProposal,
   AuthSession,
   CalendarConnection,
   CheckInRequest,
+  CheckInResponse,
   ConsentRecord,
   ConsentUpdateRequest,
   ExecutionEvent,
-  FailureTag,
+  ExecutionStartResponse,
+  FailureTagMaster,
+  FailureTagRequest,
+  FailureTagResponse,
+  FirstPlanApproveResponse,
+  FirstPlanGenerateRequest,
+  FirstPlanResponse,
   FixedSchedule,
   FixedScheduleCreateRequest,
   FreeBusy,
@@ -31,11 +37,13 @@ import type {
   NotificationSettings,
   NotificationSettingsUpdateRequest,
   OnboardingStatus,
-  Plan,
   PlanBlockUpdate,
   PlanScheduledBlock,
   PushSubscribeRequest,
   RecoveryDecisionRequest,
+  RecoveryDecisionResponse,
+  RecoveryGenerateRequest,
+  RecoveryProposalsResponse,
   ReflectionBatchRequest,
   ReflectionPendingItem,
   ReplanDiff,
@@ -285,7 +293,8 @@ export const habitsApi = {
     }),
 };
 
-// ── Today / Execution (S10-S13) — 현재 백엔드 501. fetch 래퍼만 미리 ──
+// ── Today / Execution (S10-S13) ───────────────────────────────
+// start·check-ins 는 백엔드 #13 구현됨. agenda/action 상세·pause/resume 은 미구현.
 export const todayApi = {
   agenda: () => request<TodayAgenda>('/today/agenda'),
 
@@ -293,7 +302,7 @@ export const todayApi = {
     request<ActionItem>(`/today/actions/${actionItemId}`),
 
   start: (actionItemId: string) =>
-    request<ExecutionEvent>(`/today/actions/${actionItemId}/start`, {
+    request<ExecutionStartResponse>(`/today/actions/${actionItemId}/start`, {
       method: 'POST',
       body: {},
     }),
@@ -311,22 +320,24 @@ export const todayApi = {
     }),
 
   checkIn: (body: CheckInRequest, idempotencyKey?: string) =>
-    request<ExecutionEvent>('/today/check-ins', {
+    request<CheckInResponse>('/today/check-ins', {
       method: 'POST',
       body,
       idempotencyKey,
     }),
 };
 
-// ── Plans (S06·S14·S15·S16) — 백엔드 501 ──────────────────────
+// ── Plans (S06·S14·S15·S16) — generate/get/approve 는 백엔드 #18 구현됨 ──
 export const plansApi = {
-  generate: () => request<Plan>('/plans/generate', { method: 'POST', body: {} }),
+  generate: (body: FirstPlanGenerateRequest = {}) =>
+    request<FirstPlanResponse>('/plans/generate', { method: 'POST', body }),
 
-  get: (planId: string) => request<Plan>(`/plans/${planId}`),
+  get: (planId: string) => request<FirstPlanResponse>(`/plans/${planId}`),
 
   approve: (planId: string) =>
-    request<Plan>(`/plans/${planId}/approve`, { method: 'POST', body: {} }),
+    request<FirstPlanApproveResponse>(`/plans/${planId}/approve`, { method: 'POST', body: {} }),
 
+  // 주간 보기/블록 수정은 아직 백엔드 미구현(추정 contract).
   weekly: (weekStart: string) =>
     request<WeeklyPlanResponse>(`/plans/weekly?weekStart=${encodeURIComponent(weekStart)}`),
 
@@ -356,29 +367,38 @@ export const reviewsApi = {
     }),
 };
 
-// ── Reflection (S17·S18) — 백엔드 501. fetch 래퍼만 미리 ────────
+// ── Reflection (S17·S18) — failure-tags 는 백엔드 #17 구현됨 ────
 export const reflectionApi = {
+  // /reflection/pending·batch 는 아직 백엔드 미구현(추정 contract).
   pending: () => request<ReflectionPendingItem[]>('/reflection/pending'),
-
-  failureTags: () => request<FailureTag[]>('/reflection/failure-tags'),
 
   batch: (body: ReflectionBatchRequest, idempotencyKey: string) =>
     request<void>('/reflection/batch', { method: 'POST', body, idempotencyKey }),
 
-  tagExecution: (executionId: string, body: { tags: string[]; memoEncrypted?: string }) =>
-    request<void>(`/reflection/failure-tags/${executionId}`, { method: 'POST', body }),
+  // 실패 태그 마스터 카탈로그 (#17)
+  failureTags: () => request<FailureTagMaster[]>('/reflection/failure-tags'),
+
+  tagExecution: (executionId: string, body: FailureTagRequest) =>
+    request<FailureTagResponse>(`/reflection/failure-tags/${executionId}`, {
+      method: 'POST',
+      body,
+    }),
 };
 
-// ── Recovery / Replan (S19·S20) — 백엔드 501 ───────────────────
+// ── Recovery / Replan (S19·S20) — recovery 는 백엔드 #20 구현됨 ──
 export const recoveryApi = {
   generateProposals: (executionId: string) =>
-    request<ApiRecoveryProposal[]>('/recovery/proposals/generate', {
+    request<RecoveryProposalsResponse>('/recovery/proposals/generate', {
       method: 'POST',
-      body: { executionId },
+      body: { executionId } satisfies RecoveryGenerateRequest,
     }),
 
   decide: (body: RecoveryDecisionRequest, idempotencyKey: string) =>
-    request<void>('/recovery/decisions', { method: 'POST', body, idempotencyKey }),
+    request<RecoveryDecisionResponse>('/recovery/decisions', {
+      method: 'POST',
+      body,
+      idempotencyKey,
+    }),
 };
 
 export const replanApi = {

--- a/src/screens/FocusScreen.tsx
+++ b/src/screens/FocusScreen.tsx
@@ -51,9 +51,10 @@ export function FocusScreen({ task, elapsedMin, totalMin, onPause, onComplete, o
 
   const handleComplete = () => {
     if (executionIdRef.current) {
+      // 소요 시간(actualDurationMinutes)은 백엔드가 start 시각 기준으로 계산한다.
       todayApi
         .checkIn(
-          { executionId: executionIdRef.current, completionStatus: 'done', actualDuration: elapsedMin },
+          { executionId: executionIdRef.current, completionStatus: 'done' },
           `check-${executionIdRef.current}`,
         )
         .catch(() => {});

--- a/src/screens/RecoveryScreen.tsx
+++ b/src/screens/RecoveryScreen.tsx
@@ -40,7 +40,7 @@ export function MergedRecoveryScreen({ task, failReason, onAccept, onDismiss }: 
     recoveryApi.generateProposals(task.id).then(
       (proposals) => {
         if (cancelled) return;
-        // TODO(backend-#20): proposals → RecoveryProposal[] 매핑
+        // TODO(backend-#20): proposals.cards (RecoveryCard[]) → RecoveryProposal[] 매핑
         void proposals;
       },
       () => { /* 501 ok */ },
@@ -51,10 +51,14 @@ export function MergedRecoveryScreen({ task, failReason, onAccept, onDismiss }: 
   const accept = () => {
     if (!sel) return;
     // mock-and-replace: 사용자 선택 저장 시도. Idempotency-Key 동봉.
+    // sel 은 데모 제안 id — 실제 백엔드 attemptId 매핑(backend-#20) 전까지 그대로 전달.
     if (task) {
       recoveryApi
-        .decide({ executionId: task.id, proposalId: sel }, `rec-${task.id}-${sel}`)
-        .catch(() => { /* 501 ok */ });
+        .decide(
+          { executionId: task.id, decision: 'accept', acceptedAttemptId: sel },
+          `rec-${task.id}-${sel}`,
+        )
+        .catch(() => { /* 미구현/오류 ok — 데모 흐름 유지 */ });
     }
     setAccepted(true);
     setTimeout(() => onAccept(sel), 1400);

--- a/src/screens/WeeklyPlanGenerationScreen.tsx
+++ b/src/screens/WeeklyPlanGenerationScreen.tsx
@@ -103,7 +103,7 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
     const fetchPlan = plansApi.generate().then(
       (plan) => {
         planIdRef.current = plan.planId;
-        // TODO(backend-#18): plan.weeks[0].scheduledBlocks → blocks 매핑
+        // TODO(backend-#18): plan.blocks (ScheduledBlockPreview[]) → blocks 매핑
       },
       () => { /* 501 — 더미 그대로 */ },
     );

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -242,8 +242,8 @@ export interface HabitCreateRequest {
 }
 
 // ── Today / Execution (S10-S13) ───────────────────────────────
-// 백엔드 /today/* 는 현재 501 이라 응답 모양이 contract 에 자세히 못박혀 있지 않다.
-// api-contract §10 + DB 설계서를 근거로 합리적 추정. 백엔드가 채워질 때 조정.
+// start·check-ins 는 백엔드 #13 으로 구현됨. agenda/action 상세·pause/resume 은
+// 아직 contract 추정(미구현) 이며 백엔드가 채워질 때 조정.
 
 export type ActionItemStatus =
   | 'pending'
@@ -280,6 +280,7 @@ export interface TodayAgenda {
 
 export type CompletionStatus = 'done' | 'partial_done' | 'failed' | 'over_done';
 
+// /today/focus/{executionId}/pause·resume 는 아직 contract 추정(미구현).
 export interface ExecutionEvent {
   executionId: string;
   actionItemId: string;
@@ -288,14 +289,31 @@ export interface ExecutionEvent {
   status: CompletionStatus | 'started' | string;
 }
 
+// POST /today/actions/{actionId}/start (#13)
+export interface ExecutionStartResponse {
+  executionId: string;
+  actionId: string;
+  actualStartAt: string; // KST ISO
+  completionStatus: CompletionStatus | string;
+}
+
+// POST /today/check-ins (#13) — actualDuration 은 백엔드가 계산(actualDurationMinutes).
 export interface CheckInRequest {
   executionId: string;
   completionStatus: CompletionStatus;
-  actualDuration?: number; // minutes
-  userFeedback?: string;
+  userRating?: number | null; // 1~5
+  userFeedback?: string | null;
 }
 
-// ── Reflection (S17·S18) — 백엔드 501. api-contract §11 추정 ───
+export interface CheckInResponse {
+  executionId: string;
+  actionId: string;
+  completionStatus: CompletionStatus | string;
+  actualDurationMinutes: number | null;
+  needsFailureTags: boolean; // partial_done/failed 면 실패 태그 입력 유도
+}
+
+// ── Reflection (S17·S18) — failure-tags 는 백엔드 #17 구현됨 ───
 // 13종 실패 태그 (api-contract §11)
 export type FailureTagCode =
   | 'TIME_SHORTAGE'
@@ -312,10 +330,24 @@ export type FailureTagCode =
   | 'EMERGENCY'
   | 'CONTEXT_LOSS';
 
-export interface FailureTag {
-  code: FailureTagCode | string;
-  label: string;
-  isActive: boolean;
+// GET /reflection/failure-tags (#17) — 마스터 카탈로그
+export interface FailureTagMaster {
+  tagCode: FailureTagCode | string;
+  labelKo: string;
+  description: string | null;
+  sortOrder: number;
+}
+
+// POST /reflection/failure-tags/{executionId} (#17)
+export interface FailureTagRequest {
+  tagCodes: (FailureTagCode | string)[];
+  memo?: string | null; // 클라이언트 암호화 메모(선택)
+}
+
+export interface FailureTagResponse {
+  executionId: string;
+  tagCodes: string[];
+  hasMemo: boolean;
 }
 
 export interface ReflectionPendingItem {
@@ -336,34 +368,45 @@ export interface ReflectionBatchRequest {
   }>;
 }
 
-// ── Recovery / Replan (S19·S20) — 백엔드 501. api-contract §12 추정 ──
-export type RecoveryGroup = 'DOWNSCOPE' | 'RESCHEDULE' | 'CARRY_OVER' | 'PARK';
-
-export type RecoveryStrategyCode =
-  | 'NANO_STEP'
-  | 'DOWNSCOPE_DEFAULT'
-  | 'ENVIRONMENT_SHIFT'
-  | 'CONTEXT_REWARMING'
-  | 'RESCHEDULE_DEFAULT'
-  | 'ACTIVE_RECOVERY'
-  | 'CARRYOVER_DEFAULT'
-  | 'FREEZE_SLOT'
-  | 'PARK_DEFAULT';
-
-export interface ApiRecoveryProposal {
-  proposalId: string;
-  group: RecoveryGroup;
-  strategyCode: RecoveryStrategyCode | string;
-  title: string;
-  description: string;
-  why: string;
-  estimatedMinutes: number | null;
-  confidence: number; // 0~100
+// ── Recovery / Replan (S19·S20) ───────────────────────────────
+// POST /recovery/proposals/generate (#20)
+export interface RecoveryGenerateRequest {
+  executionId: string;
 }
 
+export interface RecoveryCard {
+  attemptId: string;
+  optionGroup: string; // DOWNSCOPE / RESCHEDULE / CARRY_OVER / PARK 등
+  strategyType: string;
+  labelKo: string;
+  suggestedActionText: string;
+  minRecoveryUnitMinutes: number;
+  allowRestMode: boolean;
+  triggerTag: string | null;
+}
+
+export interface RecoveryProposalsResponse {
+  executionId: string;
+  cards: RecoveryCard[];
+  aiSource?: string;
+  isDraft?: boolean;
+}
+
+// POST /recovery/decisions (#20)
 export interface RecoveryDecisionRequest {
   executionId: string;
-  proposalId: string;
+  decision: string; // accept / reject / skip 등
+  acceptedAttemptId?: string | null;
+  decisionReason?: string | null;
+}
+
+export interface RecoveryDecisionResponse {
+  executionId: string;
+  acceptedAttemptId: string | null;
+  rejectedAttemptIds: string[];
+  skippedAttemptIds: string[];
+  resultingActionItemId: string | null;
+  isDraft?: boolean;
 }
 
 export interface ReplanDiffBlock {
@@ -381,7 +424,7 @@ export interface ReplanDiff {
   summary: string;
 }
 
-// ── Plans (S06·S14·S15·S16) — 백엔드 501. api-contract §8 추정 ──
+// ── Plans (S16) — 주간 보기/블록 수정은 아직 contract 추정(미구현) ──
 export type WorkloadLevel = 'easy' | 'medium' | 'heavy';
 
 export interface PlanScheduledBlock {
@@ -395,25 +438,69 @@ export interface PlanScheduledBlock {
   carryover?: boolean;
 }
 
-export interface PlanActionItem {
-  actionItemId: string;
+// ── First Plan (S06·S14·S15) — 백엔드 #18 구현됨 ───────────────
+// GET /plans/{planId} · POST /plans/generate 가 반환하는 첫 계획 초안.
+export interface GoalNodeDraft {
+  nodeId: string;
+  parentId: string | null;
+  nodeType: string;
   title: string;
-  goalId: string | null;
-  estimatedMinutes?: number;
+  isLeaf: boolean;
+  orderIndex: number;
 }
 
-export interface PlanWeek {
-  weekStart: string; // YYYY-MM-DD (월요일)
-  workloadLevel: WorkloadLevel;
-  warnings: string[];
-  actionItems: PlanActionItem[];
-  scheduledBlocks: PlanScheduledBlock[];
+export interface ActionItemDraft {
+  nodeId: string;
+  title: string;
+  category: string;
+  estimatedMinutes: number;
+  firstStep: string;
 }
 
-export interface Plan {
+export interface ScheduledBlockPreview {
+  origin: string; // goal / habit / fixed 등
+  originId: string | null;
+  title: string;
+  category: string;
+  start: string; // KST ISO
+  end: string; // KST ISO
+}
+
+export interface PolicyViolation {
+  nodeId: string;
+  reason: string;
+}
+
+export interface FirstPlanResponse {
   planId: string;
-  horizonEnd: string; // YYYY-MM-DD
-  weeks: PlanWeek[];
+  targetDate: string; // YYYY-MM-DD
+  horizon: string | null;
+  generatedAt: string; // KST ISO
+  goalNodes: GoalNodeDraft[];
+  actionItems: ActionItemDraft[];
+  blocks: ScheduledBlockPreview[];
+  policyViolations?: PolicyViolation[];
+  warnings?: string[];
+  aiSource?: string;
+  isDraft?: boolean;
+}
+
+// POST /plans/generate 요청 본문 (모두 선택 — 서버가 인터뷰 결과로 보완).
+export interface FirstPlanGenerateRequest {
+  interviewSessionId?: string | null;
+  targetDate?: string | null; // YYYY-MM-DD
+  outcome?: Record<string, unknown> | null; // InterviewOutcome (보통 서버 파생)
+}
+
+// POST /plans/{planId}/approve
+export interface FirstPlanApproveResponse {
+  planId: string;
+  activatedAt: string; // KST ISO
+  activatedGoals: number;
+  activatedGoalNodes: number;
+  activatedActionItems: number;
+  activatedBlocks: number;
+  isDraft?: boolean;
 }
 
 export interface WeeklyPlanResponse {

--- a/src/types/openapi.d.ts
+++ b/src/types/openapi.d.ts
@@ -732,9 +732,64 @@ export interface paths {
         put?: never;
         /**
          * Generate Plan
-         * @description 주간/horizon 계획 생성 — Goal Structuring orchestrator 실행.
+         * @description 첫 주간/horizon 계획 생성 — First Plan orchestrator(LangGraph) 실행 → Draft 저장.
+         *
+         *     흐름: VALIDATING(tier 게이트) → decompose(LLM) → schedule(룰) → review(LLM) → Draft 저장.
+         *     Focus≤3 / Maintain≤5 초과 시 LLM 분해 전에 422 `GOAL_TIER_LIMIT_EXCEEDED`.
+         *     Draft 를 `plan_drafts`(72h 만료)에 저장하고 실제 `planId` 를 반환. 항상 `is_draft=true`.
+         *
+         *     동시성 lock(ADR-0005 §7.6): 다중 디바이스 동시 생성으로 인한 state race 방지.
          */
         post: operations["generate_plan_plans_generate_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/plans/{plan_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Plan
+         * @description 저장된 First Plan Draft 미리보기 — LLM 재호출 없이 스냅샷 재구성.
+         */
+        get: operations["get_plan_plans__plan_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/plans/{plan_id}/approve": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Approve Plan
+         * @description First Plan Draft 승인 → SAVING (goal 트리 단일 가드 트랜잭션 영속화, ADR-0005 §2.5.1).
+         *
+         *     `plan_id` 로 저장된 Draft 를 로드해 goals/goal_nodes/action_items/scheduled_blocks 를
+         *     단일 트랜잭션으로 영속화(+최대 3회 재시도). `policy_guarded_transaction`(PR #30 재사용)이
+         *     절대 시간 정책 위반 시 롤백 → 422 `PLAN_POLICY_VIOLATION`, 그 외 실패는 롤백 후 500
+         *     `PLAN_SAVE_FAILED`. 만료된 Draft 는 410 `PLAN_DRAFT_EXPIRED`. 이미 승인된 Draft 는 멱등.
+         *
+         *     부수 효과: onboarding `ONBOARDING_FIRST_PLAN → ONBOARDING_NOTIFICATIONS` 전이(멱등) —
+         *     Issue #17 이 "#9(First Plan) 다음에" 로 First Plan 에 위임 (api-contract §3).
+         *     응답은 명시 승인이므로 `is_draft=false` (ADR-0005 §7.2).
+         */
+        post: operations["approve_plan_plans__plan_id__approve_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -785,6 +840,31 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/recovery/decisions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Decide Recovery
+         * @description 사용자 선택 저장 (Idempotency-Key 필수 — §1.7 미들웨어 enforce).
+         *
+         *     - `accepted` → 선택 카드 accepted, 나머지 pending 은 rejected.
+         *       그룹이 DOWNSCOPE/CARRY_OVER 면 새 ActionItem(source=recovery_*) 생성 — 원본
+         *       카드 status 는 변경하지 않는다 (혈통: parent_action_item_id).
+         *     - `skipped` → 모든 pending 카드 skipped ("오늘은 쉬기").
+         */
+        post: operations["decide_recovery_recovery_decisions_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/recovery/proposals/generate": {
         parameters: {
             query?: never;
@@ -796,7 +876,9 @@ export interface paths {
         put?: never;
         /**
          * Generate Recovery Proposals
-         * @description 실패 컨텍스트 기반 회복 옵션 2~4개 생성 (LLM + heuristic fallback).
+         * @description 실패 컨텍스트 기반 회복 옵션 2~4개 생성 (LLM ≤ 8s + heuristic fallback).
+         *
+         *     이미 pending 카드가 있으면 재생성하지 않고 그대로 반환한다 (중복 INSERT 방지).
          */
         post: operations["generate_recovery_proposals_recovery_proposals_generate_post"];
         delete?: never;
@@ -819,6 +901,88 @@ export interface paths {
          * @description 오늘+어제+그제 미체크 카드 일괄 처리. Idempotency-Key 헤더 필수.
          */
         post: operations["batch_reflect_reflection_batch_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/reflection/failure-tags": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Failure Tags
+         * @description S18 칩 마스터 — 13종 (is_active=true, sort_order 순).
+         */
+        get: operations["list_failure_tags_reflection_failure_tags_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/reflection/failure-tags/{execution_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Tag Failure Reasons
+         * @description 실패 사유 태깅 (0~2개) + memo at-rest 암호화 (#19-B).
+         *
+         *     이 태그가 Recovery 룰 엔진(§12)의 `primary_trigger_tags` 매칭 입력이 된다.
+         */
+        post: operations["tag_failure_reasons_reflection_failure_tags__execution_id__post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/replan/{execution_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Replan Diff
+         * @description S20 before/after diff — #20-B 후속.
+         */
+        get: operations["get_replan_diff_replan__execution_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/replan/{execution_id}/approve": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Approve Replan
+         * @description S20 최종 적용 (Idempotency) — #20-B 후속.
+         */
+        post: operations["approve_replan_replan__execution_id__approve_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -1002,6 +1166,29 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/today/actions/{action_id}/start": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Start Action
+         * @description [▶ 시작] → execution_events 생성 (#19-B).
+         *
+         *     카드의 미종결 scheduled_block 이 있으면 사용, 없으면 즉석 블록 생성
+         *     (source='user_edit'). 같은 카드의 in_progress 실행이 있으면 409.
+         */
+        post: operations["start_action_today_actions__action_id__start_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/today/agenda": {
         parameters: {
             query?: never;
@@ -1016,6 +1203,30 @@ export interface paths {
         get: operations["today_agenda_today_agenda_get"];
         put?: never;
         post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/today/check-ins": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Quick Check In
+         * @description Quick Check-in 4칩 (S13/S17) — 완료/조금함/못함/더함 (#19-B).
+         *
+         *     execution 종결 + 블록 finished + `action_item.status` 전이.
+         *     `needs_failure_tags=True`(failed/partial_done) 면 FE 는 S18 실패 사유로 이동
+         *     → `POST /reflection/failure-tags/{executionId}` → Recovery(§12) 로 이어진다.
+         */
+        post: operations["quick_check_in_today_check_ins_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -1061,6 +1272,22 @@ export interface components {
             title: string;
             /** Whynow */
             whyNow: string | null;
+        };
+        /**
+         * ActionItemDraft
+         * @description leaf 노드에 매달리는 실행 항목 — SMART + tiny_first_step.
+         */
+        ActionItemDraft: {
+            /** Category */
+            category: string;
+            /** Estimatedminutes */
+            estimatedMinutes: number;
+            /** Firststep */
+            firstStep: string;
+            /** Nodeid */
+            nodeId: string;
+            /** Title */
+            title: string;
         };
         /**
          * AgendaCard
@@ -1208,6 +1435,39 @@ export interface components {
             title: string;
         };
         /**
+         * CheckInRequest
+         * @description POST /today/check-ins 요청 — Quick Check-in 4칩 (S13/S17).
+         */
+        CheckInRequest: {
+            /**
+             * Completionstatus
+             * @enum {string}
+             */
+            completionStatus: "done" | "partial_done" | "failed" | "over_done";
+            /** Executionid */
+            executionId: string;
+            /** Userfeedback */
+            userFeedback?: string | null;
+            /** Userrating */
+            userRating?: number | null;
+        };
+        /**
+         * CheckInResponse
+         * @description 체크인 결과. `needs_failure_tags=True` 면 FE 는 S18(실패 사유)로 이동.
+         */
+        CheckInResponse: {
+            /** Actionid */
+            actionId: string;
+            /** Actualdurationminutes */
+            actualDurationMinutes: number | null;
+            /** Completionstatus */
+            completionStatus: string;
+            /** Executionid */
+            executionId: string;
+            /** Needsfailuretags */
+            needsFailureTags: boolean;
+        };
+        /**
          * DbStatus
          * @description DB 헬스 정보 (health 응답에 포함).
          */
@@ -1218,6 +1478,145 @@ export interface components {
             latency_ms?: number | null;
             /** Ok */
             ok: boolean;
+        };
+        /**
+         * ExecutionStartResponse
+         * @description POST /today/actions/{id}/start 응답 — [▶ 시작] (#19-B).
+         *
+         *     scheduled_block 이 없으면 즉석(ad-hoc) 블록을 생성해 연결한다 (source='user_edit').
+         */
+        ExecutionStartResponse: {
+            /** Actionid */
+            actionId: string;
+            /**
+             * Actualstartat
+             * Format: date-time
+             */
+            actualStartAt: string;
+            /** Completionstatus */
+            completionStatus: string;
+            /** Executionid */
+            executionId: string;
+        };
+        /**
+         * FailureTagMaster
+         * @description GET /reflection/failure-tags 응답 row — S18 칩의 원본 (13종, is_active=true).
+         */
+        FailureTagMaster: {
+            /** Description */
+            description: string | null;
+            /** Labelko */
+            labelKo: string;
+            /** Sortorder */
+            sortOrder: number;
+            /** Tagcode */
+            tagCode: string;
+        };
+        /**
+         * FailureTagRequest
+         * @description POST /reflection/failure-tags/{executionId} — 실패 사유 0~2개 + 메모.
+         */
+        FailureTagRequest: {
+            /** Memo */
+            memo?: string | null;
+            /** Tagcodes */
+            tagCodes: string[];
+        };
+        /**
+         * FailureTagResponse
+         * @description 태깅 결과.
+         */
+        FailureTagResponse: {
+            /** Executionid */
+            executionId: string;
+            /** Hasmemo */
+            hasMemo: boolean;
+            /** Tagcodes */
+            tagCodes: string[];
+        };
+        /**
+         * FirstPlanApproveResponse
+         * @description 승인 결과 — 활성화 완료. 명시 승인 endpoint 이므로 `is_draft=False` (ADR-0005 §7.2).
+         *
+         *     #62: `plan_id` 로 저장된 Draft 를 로드해 goal 트리까지 영속화한 결과 카운트.
+         */
+        FirstPlanApproveResponse: {
+            /** Activatedactionitems */
+            activatedActionItems: number;
+            /**
+             * Activatedat
+             * Format: date-time
+             */
+            activatedAt: string;
+            /** Activatedblocks */
+            activatedBlocks: number;
+            /** Activatedgoalnodes */
+            activatedGoalNodes: number;
+            /** Activatedgoals */
+            activatedGoals: number;
+            /**
+             * Isdraft
+             * @default false
+             * @constant
+             */
+            isDraft: false;
+            /** Planid */
+            planId: string;
+        };
+        /**
+         * FirstPlanGenerateRequest
+         * @description POST /plans/generate (첫 계획) 요청.
+         *
+         *     `interview_session_id` 로 확정된 `InterviewOutcome` 을 참조하거나(서버가 로드),
+         *     온보딩 흐름에서 outcome 을 인라인 전달할 수 있다(`outcome`). 둘 중 하나는 필수 —
+         *     검증은 라우터/오케스트레이터 VALIDATING 단계에서 수행.
+         */
+        FirstPlanGenerateRequest: {
+            /** Interviewsessionid */
+            interviewSessionId?: string | null;
+            outcome?: components["schemas"]["InterviewOutcome"] | null;
+            /** Targetdate */
+            targetDate?: string | null;
+        };
+        /**
+         * FirstPlanResponse
+         * @description First Plan 미리보기 응답 — 항상 Draft (사용자 [수락] 전).
+         *
+         *     `is_draft=True` 고정, `ai_source` 는 오케스트레이터 `used_fallback` 에 따라 라우터가 set.
+         */
+        FirstPlanResponse: {
+            /** Actionitems */
+            actionItems: components["schemas"]["ActionItemDraft"][];
+            /**
+             * Aisource
+             * @default llm
+             * @enum {string}
+             */
+            aiSource: "llm" | "rule";
+            /** Blocks */
+            blocks: components["schemas"]["ScheduledBlockPreview"][];
+            /**
+             * Generatedat
+             * Format: date-time
+             */
+            generatedAt: string;
+            /** Goalnodes */
+            goalNodes: components["schemas"]["GoalNodeDraft"][];
+            /** Horizon */
+            horizon: string | null;
+            /**
+             * Isdraft
+             * @default true
+             */
+            isDraft: boolean;
+            /** Planid */
+            planId: string;
+            /** Policyviolations */
+            policyViolations?: components["schemas"]["PolicyViolation"][];
+            /** Targetdate */
+            targetDate: string;
+            /** Warnings */
+            warnings?: string[];
         };
         /**
          * FixedSchedule
@@ -1364,6 +1763,27 @@ export interface components {
             depth: number;
             /** Nodeid */
             nodeId: string;
+            /** Parentid */
+            parentId: string | null;
+            /** Title */
+            title: string;
+        };
+        /**
+         * GoalNodeDraft
+         * @description 분해된 goal_node 한 개 (root → branch → leaf 트리).
+         */
+        GoalNodeDraft: {
+            /** Isleaf */
+            isLeaf: boolean;
+            /** Nodeid */
+            nodeId: string;
+            /**
+             * Nodetype
+             * @enum {string}
+             */
+            nodeType: "root" | "branch" | "leaf";
+            /** Orderindex */
+            orderIndex: number;
             /** Parentid */
             parentId: string | null;
             /** Title */
@@ -1733,6 +2153,16 @@ export interface components {
             suggestedNextScreen: string;
         };
         /**
+         * PolicyViolation
+         * @description 정책 위반으로 제외된 노드 + 사유 (cap / 충돌 등).
+         */
+        PolicyViolation: {
+            /** Nodeid */
+            nodeId: string;
+            /** Reason */
+            reason: string;
+        };
+        /**
          * PreferenceProfile
          * @description 선호 방식 (recovery.* + energy.* 슬롯군).
          *
@@ -1779,12 +2209,134 @@ export interface components {
             text: string;
         };
         /**
+         * RecoveryCard
+         * @description 회복 옵션 카드 1장 — recovery_attempts 1행과 대응 (user_decision='pending').
+         */
+        RecoveryCard: {
+            /** Allowrestmode */
+            allowRestMode: boolean;
+            /** Attemptid */
+            attemptId: string;
+            /** Labelko */
+            labelKo: string;
+            /** Minrecoveryunitminutes */
+            minRecoveryUnitMinutes: number;
+            /**
+             * Optiongroup
+             * @enum {string}
+             */
+            optionGroup: "DOWNSCOPE" | "RESCHEDULE" | "CARRY_OVER" | "PARK";
+            /** Strategytype */
+            strategyType: string;
+            /** Suggestedactiontext */
+            suggestedActionText: string;
+            /** Triggertag */
+            triggerTag: string | null;
+        };
+        /**
+         * RecoveryDecisionRequest
+         * @description POST /recovery/decisions 요청 (Idempotency-Key 필수, §1.7).
+         *
+         *     - `decision="accepted"` → `accepted_attempt_id` 필수, 나머지 pending 카드는 rejected.
+         *     - `decision="skipped"` → 모든 pending 카드 skipped ("오늘은 쉬기").
+         */
+        RecoveryDecisionRequest: {
+            /** Acceptedattemptid */
+            acceptedAttemptId?: string | null;
+            /**
+             * Decision
+             * @enum {string}
+             */
+            decision: "accepted" | "skipped";
+            /** Decisionreason */
+            decisionReason?: string | null;
+            /** Executionid */
+            executionId: string;
+        };
+        /**
+         * RecoveryDecisionResponse
+         * @description 결정 결과 — 명시 승인 endpoint 이므로 `is_draft=False` (ADR-0005 §7.2).
+         */
+        RecoveryDecisionResponse: {
+            /** Acceptedattemptid */
+            acceptedAttemptId: string | null;
+            /** Executionid */
+            executionId: string;
+            /**
+             * Isdraft
+             * @default false
+             */
+            isDraft: boolean;
+            /** Rejectedattemptids */
+            rejectedAttemptIds: string[];
+            /** Resultingactionitemid */
+            resultingActionItemId: string | null;
+            /** Skippedattemptids */
+            skippedAttemptIds: string[];
+        };
+        /**
+         * RecoveryGenerateRequest
+         * @description POST /recovery/proposals/generate 요청.
+         */
+        RecoveryGenerateRequest: {
+            /** Executionid */
+            executionId: string;
+        };
+        /**
+         * RecoveryProposalsResponse
+         * @description 후보 2~4장 — Draft Layer (`is_draft=True` 강제, 라우터 책임).
+         */
+        RecoveryProposalsResponse: {
+            /**
+             * Aisource
+             * @default llm
+             * @enum {string}
+             */
+            aiSource: "llm" | "rule";
+            /** Cards */
+            cards: components["schemas"]["RecoveryCard"][];
+            /** Executionid */
+            executionId: string;
+            /**
+             * Isdraft
+             * @default true
+             */
+            isDraft: boolean;
+        };
+        /**
          * RefreshRequest
          * @description POST /auth/refresh 요청.
          */
         RefreshRequest: {
             /** Refreshtoken */
             refreshToken: string;
+        };
+        /**
+         * ScheduledBlockPreview
+         * @description 미리보기용 스케줄 블록 — DB scheduled_blocks 대응(미영속). 시각은 KST 응답.
+         */
+        ScheduledBlockPreview: {
+            /** Category */
+            category: string;
+            /**
+             * End
+             * Format: date-time
+             */
+            end: string;
+            /**
+             * Origin
+             * @enum {string}
+             */
+            origin: "habit" | "goal";
+            /** Originid */
+            originId?: string | null;
+            /**
+             * Start
+             * Format: date-time
+             */
+            start: string;
+            /** Title */
+            title: string;
         };
         /**
          * SettingsResponse
@@ -3386,8 +3938,21 @@ export interface operations {
             path?: never;
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["FirstPlanGenerateRequest"];
+            };
+        };
         responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FirstPlanResponse"];
+                };
+            };
             /** @description Validation Error */
             422: {
                 headers: {
@@ -3397,13 +3962,70 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
+        };
+    };
+    get_plan_plans__plan_id__get: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                plan_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
             /** @description Successful Response */
-            501: {
+            200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["FirstPlanResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    approve_plan_plans__plan_id__approve_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                plan_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FirstPlanApproveResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };
@@ -3501,7 +4123,77 @@ export interface operations {
             };
         };
     };
+    decide_recovery_recovery_decisions_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RecoveryDecisionRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RecoveryDecisionResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     generate_recovery_proposals_recovery_proposals_generate_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RecoveryGenerateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RecoveryProposalsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    batch_reflect_reflection_batch_post: {
         parameters: {
             query?: never;
             header?: {
@@ -3532,13 +4224,116 @@ export interface operations {
             };
         };
     };
-    batch_reflect_reflection_batch_post: {
+    list_failure_tags_reflection_failure_tags_get: {
         parameters: {
             query?: never;
             header?: {
                 authorization?: string | null;
             };
             path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FailureTagMaster"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    tag_failure_reasons_reflection_failure_tags__execution_id__post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                execution_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["FailureTagRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FailureTagResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_replan_diff_replan__execution_id__get: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                execution_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+            /** @description Successful Response */
+            501: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    approve_replan_replan__execution_id__approve_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                execution_id: string;
+            };
             cookie?: never;
         };
         requestBody?: never;
@@ -3889,6 +4684,39 @@ export interface operations {
             };
         };
     };
+    start_action_today_actions__action_id__start_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                action_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ExecutionStartResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     today_agenda_today_agenda_get: {
         parameters: {
             query?: never;
@@ -3907,6 +4735,41 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["TodayAgenda"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    quick_check_in_today_check_ins_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CheckInRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CheckInResponse"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
백엔드(`reaction-backend`)의 OpenAPI 를 다시 덤프해 프론트 타입·API 래퍼와 동기화했습니다. 이번 변경은 **추가(additive)** 만 있으며, 기존 엔드포인트/필드의 변경·삭제는 없습니다.

## 신규 구현된 엔드포인트 (이전 501 stub → 정식 구현)
백엔드에 아래 9개 경로가 새로 추가되었습니다. 프론트는 이미 mock-and-replace 래퍼를 갖고 있었으므로, **요청/응답 타입을 실제 백엔드 스키마에 맞게 교정**했습니다.

| 엔드포인트 | 메서드 | 요청 → 응답 |
|---|---|---|
| `/today/actions/{id}/start` | POST | → `ExecutionStartResponse` |
| `/today/check-ins` | POST | `CheckInRequest` → `CheckInResponse` |
| `/plans/{id}` | GET | → `FirstPlanResponse` |
| `/plans/{id}/approve` | POST | → `FirstPlanApproveResponse` |
| `/recovery/decisions` | POST | `RecoveryDecisionRequest` → `RecoveryDecisionResponse` |
| `/reflection/failure-tags` | GET | → `FailureTagMaster[]` |
| `/reflection/failure-tags/{executionId}` | POST | `FailureTagRequest` → `FailureTagResponse` |
| `/replan/{executionId}` | GET | (응답 스키마 미문서화 — 추정 유지) |
| `/replan/{executionId}/approve` | POST | (응답 스키마 미문서화 — 추정 유지) |

추가로 기존 경로 `/plans/generate`, `/recovery/proposals/generate` 의 요청·응답 스키마도 확정되어 함께 반영했습니다.

## 주요 필드 차이 (수기 추정 → 실제 contract)
- **CheckIn**: 요청에서 `actualDuration` 제거(백엔드가 start 시각 기준 `actualDurationMinutes` 계산), `userRating` 추가. 응답은 `CheckInResponse`(`needsFailureTags` 포함).
- **Recovery**: `decide` 요청이 `{ executionId, proposalId }` → `{ executionId, decision, acceptedAttemptId? }` 로 변경. `generateProposals` 응답이 `ApiRecoveryProposal[]` → `RecoveryProposalsResponse`(`cards: RecoveryCard[]`).
- **Reflection failure-tags**: 마스터 카탈로그가 `{ tagCode, labelKo, description, sortOrder }`(`FailureTagMaster`). 태그 등록 요청은 `{ tagCodes, memo? }`(`FailureTagRequest`).
- **Plans (first plan)**: `Plan/PlanWeek` 추정 구조 → `FirstPlanResponse`(`goalNodes`, `actionItems`, `blocks: ScheduledBlockPreview[]`, `policyViolations`). approve 응답은 활성화 건수 요약(`FirstPlanApproveResponse`).
- **Today start**: 응답이 `ExecutionStartResponse`(`actualStartAt` 등).

## 반영 내용
- `openapi.json` / `src/types/openapi.d.ts` 재생성.
- `src/types/api.ts`: 위 신규 스키마에 맞춘 camelCase 타입 추가, 더 이상 쓰이지 않는 추정 타입(`Plan`, `PlanWeek`, `ApiRecoveryProposal` 등) 정리.
- `src/lib/api.ts`: 래퍼 요청/응답 제네릭 타입 교정, 구현 완료 엔드포인트의 "501" 주석 갱신.
- 호출부 교정: `FocusScreen`(check-in 본문), `RecoveryScreen`(decide 본문) — 기존 mock-and-replace · DemoNotice 패턴 유지. 변경된 응답 매핑 TODO 주석 갱신.

## 검증
- `npx tsc --noEmit` ✅
- `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WFiNPuPy78UjbRH7HRFj6R)_