### PR TITLE
chore(api): 백엔드 API 동기화 (routine)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -267,6 +267,93 @@
         "title": "AgendaHabit",
         "type": "object"
       },
+      "AnonymizeRequest": {
+        "description": "POST /settings/anonymize 요청.\n\n`confirmationToken` 없으면 step1(토큰 발급), 있으면 step2(실행) — 2단계 확인.",
+        "properties": {
+          "confirmationToken": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Confirmationtoken"
+          }
+        },
+        "title": "AnonymizeRequest",
+        "type": "object"
+      },
+      "AnonymizeResponse": {
+        "description": "익명화 응답. `status` 로 단계 구분.\n\n- `confirmation_required` — 토큰 발급(미적용). `confirmationToken`/`expiresAt` 채움.\n- `anonymized` — 적용 완료. `anonymizedAt`/`maskedCount` 채움.",
+        "properties": {
+          "anonymizedAt": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Anonymizedat"
+          },
+          "confirmationToken": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Confirmationtoken"
+          },
+          "expiresAt": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expiresat"
+          },
+          "maskedCount": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Maskedcount"
+          },
+          "message": {
+            "title": "Message",
+            "type": "string"
+          },
+          "status": {
+            "enum": [
+              "confirmation_required",
+              "anonymized"
+            ],
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "message"
+        ],
+        "title": "AnonymizeResponse",
+        "type": "object"
+      },
       "ApproveInsertResult": {
         "description": "POST /calendar/events/approve-insert 응답.",
         "properties": {
@@ -337,6 +424,82 @@
           "peakWindow"
         ],
         "title": "AvailabilityProfile",
+        "type": "object"
+      },
+      "BlockEditRequest": {
+        "description": "PATCH /plans/{planId}/blocks/{blockId} — 15분 snap 이동.\n\n`endAt` 생략 시 기존 길이를 보존한 채 시작만 옮긴다. 시각은 KST ISO 8601.",
+        "properties": {
+          "endAt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Endat"
+          },
+          "startAt": {
+            "title": "Startat",
+            "type": "string"
+          }
+        },
+        "required": [
+          "startAt"
+        ],
+        "title": "BlockEditRequest",
+        "type": "object"
+      },
+      "BlockEditResponse": {
+        "description": "편집 결과 — 스냅 적용된 최종 블록.",
+        "properties": {
+          "actionId": {
+            "title": "Actionid",
+            "type": "string"
+          },
+          "blockId": {
+            "title": "Blockid",
+            "type": "string"
+          },
+          "blockStatus": {
+            "title": "Blockstatus",
+            "type": "string"
+          },
+          "category": {
+            "title": "Category",
+            "type": "string"
+          },
+          "endAt": {
+            "format": "date-time",
+            "title": "Endat",
+            "type": "string"
+          },
+          "source": {
+            "title": "Source",
+            "type": "string"
+          },
+          "startAt": {
+            "format": "date-time",
+            "title": "Startat",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "blockId",
+          "actionId",
+          "title",
+          "category",
+          "startAt",
+          "endAt",
+          "blockStatus",
+          "source"
+        ],
+        "title": "BlockEditResponse",
         "type": "object"
       },
       "BusyInterval": {
@@ -522,6 +685,77 @@
           "needsFailureTags"
         ],
         "title": "CheckInResponse",
+        "type": "object"
+      },
+      "ConsentCreateRequest": {
+        "description": "POST /privacy/consent — 동의/철회 (append-only 새 기록).",
+        "properties": {
+          "consentType": {
+            "enum": [
+              "required",
+              "marketing",
+              "research"
+            ],
+            "title": "Consenttype",
+            "type": "string"
+          },
+          "granted": {
+            "title": "Granted",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "consentType",
+          "granted"
+        ],
+        "title": "ConsentCreateRequest",
+        "type": "object"
+      },
+      "ConsentItem": {
+        "description": "consent_type 별 현재(최신) 동의 상태.",
+        "properties": {
+          "consentType": {
+            "enum": [
+              "required",
+              "marketing",
+              "research"
+            ],
+            "title": "Consenttype",
+            "type": "string"
+          },
+          "isGranted": {
+            "title": "Isgranted",
+            "type": "boolean"
+          },
+          "updatedAt": {
+            "format": "date-time",
+            "title": "Updatedat",
+            "type": "string"
+          }
+        },
+        "required": [
+          "consentType",
+          "isGranted",
+          "updatedAt"
+        ],
+        "title": "ConsentItem",
+        "type": "object"
+      },
+      "ConsentListResponse": {
+        "description": "GET /privacy/consent — 동의 현황 (필수/마케팅/연구 분리).",
+        "properties": {
+          "consents": {
+            "items": {
+              "$ref": "#/components/schemas/ConsentItem"
+            },
+            "title": "Consents",
+            "type": "array"
+          }
+        },
+        "required": [
+          "consents"
+        ],
+        "title": "ConsentListResponse",
         "type": "object"
       },
       "DbStatus": {
@@ -1559,6 +1793,90 @@
         "title": "HabitInstance",
         "type": "object"
       },
+      "HabitPenaltyAcceptResponse": {
+        "description": "POST /reviews/habit-penalty/{habitId}/accept — 빈도 다운 결과.",
+        "properties": {
+          "habitId": {
+            "title": "Habitid",
+            "type": "string"
+          },
+          "message": {
+            "title": "Message",
+            "type": "string"
+          },
+          "newFrequency": {
+            "title": "Newfrequency",
+            "type": "integer"
+          },
+          "previousFrequency": {
+            "title": "Previousfrequency",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "habitId",
+          "previousFrequency",
+          "newFrequency",
+          "message"
+        ],
+        "title": "HabitPenaltyAcceptResponse",
+        "type": "object"
+      },
+      "HabitPenaltyCandidate": {
+        "description": "3주 연속 미달로 빈도 재설계를 제안할 habit.",
+        "properties": {
+          "currentFrequency": {
+            "title": "Currentfrequency",
+            "type": "integer"
+          },
+          "habitId": {
+            "title": "Habitid",
+            "type": "string"
+          },
+          "message": {
+            "title": "Message",
+            "type": "string"
+          },
+          "recentWeeks": {
+            "items": {
+              "$ref": "#/components/schemas/HabitWeekStat"
+            },
+            "title": "Recentweeks",
+            "type": "array"
+          },
+          "suggestedFrequency": {
+            "title": "Suggestedfrequency",
+            "type": "integer"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "habitId",
+          "title",
+          "currentFrequency",
+          "suggestedFrequency",
+          "message"
+        ],
+        "title": "HabitPenaltyCandidate",
+        "type": "object"
+      },
+      "HabitPenaltyListResponse": {
+        "description": "GET /reviews/habit-penalty — 제안 후보 목록.",
+        "properties": {
+          "candidates": {
+            "items": {
+              "$ref": "#/components/schemas/HabitPenaltyCandidate"
+            },
+            "title": "Candidates",
+            "type": "array"
+          }
+        },
+        "title": "HabitPenaltyListResponse",
+        "type": "object"
+      },
       "HabitUpdateRequest": {
         "description": "PATCH /habits/{id} 요청 — 제목·빈도 (api-contract §7).",
         "properties": {
@@ -1588,6 +1906,25 @@
           }
         },
         "title": "HabitUpdateRequest",
+        "type": "object"
+      },
+      "HabitWeekStat": {
+        "description": "페널티 근거 — 한 주의 달성/목표.",
+        "properties": {
+          "doneCount": {
+            "title": "Donecount",
+            "type": "integer"
+          },
+          "targetCount": {
+            "title": "Targetcount",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "doneCount",
+          "targetCount"
+        ],
+        "title": "HabitWeekStat",
         "type": "object"
       },
       "HealthResponse": {
@@ -2980,6 +3317,289 @@
           "type"
         ],
         "title": "ValidationError",
+        "type": "object"
+      },
+      "WeeklyBlock": {
+        "description": "주간 그리드의 스케줄 블록 한 칸.",
+        "properties": {
+          "actionId": {
+            "title": "Actionid",
+            "type": "string"
+          },
+          "blockId": {
+            "title": "Blockid",
+            "type": "string"
+          },
+          "blockStatus": {
+            "title": "Blockstatus",
+            "type": "string"
+          },
+          "category": {
+            "title": "Category",
+            "type": "string"
+          },
+          "endAt": {
+            "format": "date-time",
+            "title": "Endat",
+            "type": "string"
+          },
+          "source": {
+            "title": "Source",
+            "type": "string"
+          },
+          "startAt": {
+            "format": "date-time",
+            "title": "Startat",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "blockId",
+          "actionId",
+          "title",
+          "category",
+          "startAt",
+          "endAt",
+          "blockStatus",
+          "source"
+        ],
+        "title": "WeeklyBlock",
+        "type": "object"
+      },
+      "WeeklyGenerateRequest": {
+        "description": "POST /reviews/weekly/generate — 수동 재생성 (디버그).\n\n`weekStart` 생략 시 이번 주(월요일)로 계산한다.",
+        "properties": {
+          "weekStart": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "YYYY-MM-DD (해당 주 월요일)",
+            "title": "Weekstart"
+          }
+        },
+        "title": "WeeklyGenerateRequest",
+        "type": "object"
+      },
+      "WeeklyPlanDay": {
+        "description": "하루치 — 그리드/네비게이터 단위.",
+        "properties": {
+          "blocks": {
+            "items": {
+              "$ref": "#/components/schemas/WeeklyBlock"
+            },
+            "title": "Blocks",
+            "type": "array"
+          },
+          "date": {
+            "format": "date",
+            "title": "Date",
+            "type": "string"
+          },
+          "weekday": {
+            "title": "Weekday",
+            "type": "string"
+          }
+        },
+        "required": [
+          "date",
+          "weekday"
+        ],
+        "title": "WeeklyPlanDay",
+        "type": "object"
+      },
+      "WeeklyPlanResponse": {
+        "description": "GET /plans/weekly — 7일 블록 그리드 (모바일=1일 그리드+7일 네비게이터).",
+        "properties": {
+          "days": {
+            "items": {
+              "$ref": "#/components/schemas/WeeklyPlanDay"
+            },
+            "title": "Days",
+            "type": "array"
+          },
+          "planId": {
+            "title": "Planid",
+            "type": "string"
+          },
+          "weekEnd": {
+            "format": "date",
+            "title": "Weekend",
+            "type": "string"
+          },
+          "weekStart": {
+            "format": "date",
+            "title": "Weekstart",
+            "type": "string"
+          }
+        },
+        "required": [
+          "planId",
+          "weekStart",
+          "weekEnd",
+          "days"
+        ],
+        "title": "WeeklyPlanResponse",
+        "type": "object"
+      },
+      "WeeklyReviewResponse": {
+        "description": "GET /reviews/weekly · generate 응답 — 룰 기반 주간 리뷰 카드 (S21).",
+        "properties": {
+          "adherenceRate": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Adherencerate"
+          },
+          "averageRecoveryMinutes": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Averagerecoveryminutes"
+          },
+          "avgDelayMinutes": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Avgdelayminutes"
+          },
+          "categorySuccessRate": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "title": "Categorysuccessrate",
+            "type": "object"
+          },
+          "consistencyDays": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Consistencydays"
+          },
+          "drainWindow": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Drainwindow"
+          },
+          "generatedAt": {
+            "format": "date-time",
+            "title": "Generatedat",
+            "type": "string"
+          },
+          "oneLiner": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Oneliner"
+          },
+          "peakWindow": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Peakwindow"
+          },
+          "policyUpdateCandidates": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "title": "Policyupdatecandidates",
+            "type": "array"
+          },
+          "repeatedFailureCount": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Repeatedfailurecount"
+          },
+          "resilienceRate": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Resiliencerate"
+          },
+          "restartSuccessRate": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Restartsuccessrate"
+          },
+          "weekEnd": {
+            "format": "date",
+            "title": "Weekend",
+            "type": "string"
+          },
+          "weekStart": {
+            "format": "date",
+            "title": "Weekstart",
+            "type": "string"
+          }
+        },
+        "required": [
+          "weekStart",
+          "weekEnd",
+          "generatedAt"
+        ],
+        "title": "WeeklyReviewResponse",
         "type": "object"
       }
     }
