### PR TITLE
feat(api): weekly/reviews 실데이터 연동 + 타입 교정

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -37,8 +37,8 @@ import type {
   NotificationSettings,
   NotificationSettingsUpdateRequest,
   OnboardingStatus,
-  PlanBlockUpdate,
-  PlanScheduledBlock,
+  BlockEditRequest,
+  BlockEditResponse,
   PushSubscribeRequest,
   RecoveryDecisionRequest,
   RecoveryDecisionResponse,
@@ -54,8 +54,11 @@ import type {
   ToneModeUpdateRequest,
   UserProfile,
   UserSettings,
+  HabitPenaltyAcceptResponse,
+  HabitPenaltyListResponse,
+  WeeklyGenerateRequest,
   WeeklyPlanResponse,
-  WeeklyReview,
+  WeeklyReviewResponse,
 } from '../types/api';
 
 const BASE_URL = (import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8000').replace(/\/$/, '');
@@ -337,30 +340,33 @@ export const plansApi = {
   approve: (planId: string) =>
     request<FirstPlanApproveResponse>(`/plans/${planId}/approve`, { method: 'POST', body: {} }),
 
-  // 주간 보기/블록 수정은 아직 백엔드 미구현(추정 contract).
+  // 주간 보기/블록 수정 — 백엔드 #21 구현됨.
   weekly: (weekStart: string) =>
     request<WeeklyPlanResponse>(`/plans/weekly?weekStart=${encodeURIComponent(weekStart)}`),
 
-  updateBlock: (planId: string, blockId: string, body: PlanBlockUpdate) =>
-    request<PlanScheduledBlock>(`/plans/${planId}/blocks/${blockId}`, {
+  updateBlock: (planId: string, blockId: string, body: BlockEditRequest) =>
+    request<BlockEditResponse>(`/plans/${planId}/blocks/${blockId}`, {
       method: 'PATCH',
       body,
     }),
 };
 
-// ── Reviews (S21·S22) — 백엔드 501 ────────────────────────────
+// ── Reviews (S21·S22) — 백엔드 #21 구현됨 ─────────────────────
 export const reviewsApi = {
   weekly: (weekStart: string) =>
-    request<WeeklyReview>(`/reviews/weekly?weekStart=${encodeURIComponent(weekStart)}`),
+    request<WeeklyReviewResponse>(`/reviews/weekly?weekStart=${encodeURIComponent(weekStart)}`),
 
   regenerate: (weekStart: string) =>
-    request<WeeklyReview>('/reviews/weekly/generate', {
+    request<WeeklyReviewResponse>('/reviews/weekly/generate', {
       method: 'POST',
-      body: { weekStart },
+      body: { weekStart } satisfies WeeklyGenerateRequest,
     }),
 
+  // 습관 패널티 후보 목록 (#21)
+  habitPenalty: () => request<HabitPenaltyListResponse>('/reviews/habit-penalty'),
+
   acceptHabitPenalty: (habitId: string, idempotencyKey: string) =>
-    request<void>(`/reviews/habit-penalty/${habitId}/accept`, {
+    request<HabitPenaltyAcceptResponse>(`/reviews/habit-penalty/${habitId}/accept`, {
       method: 'POST',
       body: {},
       idempotencyKey,

--- a/src/screens/WeeklyCalendarScreen.tsx
+++ b/src/screens/WeeklyCalendarScreen.tsx
@@ -6,6 +6,30 @@ import { DemoNotice } from '../components/DemoNotice';
 import { Segmented } from '../components/Segmented';
 import { useNavigation } from '../contexts/NavigationContext';
 import type { Block } from '../types';
+import type { WeeklyPlanResponse, BlockEditRequest } from '../types/api';
+
+// 백엔드 WeeklyPlanResponse(days[].blocks[] = WeeklyBlock) → 화면 BlockWithStatus[].
+function weeklyToBlocks(res: WeeklyPlanResponse): (Block & { status: 'pending' | 'done' | 'failed' })[] {
+  const out: (Block & { status: 'pending' | 'done' | 'failed' })[] = [];
+  for (const day of res.days ?? []) {
+    for (const b of day.blocks ?? []) {
+      const s = new Date(b.startAt);
+      const e = new Date(b.endAt);
+      const status = b.blockStatus === 'done' ? 'done' : b.blockStatus === 'failed' ? 'failed' : 'pending';
+      out.push({
+        id: b.blockId,
+        day: (s.getDay() + 6) % 7, // 월=0 .. 일=6
+        time: `${String(s.getHours()).padStart(2, '0')}:${String(s.getMinutes()).padStart(2, '0')}`,
+        dur: Math.max(15, Math.round((e.getTime() - s.getTime()) / 60000)),
+        title: b.title,
+        goal: b.category,
+        fixed: b.source === 'fixed',
+        status,
+      });
+    }
+  }
+  return out;
+}
 
 // 15분 snap 단위 — Issue #9 S15 Direct Edit DoD.
 const SNAP_MIN = 15;
@@ -119,20 +143,6 @@ export function WeeklyCalendarScreenV2() {
     return d.toISOString().slice(0, 10);
   })();
 
-  // mock-and-replace: 주차 바뀔 때마다 /plans/weekly?weekStart= 시도. 501/404 → 더미 그대로.
-  useEffect(() => {
-    let cancelled = false;
-    plansApi.weekly(weekStartStr).then(
-      (res) => {
-        if (cancelled) return;
-        // TODO(backend-#21): res.blocks → BlockWithStatus[] 매핑
-        // planId 는 응답 구조 확정 후 res.planId 또는 res.weeks[0].planId 로 추출.
-        void res;
-      },
-      () => { /* 404/501 ok — 더미 유지 */ },
-    );
-    return () => { cancelled = true; };
-  }, [weekStartStr]);
 
   // 이번 주: 실행이 진행 중 — 완료/실패/이월 상태가 섞여 있다.
   const [thisWeekBlocks, setThisWeekBlocks] = useState<BlockWithStatus[]>(
@@ -150,6 +160,28 @@ export function WeeklyCalendarScreenV2() {
   // 활성 주차의 블록/세터로 별칭 — 아래 편집 로직(setBlocks)이 그대로 동작.
   const blocks = isThisWeek ? thisWeekBlocks : nextWeekBlocks;
   const setBlocks = isThisWeek ? setThisWeekBlocks : setNextWeekBlocks;
+  // 백엔드 실제 주간 계획이 들어왔는지 — true 면 더미가 아니라 진짜 데이터.
+  const [usingRealPlan, setUsingRealPlan] = useState(false);
+
+  // 주차 바뀔 때마다 /plans/weekly(#21 구현됨) 시도. 실데이터 오면 더미 교체, 없으면 더미 유지.
+  useEffect(() => {
+    let cancelled = false;
+    setUsingRealPlan(false);
+    plansApi.weekly(weekStartStr).then(
+      (res) => {
+        if (cancelled) return;
+        planIdRef.current = res.planId;
+        const mapped = weeklyToBlocks(res);
+        if (mapped.length) {
+          setBlocks(mapped);
+          setUsingRealPlan(true);
+        }
+      },
+      () => { /* 미구현/네트워크 — 더미 유지 */ },
+    );
+    return () => { cancelled = true; };
+  }, [weekStartStr]);
+
   const [editing, setEditing] = useState<Block | null>(null);
   // 두 종류 토스트: 성공(success) / 에러(error). 인라인 표시는 색만 다름.
   const [toast, setToast] = useState<{ msg: string; tone: 'success' | 'error' } | null>(null);
@@ -274,15 +306,14 @@ export function WeeklyCalendarScreenV2() {
       showToast('블록 이동됨 (임시 저장)');
       return;
     }
-    // 이번 주 월요일 기준으로 scheduledTime 생성.
-    const monday = new Date(_monday);
-    monday.setDate(monday.getDate() + newDay);
-    monday.setHours(Math.floor(newMinute / 60), newMinute % 60, 0, 0);
+    // 선택 주차 월요일 기준으로 startAt/endAt(ISO) 생성.
+    const startAt = new Date(_monday);
+    startAt.setDate(startAt.getDate() + newDay);
+    startAt.setHours(Math.floor(newMinute / 60), newMinute % 60, 0, 0);
+    const endAt = new Date(startAt.getTime() + block.dur * 60000);
     try {
-      await plansApi.updateBlock(planIdRef.current, block.id, {
-        scheduledTime: monday.toISOString(),
-        durationMinutes: block.dur,
-      });
+      const body: BlockEditRequest = { startAt: startAt.toISOString(), endAt: endAt.toISOString() };
+      await plansApi.updateBlock(planIdRef.current, block.id, body);
       showToast('블록 이동됨');
     } catch (err) {
       // 422 코드 분기.
@@ -393,11 +424,13 @@ export function WeeklyCalendarScreenV2() {
           <span style={{ fontSize: 9, fontFamily: 'var(--font-mono)', color: 'var(--text-3)', letterSpacing: '0.08em' }}>{weekLabel}</span>
         </div>
         <p style={{ fontSize: 11, color: 'var(--text-3)', margin: '0 0 8px' }}>블록을 탭하면 수정, 길게 누른 채 끌면 15분 단위로 이동돼요.</p>
-        <div style={{ marginBottom: 8 }}>
-          <DemoNotice storageKey="weekly-calendar">
-            주간 계획은 백엔드 연동 전이라 예시예요. 편집은 임시 저장되며 서버 연결 후 동기화됩니다.
-          </DemoNotice>
-        </div>
+        {!usingRealPlan && (
+          <div style={{ marginBottom: 8 }}>
+            <DemoNotice storageKey="weekly-calendar">
+              주간 계획은 백엔드 연동 전이라 예시예요. 편집은 임시 저장되며 서버 연결 후 동기화됩니다.
+            </DemoNotice>
+          </div>
+        )}
         <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
           {[
             { label: '완료', n: blocks.filter((b) => b.status === 'done').length, bg: '#E5EFE3', bd: '#b4dfc8', fg: 'var(--success)' },

--- a/src/screens/WeeklyReviewScreen.tsx
+++ b/src/screens/WeeklyReviewScreen.tsx
@@ -1,10 +1,11 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Sparkle, ArrowRight } from '@phosphor-icons/react';
 import { REVIEW_V2 } from '../data';
 import { reviewsApi } from '../lib/api';
 import { DemoNotice } from '../components/DemoNotice';
 import { useNavigation } from '../contexts/NavigationContext';
 import type { FailItem } from '../types';
+import type { WeeklyReviewResponse } from '../types/api';
 
 // 이번 주 월요일 (YYYY-MM-DD)
 function thisMonday(): string {
@@ -118,9 +119,17 @@ function SectionLabel({ children }: { children: React.ReactNode }) {
   );
 }
 
+// 0~1 비율이면 %로, 이미 0~100이면 그대로.
+function toPct(v: number | null | undefined): number | null {
+  if (v == null) return null;
+  return v <= 1 ? Math.round(v * 100) : Math.round(v);
+}
+
 export function WeeklyReviewScreenV2() {
   const { week, scoreOutOf100, stats, kpi, fails, daily, policy } = REVIEW_V2;
   const { setScreen, setTab, setWeekOffset } = useNavigation();
+  // 백엔드 실제 주간 리뷰. 들어오면 hero 점수/복구율/한줄요약을 실데이터로 덮는다.
+  const [real, setReal] = useState<WeeklyReviewResponse | null>(null);
 
   // "다음 주 계획 확인" — 다음 주(weekOffset=1)로 주간 계획 화면 이동.
   const goToNextWeekPlan = () => {
@@ -129,19 +138,19 @@ export function WeeklyReviewScreenV2() {
     setScreen('weekly');
   };
 
-  // mock-and-replace: 진입 시 /reviews/weekly?weekStart= 시도. 501 → 더미 유지.
+  // /reviews/weekly(#21 구현됨) 시도. 실데이터 오면 일부 지표를 덮고, 없으면 더미 유지.
   useEffect(() => {
     let cancelled = false;
     reviewsApi.weekly(thisMonday()).then(
-      (res) => {
-        if (cancelled) return;
-        // TODO(backend-#21): res.adherenceRate/resilienceRate/peakWindow 등을 REVIEW_V2 자리 매핑
-        void res;
-      },
-      () => { /* 501 ok */ },
+      (res) => { if (!cancelled) setReal(res); },
+      () => { /* 미구현/오류 — 더미 유지 */ },
     );
     return () => { cancelled = true; };
   }, []);
+
+  const usingReal = !!real;
+  const score = toPct(real?.adherenceRate) ?? scoreOutOf100;
+  const recoveryPct = toPct(real?.resilienceRate) ?? stats.recovery;
 
   return (
     <div style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column', background: 'var(--surface-ground)', overflow: 'hidden' }}>
@@ -152,21 +161,23 @@ export function WeeklyReviewScreenV2() {
         <div>
           <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--text-3)', fontFamily: 'var(--font-mono)', marginBottom: 3 }}>{week}</div>
           <h1 style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 24, letterSpacing: '-0.02em', margin: '0 0 10px' }}>이번 주, 잘 했어요</h1>
-          <DemoNotice storageKey="weekly-review">
-            주간 리뷰 집계는 백엔드 연동 전이라 예시 통계를 보여드려요.
-          </DemoNotice>
+          {!usingReal && (
+            <DemoNotice storageKey="weekly-review">
+              주간 리뷰 집계는 백엔드 연동 전이라 예시 통계를 보여드려요.
+            </DemoNotice>
+          )}
         </div>
 
         {/* Hero: Score donut */}
         <div style={{ background: 'linear-gradient(135deg, var(--coral-50) 0%, var(--surface-raised) 100%)', border: '1px solid var(--coral-200)', borderRadius: 18, padding: '14px 16px', display: 'flex', alignItems: 'center', gap: 14, minWidth: 0 }}>
-          <ScoreDonut score={scoreOutOf100} />
+          <ScoreDonut score={score} />
           <div style={{ flex: 1, minWidth: 0 }}>
             <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--coral-600)', fontFamily: 'var(--font-mono)', marginBottom: 3 }}>주간 점수</div>
             <div style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 15, letterSpacing: '-0.01em', color: 'var(--text-1)', lineHeight: 1.3, marginBottom: 5 }}>
-              지난 주보다 <span style={{ color: 'var(--brand)' }}>+12점</span> 좋아졌어요
+              {real?.oneLiner ?? <>지난 주보다 <span style={{ color: 'var(--brand)' }}>+12점</span> 좋아졌어요</>}
             </div>
             <p style={{ fontSize: 11, color: 'var(--text-2)', lineHeight: 1.5, margin: 0 }}>
-              <span className="tnum">{stats.hours}h</span> 실행 · 복구 <span style={{ color: 'var(--success)', fontWeight: 700 }} className="tnum">{stats.recovery}%</span> 성공
+              <span className="tnum">{stats.hours}h</span> 실행 · 복구 <span style={{ color: 'var(--success)', fontWeight: 700 }} className="tnum">{recoveryPct}%</span> 성공
             </p>
           </div>
         </div>

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -503,28 +503,81 @@ export interface FirstPlanApproveResponse {
   isDraft?: boolean;
 }
 
+// GET /plans/weekly (#21 구현됨) — 실제 contract.
+export interface WeeklyBlock {
+  blockId: string;
+  actionId: string;
+  title: string;
+  category: string;
+  source: string; // goal / habit / fixed 등
+  startAt: string; // KST ISO
+  endAt: string;   // KST ISO
+  blockStatus: string; // pending / done / failed 등
+}
+export interface WeeklyPlanDay {
+  date: string;    // YYYY-MM-DD
+  weekday: string; // mon..sun
+  blocks?: WeeklyBlock[];
+}
 export interface WeeklyPlanResponse {
+  planId: string;
   weekStart: string;
-  blocks: PlanScheduledBlock[];
-  workloadLevel?: WorkloadLevel;
+  weekEnd: string;
+  days: WeeklyPlanDay[];
 }
 
-export interface PlanBlockUpdate {
-  scheduledTime?: string;
-  durationMinutes?: number;
-  title?: string;
+// PATCH /plans/{planId}/blocks/{blockId} (#21)
+export interface BlockEditRequest {
+  startAt: string; // KST ISO
+  endAt?: string | null;
+}
+export interface BlockEditResponse {
+  blockId: string;
+  startAt: string;
+  endAt: string | null;
+  blockStatus?: string;
 }
 
-// ── Reviews (S21·S22) — 백엔드 501. api-contract §13 추정 ───────
-export interface WeeklyReview {
-  weekStart: string; // YYYY-MM-DD
-  adherenceRate: number; // 0~100
-  consistencyDays: number;
-  resilienceRate: number;
-  categorySuccessRate: Record<string, number>;
-  peakWindow: string | null;  // 예: "21:00-22:00"
-  drainWindow: string | null;
-  policyUpdateCandidates: string[];
+// ── Reviews (S21·S22) — GET /reviews/weekly (#21 구현됨) ───────
+export interface WeeklyReviewResponse {
+  weekStart: string;
+  weekEnd: string;
+  generatedAt: string;
+  oneLiner?: string | null;
+  adherenceRate?: number | null;
+  resilienceRate?: number | null;
+  restartSuccessRate?: number | null;
+  consistencyDays?: number | null;
+  averageRecoveryMinutes?: number | null;
+  avgDelayMinutes?: number | null;
+  repeatedFailureCount?: number | null;
+  categorySuccessRate?: Record<string, number> | null;
+  peakWindow?: string | null;
+  drainWindow?: string | null;
+  policyUpdateCandidates?: unknown[] | null;
+}
+export interface WeeklyGenerateRequest {
+  weekStart?: string;
+}
+export interface HabitWeekStat {
+  weekStart: string;
+  doneCount: number;
+  targetCount: number;
+}
+export interface HabitPenaltyCandidate {
+  habitId: string;
+  title: string;
+  currentFrequency: number;
+  suggestedFrequency: number;
+  message: string;
+  recentWeeks?: HabitWeekStat[];
+}
+export interface HabitPenaltyListResponse {
+  candidates?: HabitPenaltyCandidate[];
+}
+export interface HabitPenaltyAcceptResponse {
+  habitId: string;
+  newFrequency?: number;
 }
 
 // ── Settings / Privacy (S23·S28) — 백엔드 501. api-contract §16 ──


### PR DESCRIPTION
#37 이 감지한 #21 구현 엔드포인트(주간 보기/블록 수정/주간 리뷰) 실연동. 추정 타입을 실스키마로 교정(WeeklyPlanResponse=days[].blocks[], BlockEditRequest=startAt/endAt, WeeklyReviewResponse 등). WeeklyCalendar 실블록+PATCH, WeeklyReview hero 지표 override. 실데이터 시 더미 교체+DemoNotice 숨김. check:api(GONE 0)/tsc/build 통과. 🤖 Generated with Claude Code