@@ -5427,6 +6047,72 @@
         ]
       }
     },
+    "/plans/weekly": {
+      "get": {
+        "description": "주간 블록 그리드 (S14). weekStart 생략 시 이번 주 월요일 기준.",
+        "operationId": "get_weekly_plan_plans_weekly_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "weekStart",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Weekstart"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WeeklyPlanResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Weekly Plan",
+        "tags": [
+          "planning"
+        ]
+      }
+    },
     "/plans/{plan_id}": {
       "get": {
         "description": "저장된 First Plan Draft 미리보기 — LLM 재호출 없이 스냅샷 재구성.",
@@ -5545,6 +6231,84 @@
         ]
       }
     },
+    "/plans/{plan_id}/blocks/{block_id}": {
+      "patch": {
+        "description": "블록 15분 snap 이동 (S15). 충돌 422 `PLAN_BLOCK_CONFLICT` / 정책 422 `POLICY_VIOLATION`.",
+        "operationId": "edit_block_plans__plan_id__blocks__block_id__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "plan_id",
+            "required": true,
+            "schema": {
+              "title": "Plan Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "block_id",
+            "required": true,
+            "schema": {
+              "title": "Block Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BlockEditRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BlockEditResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Edit Block",
+        "tags": [
+          "planning"
+        ]
+      }
+    },
     "/policy-snapshot/current": {
       "get": {
         "description": "현재 활성 PolicySnapshot.",
@@ -5595,7 +6359,7 @@
     },
     "/privacy/consent": {
       "get": {
-        "description": "[#23-B] 동의 기록 — append-only `user_consents` 테이블 (마이그레이션 동반).",
+        "description": "동의 현황 — consent_type 별 최신 기록 (필수/마케팅/연구).",
         "operationId": "get_consent_privacy_consent_get",
         "parameters": [
           {
@@ -5619,7 +6383,9 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/ConsentListResponse"
+                }
               }
             },
             "description": "Successful Response"
@@ -5641,7 +6407,7 @@
         ]
       },
       "post": {
-        "description": "[#23-B] 신규 동의 (마케팅/연구 토글).",
+        "description": "동의/철회 — append-only 새 기록 추가 후 갱신된 현황 반환.\n\n`consentType` 외 값은 Pydantic Literal → 422 `COMMON_VALIDATION_ERROR`.",
         "operationId": "create_consent_privacy_consent_post",
         "parameters": [
           {
@@ -5661,11 +6427,23 @@
             }
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConsentCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/ConsentListResponse"
+                }
               }
             },
             "description": "Successful Response"
@@ -6092,10 +6870,10 @@
         ]
       }
     },
-    "/reviews/weekly": {
+    "/reviews/habit-penalty": {
       "get": {
-        "description": "이번 주 (또는 지정 주차) 리뷰 카드.",
-        "operationId": "get_weekly_review_reviews_weekly_get",
+        "description": "3주 연속 미달(50% 미만) habit 의 빈도 재설계 제안 후보 (S22).",
+        "operationId": "list_habit_penalty_reviews_habit_penalty_get",
         "parameters": [
           {
             "in": "header",
@@ -6115,6 +6893,16 @@
           }
         ],
         "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HabitPenaltyListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
           "422": {
             "content": {
               "application/json": {
@@ -6124,17 +6912,194 @@
               }
             },
             "description": "Validation Error"
+          }
+        },
+        "summary": "List Habit Penalty",
+        "tags": [
+          "reviews"
+        ]
+      }
+    },
+    "/reviews/habit-penalty/{habit_id}/accept": {
+      "post": {
+        "description": "빈도 재설계 수락 → frequency 다운 (Idempotency-Key 필수 — §1.7 미들웨어).",
+        "operationId": "accept_habit_penalty_reviews_habit_penalty__habit_id__accept_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "habit_id",
+            "required": true,
+            "schema": {
+              "title": "Habit Id",
+              "type": "string"
+            }
           },
-          "501": {
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/HabitPenaltyAcceptResponse"
+                }
               }
             },
             "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Accept Habit Penalty",
+        "tags": [
+          "reviews"
+        ]
+      }
+    },
+    "/reviews/weekly": {
+      "get": {
+        "description": "이번 주(또는 지정 주차) 리뷰. precomputed 우선, 없으면 즉석 계산(쓰기 없음).",
+        "operationId": "get_weekly_review_reviews_weekly_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "weekStart",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Weekstart"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WeeklyReviewResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
           }
         },
         "summary": "Get Weekly Review",
+        "tags": [
+          "reviews"
+        ]
+      }
+    },
+    "/reviews/weekly/generate": {
+      "post": {
+        "description": "주간 리뷰 강제 재생성 + 영속화 (디버그/관리자). 같은 주 덮어쓰기.",
+        "operationId": "generate_weekly_review_reviews_weekly_generate_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WeeklyGenerateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WeeklyReviewResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Generate Weekly Review",
         "tags": [
           "reviews"
         ]
@@ -6192,7 +7157,7 @@
     },
     "/settings/anonymize": {
       "post": {
-        "description": "[#23-B] 즉시 익명화 — 2단계 확인 토큰 + `_encrypted` 필드 마스킹.",
+        "description": "즉시 익명화 — 2단계 확인.\n\n- `confirmationToken` 없으면 step1: 확인 토큰 발급(미적용).\n- `confirmationToken` 있으면 step2: 검증 후 `_encrypted` 필드 마스킹 + 이름 마스킹 +\n  `is_anonymized`/`anonymized_at` set. hard delete 아님(행 보존).",
         "operationId": "anonymize_settings_anonymize_post",
         "parameters": [
           {
@@ -6212,11 +7177,23 @@
             }
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AnonymizeRequest"
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/AnonymizeResponse"
+                }
               }
             },
             "description": "Successful Response"

--- a/src/types/openapi.d.ts
+++ b/src/types/openapi.d.ts
@@ -747,6 +747,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/plans/weekly": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Weekly Plan
+         * @description 주간 블록 그리드 (S14). weekStart 생략 시 이번 주 월요일 기준.
+         */
+        get: operations["get_weekly_plan_plans_weekly_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/plans/{plan_id}": {
         parameters: {
             query?: never;
@@ -796,6 +816,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/plans/{plan_id}/blocks/{block_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Edit Block
+         * @description 블록 15분 snap 이동 (S15). 충돌 422 `PLAN_BLOCK_CONFLICT` / 정책 422 `POLICY_VIOLATION`.
+         */
+        patch: operations["edit_block_plans__plan_id__blocks__block_id__patch"];
+        trace?: never;
+    };
     "/policy-snapshot/current": {
         parameters: {
             query?: never;
@@ -825,13 +865,15 @@ export interface paths {
         };
         /**
          * Get Consent
-         * @description [#23-B] 동의 기록 — append-only `user_consents` 테이블 (마이그레이션 동반).
+         * @description 동의 현황 — consent_type 별 최신 기록 (필수/마케팅/연구).
          */
         get: operations["get_consent_privacy_consent_get"];
         put?: never;
         /**
          * Create Consent
-         * @description [#23-B] 신규 동의 (마케팅/연구 토글).
+         * @description 동의/철회 — append-only 새 기록 추가 후 갱신된 현황 반환.
+         *
+         *     `consentType` 외 값은 Pydantic Literal → 422 `COMMON_VALIDATION_ERROR`.
          */
         post: operations["create_consent_privacy_consent_post"];
         delete?: never;
@@ -989,6 +1031,46 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/reviews/habit-penalty": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Habit Penalty
+         * @description 3주 연속 미달(50% 미만) habit 의 빈도 재설계 제안 후보 (S22).
+         */
+        get: operations["list_habit_penalty_reviews_habit_penalty_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/reviews/habit-penalty/{habit_id}/accept": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Accept Habit Penalty
+         * @description 빈도 재설계 수락 → frequency 다운 (Idempotency-Key 필수 — §1.7 미들웨어).
+         */
+        post: operations["accept_habit_penalty_reviews_habit_penalty__habit_id__accept_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/reviews/weekly": {
         parameters: {
             query?: never;
@@ -998,11 +1080,31 @@ export interface paths {
         };
         /**
          * Get Weekly Review
-         * @description 이번 주 (또는 지정 주차) 리뷰 카드.
+         * @description 이번 주(또는 지정 주차) 리뷰. precomputed 우선, 없으면 즉석 계산(쓰기 없음).
          */
         get: operations["get_weekly_review_reviews_weekly_get"];
         put?: never;
         post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/reviews/weekly/generate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Generate Weekly Review
+         * @description 주간 리뷰 강제 재생성 + 영속화 (디버그/관리자). 같은 주 덮어쓰기.
+         */
+        post: operations["generate_weekly_review_reviews_weekly_generate_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -1042,7 +1144,11 @@ export interface paths {
         put?: never;
         /**
          * Anonymize
-         * @description [#23-B] 즉시 익명화 — 2단계 확인 토큰 + `_encrypted` 필드 마스킹.
+         * @description 즉시 익명화 — 2단계 확인.
+         *
+         *     - `confirmationToken` 없으면 step1: 확인 토큰 발급(미적용).
+         *     - `confirmationToken` 있으면 step2: 검증 후 `_encrypted` 필드 마스킹 + 이름 마스킹 +
+         *       `is_anonymized`/`anonymized_at` set. hard delete 아님(행 보존).
          */
         post: operations["anonymize_settings_anonymize_post"];
         delete?: never;
@@ -1344,6 +1450,40 @@ export interface components {
             title: string;
         };
         /**
+         * AnonymizeRequest
+         * @description POST /settings/anonymize 요청.
+         *
+         *     `confirmationToken` 없으면 step1(토큰 발급), 있으면 step2(실행) — 2단계 확인.
+         */
+        AnonymizeRequest: {
+            /** Confirmationtoken */
+            confirmationToken?: string | null;
+        };
+        /**
+         * AnonymizeResponse
+         * @description 익명화 응답. `status` 로 단계 구분.
+         *
+         *     - `confirmation_required` — 토큰 발급(미적용). `confirmationToken`/`expiresAt` 채움.
+         *     - `anonymized` — 적용 완료. `anonymizedAt`/`maskedCount` 채움.
+         */
+        AnonymizeResponse: {
+            /** Anonymizedat */
+            anonymizedAt?: string | null;
+            /** Confirmationtoken */
+            confirmationToken?: string | null;
+            /** Expiresat */
+            expiresAt?: string | null;
+            /** Maskedcount */
+            maskedCount?: number | null;
+            /** Message */
+            message: string;
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "confirmation_required" | "anonymized";
+        };
+        /**
          * ApproveInsertResult
          * @description POST /calendar/events/approve-insert 응답.
          */
@@ -1377,6 +1517,46 @@ export interface components {
             noTouchWindows?: components["schemas"]["NoTouchWindow"][];
             /** Peakwindow */
             peakWindow: string[];
+        };
+        /**
+         * BlockEditRequest
+         * @description PATCH /plans/{planId}/blocks/{blockId} — 15분 snap 이동.
+         *
+         *     `endAt` 생략 시 기존 길이를 보존한 채 시작만 옮긴다. 시각은 KST ISO 8601.
+         */
+        BlockEditRequest: {
+            /** Endat */
+            endAt?: string | null;
+            /** Startat */
+            startAt: string;
+        };
+        /**
+         * BlockEditResponse
+         * @description 편집 결과 — 스냅 적용된 최종 블록.
+         */
+        BlockEditResponse: {
+            /** Actionid */
+            actionId: string;
+            /** Blockid */
+            blockId: string;
+            /** Blockstatus */
+            blockStatus: string;
+            /** Category */
+            category: string;
+            /**
+             * Endat
+             * Format: date-time
+             */
+            endAt: string;
+            /** Source */
+            source: string;
+            /**
+             * Startat
+             * Format: date-time
+             */
+            startAt: string;
+            /** Title */
+            title: string;
         };
         /**
          * BusyInterval
@@ -1466,6 +1646,45 @@ export interface components {
             executionId: string;
             /** Needsfailuretags */
             needsFailureTags: boolean;
+        };
+        /**
+         * ConsentCreateRequest
+         * @description POST /privacy/consent — 동의/철회 (append-only 새 기록).
+         */
+        ConsentCreateRequest: {
+            /**
+             * Consenttype
+             * @enum {string}
+             */
+            consentType: "required" | "marketing" | "research";
+            /** Granted */
+            granted: boolean;
+        };
+        /**
+         * ConsentItem
+         * @description consent_type 별 현재(최신) 동의 상태.
+         */
+        ConsentItem: {
+            /**
+             * Consenttype
+             * @enum {string}
+             */
+            consentType: "required" | "marketing" | "research";
+            /** Isgranted */
+            isGranted: boolean;
+            /**
+             * Updatedat
+             * Format: date-time
+             */
+            updatedAt: string;
+        };
+        /**
+         * ConsentListResponse
+         * @description GET /privacy/consent — 동의 현황 (필수/마케팅/연구 분리).
+         */
+        ConsentListResponse: {
+            /** Consents */
+            consents: components["schemas"]["ConsentItem"][];
         };
         /**
          * DbStatus
@@ -1889,6 +2108,46 @@ export interface components {
             weekStart: string;
         };
         /**
+         * HabitPenaltyAcceptResponse
+         * @description POST /reviews/habit-penalty/{habitId}/accept — 빈도 다운 결과.
+         */
+        HabitPenaltyAcceptResponse: {
+            /** Habitid */
+            habitId: string;
+            /** Message */
+            message: string;
+            /** Newfrequency */
+            newFrequency: number;
+            /** Previousfrequency */
+            previousFrequency: number;
+        };
+        /**
+         * HabitPenaltyCandidate
+         * @description 3주 연속 미달로 빈도 재설계를 제안할 habit.
+         */
+        HabitPenaltyCandidate: {
+            /** Currentfrequency */
+            currentFrequency: number;
+            /** Habitid */
+            habitId: string;
+            /** Message */
+            message: string;
+            /** Recentweeks */
+            recentWeeks?: components["schemas"]["HabitWeekStat"][];
+            /** Suggestedfrequency */
+            suggestedFrequency: number;
+            /** Title */
+            title: string;
+        };
+        /**
+         * HabitPenaltyListResponse
+         * @description GET /reviews/habit-penalty — 제안 후보 목록.
+         */
+        HabitPenaltyListResponse: {
+            /** Candidates */
+            candidates?: components["schemas"]["HabitPenaltyCandidate"][];
+        };
+        /**
          * HabitUpdateRequest
          * @description PATCH /habits/{id} 요청 — 제목·빈도 (api-contract §7).
          */
@@ -1897,6 +2156,16 @@ export interface components {
             frequencyPerWeek?: number | null;
             /** Title */
             title?: string | null;
+        };
+        /**
+         * HabitWeekStat
+         * @description 페널티 근거 — 한 주의 달성/목표.
+         */
+        HabitWeekStat: {
+            /** Donecount */
+            doneCount: number;
+            /** Targetcount */
+            targetCount: number;
         };
         /**
          * HealthResponse
@@ -2514,6 +2783,131 @@ export interface components {
             msg: string;
             /** Error Type */
             type: string;
+        };
+        /**
+         * WeeklyBlock
+         * @description 주간 그리드의 스케줄 블록 한 칸.
+         */
+        WeeklyBlock: {
+            /** Actionid */
+            actionId: string;
+            /** Blockid */
+            blockId: string;
+            /** Blockstatus */
+            blockStatus: string;
+            /** Category */
+            category: string;
+            /**
+             * Endat
+             * Format: date-time
+             */
+            endAt: string;
+            /** Source */
+            source: string;
+            /**
+             * Startat
+             * Format: date-time
+             */
+            startAt: string;
+            /** Title */
+            title: string;
+        };
+        /**
+         * WeeklyGenerateRequest
+         * @description POST /reviews/weekly/generate — 수동 재생성 (디버그).
+         *
+         *     `weekStart` 생략 시 이번 주(월요일)로 계산한다.
+         */
+        WeeklyGenerateRequest: {
+            /**
+             * Weekstart
+             * @description YYYY-MM-DD (해당 주 월요일)
+             */
+            weekStart?: string | null;
+        };
+        /**
+         * WeeklyPlanDay
+         * @description 하루치 — 그리드/네비게이터 단위.
+         */
+        WeeklyPlanDay: {
+            /** Blocks */
+            blocks?: components["schemas"]["WeeklyBlock"][];
+            /**
+             * Date
+             * Format: date
+             */
+            date: string;
+            /** Weekday */
+            weekday: string;
+        };
+        /**
+         * WeeklyPlanResponse
+         * @description GET /plans/weekly — 7일 블록 그리드 (모바일=1일 그리드+7일 네비게이터).
+         */
+        WeeklyPlanResponse: {
+            /** Days */
+            days: components["schemas"]["WeeklyPlanDay"][];
+            /** Planid */
+            planId: string;
+            /**
+             * Weekend
+             * Format: date
+             */
+            weekEnd: string;
+            /**
+             * Weekstart
+             * Format: date
+             */
+            weekStart: string;
+        };
+        /**
+         * WeeklyReviewResponse
+         * @description GET /reviews/weekly · generate 응답 — 룰 기반 주간 리뷰 카드 (S21).
+         */
+        WeeklyReviewResponse: {
+            /** Adherencerate */
+            adherenceRate?: number | null;
+            /** Averagerecoveryminutes */
+            averageRecoveryMinutes?: number | null;
+            /** Avgdelayminutes */
+            avgDelayMinutes?: number | null;
+            /** Categorysuccessrate */
+            categorySuccessRate?: {
+                [key: string]: number;
+            };
+            /** Consistencydays */
+            consistencyDays?: number | null;
+            /** Drainwindow */
+            drainWindow?: string | null;
+            /**
+             * Generatedat
+             * Format: date-time
+             */
+            generatedAt: string;
+            /** Oneliner */
+            oneLiner?: string | null;
+            /** Peakwindow */
+            peakWindow?: string | null;
+            /** Policyupdatecandidates */
+            policyUpdateCandidates?: {
+                [key: string]: unknown;
+            }[];
+            /** Repeatedfailurecount */
+            repeatedFailureCount?: number | null;
+            /** Resiliencerate */
+            resilienceRate?: number | null;
+            /** Restartsuccessrate */
+            restartSuccessRate?: number | null;
+            /**
+             * Weekend
+             * Format: date
+             */
+            weekEnd: string;
+            /**
+             * Weekstart
+             * Format: date
+             */
+            weekStart: string;
         };
     };
     responses: never;
@@ -3964,6 +4358,39 @@ export interface operations {
             };
         };
     };
+    get_weekly_plan_plans_weekly_get: {
+        parameters: {
+            query?: {
+                weekStart?: string | null;
+            };
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WeeklyPlanResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     get_plan_plans__plan_id__get: {
         parameters: {
             query?: never;
@@ -4030,6 +4457,44 @@ export interface operations {
             };
         };
     };
+    edit_block_plans__plan_id__blocks__block_id__patch: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                plan_id: string;
+                block_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["BlockEditRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BlockEditResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     get_current_policy_policy_snapshot_current_get: {
         parameters: {
             query?: never;
@@ -4078,7 +4543,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["ConsentListResponse"];
                 };
             };
             /** @description Validation Error */
@@ -4101,7 +4566,11 @@ export interface operations {
             path?: never;
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ConsentCreateRequest"];
+            };
+        };
         responses: {
             /** @description Successful Response */
             200: {
@@ -4109,7 +4578,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["ConsentListResponse"];
                 };
             };
             /** @description Validation Error */
@@ -4358,7 +4827,7 @@ export interface operations {
             };
         };
     };
-    get_weekly_review_reviews_weekly_get: {
+    list_habit_penalty_reviews_habit_penalty_get: {
         parameters: {
             query?: never;
             header?: {
@@ -4369,6 +4838,15 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HabitPenaltyListResponse"];
+                };
+            };
             /** @description Validation Error */
             422: {
                 headers: {
@@ -4378,13 +4856,105 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
+        };
+    };
+    accept_habit_penalty_reviews_habit_penalty__habit_id__accept_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                habit_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
             /** @description Successful Response */
-            501: {
+            200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["HabitPenaltyAcceptResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_weekly_review_reviews_weekly_get: {
+        parameters: {
+            query?: {
+                weekStart?: string | null;
+            };
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WeeklyReviewResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    generate_weekly_review_reviews_weekly_generate_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["WeeklyGenerateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WeeklyReviewResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };
@@ -4429,7 +4999,11 @@ export interface operations {
             path?: never;
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AnonymizeRequest"];
+            };
+        };
         responses: {
             /** @description Successful Response */
             200: {
@@ -4437,7 +5011,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["AnonymizeResponse"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
reaction-backend `main` 의 OpenAPI 를 다시 덤프해 `openapi.json` 과 생성 타입(`src/types/openapi.d.ts`)을 갱신한 자동 동기화 PR입니다.

## (a) 신규/변경 엔드포인트
백엔드에 **신규 엔드포인트 5개**가 추가되었습니다 (모두 순수 추가 — 기존 경로/스키마 제거 없음, GONE 0):

| 메서드 | 경로 | 비고 |
|---|---|---|
| GET | `/plans/weekly` | 주간 계획 보기 (응답이 `{planId, weekStart, weekEnd, days[]}` 구조) |
| PATCH | `/plans/{plan_id}/blocks/{block_id}` | 블록 시간 수정 (`BlockEditRequest`) |
| GET | `/reviews/habit-penalty` | 습관 패널티 후보 목록 |
| POST | `/reviews/habit-penalty/{habit_id}/accept` | 패널티 수락 |
| POST | `/reviews/weekly/generate` | 주간 회고 재생성 |

신규 스키마: `WeeklyPlanResponse` / `WeeklyPlanDay` / `WeeklyBlock`, `BlockEditRequest` / `BlockEditResponse`, `WeeklyReviewResponse`, `WeeklyGenerateRequest`, `HabitPenaltyListResponse` / `HabitPenaltyCandidate` / `HabitPenaltyAcceptResponse` 등.

기존 화면 연동 대상 스키마(`FirstPlanResponse`, `RecoveryProposalsResponse`/`RecoveryCard`/`RecoveryDecisionResponse`, `ExecutionStartResponse`, `CheckInRequest`/`CheckInResponse`)는 **필드 변경 없음**으로 확인했습니다.

## (b) 화면 실연동
이번 회차에는 **화면 코드 변경이 없습니다.** 사유:
- 실연동 대상(OK)인 First Plan / Recovery / Today 는 이미 #34~#36 에서 연동 완료되었고, 관련 응답 스키마가 그대로라 추가 작업이 없습니다.
- 새로 구현된 백엔드 엔드포인트(`/plans/weekly`, `/reviews/*`, 블록 수정)는 루틴 지침상 **"UI 그대로 두기"** 대상(weekly·reviews)입니다.
- ⚠️ **주의(후속 작업 제안):** 이 엔드포인트들의 실제 백엔드 스키마가 프론트의 기존 *추정* 타입(`WeeklyPlanResponse`={weekStart, blocks[]}, `WeeklyReview`, `PlanBlockUpdate` 등)과 **다릅니다**. 정식으로 주간 보기/주간 회고 화면을 실연동할 때 `src/types/api.ts` 의 해당 타입과 `WeeklyCalendarScreen`/`WeeklyReviewScreen` 매핑을 함께 갱신해야 합니다. (이번 PR에서는 fenced 화면을 건드리지 않기 위해 타입 변경을 보류했습니다.)

## (c) check:api 요약
```
openapi 경로 61개 · api.ts 호출 66개
✅ OK   63   (백엔드 구현됨, 메서드 일치)
⚠️ WARN 3   (today/focus pause·resume, reflection/pending — 여전히 미구현 stub)
❌ GONE 0   ✅ 게이트 통과
🆕 NEW  11   (openapi 에 있으나 api.ts 래퍼 없음)
```
검증 게이트: `npm run check:api` → GONE 0 (PASS) · `npx tsc --noEmit` → OK · `npm run build` → OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AodmrNANj8VRvni8xnmBCz

---
_Generated by [Claude Code](https://claude.ai/code/session_01AodmrNANj8VRvni8xnmBCz)_