### PR TITLE
chore(api): 백엔드 API 동기화 (routine)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2871,6 +2871,141 @@
         "title": "RefreshRequest",
         "type": "object"
       },
+      "ReplanApproveResponse": {
+        "description": "POST /replan/{executionId}/approve — 최종 적용 (명시 승인 → `is_draft=False`).\n\n회복 ActionItem 을 `scheduled_block`(source=`recovery`) 으로 배치한다. 멱등:\n이미 배치돼 있으면 같은 block 을 반환한다. 원본 `action_item.status` 불변.",
+        "properties": {
+          "actionItemId": {
+            "title": "Actionitemid",
+            "type": "string"
+          },
+          "endAt": {
+            "format": "date-time",
+            "title": "Endat",
+            "type": "string"
+          },
+          "executionId": {
+            "title": "Executionid",
+            "type": "string"
+          },
+          "isDraft": {
+            "default": false,
+            "title": "Isdraft",
+            "type": "boolean"
+          },
+          "scheduledBlockId": {
+            "title": "Scheduledblockid",
+            "type": "string"
+          },
+          "startAt": {
+            "format": "date-time",
+            "title": "Startat",
+            "type": "string"
+          }
+        },
+        "required": [
+          "executionId",
+          "scheduledBlockId",
+          "actionItemId",
+          "startAt",
+          "endAt"
+        ],
+        "title": "ReplanApproveResponse",
+        "type": "object"
+      },
+      "ReplanBlock": {
+        "description": "Replan diff 의 한 면(before/after) — 카드 1장 + 시간 배치 1건.\n\n`start_at`/`end_at` 은 응답 시 KST(+09:00). before 는 원본 실패 카드의 계획 시각,\nafter 는 회복 카드의 제안 시각(원본 시간대를 회복 target_date 로 그대로 이동).",
+        "properties": {
+          "actionItemId": {
+            "title": "Actionitemid",
+            "type": "string"
+          },
+          "endAt": {
+            "format": "date-time",
+            "title": "Endat",
+            "type": "string"
+          },
+          "estimatedMinutes": {
+            "title": "Estimatedminutes",
+            "type": "integer"
+          },
+          "startAt": {
+            "format": "date-time",
+            "title": "Startat",
+            "type": "string"
+          },
+          "targetDate": {
+            "format": "date",
+            "title": "Targetdate",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "actionItemId",
+          "title",
+          "targetDate",
+          "startAt",
+          "endAt",
+          "estimatedMinutes"
+        ],
+        "title": "ReplanBlock",
+        "type": "object"
+      },
+      "ReplanDiffResponse": {
+        "description": "GET /replan/{executionId} — S20 before/after 프리뷰 (Draft Layer).\n\n승인 전까지 `is_draft=True`. `already_approved=True` 면 이미 approve 로 블록이\n배치된 상태(멱등 재조회).",
+        "properties": {
+          "after": {
+            "$ref": "#/components/schemas/ReplanBlock"
+          },
+          "aiSource": {
+            "default": "llm",
+            "enum": [
+              "llm",
+              "rule"
+            ],
+            "title": "Aisource",
+            "type": "string"
+          },
+          "alreadyApproved": {
+            "default": false,
+            "title": "Alreadyapproved",
+            "type": "boolean"
+          },
+          "before": {
+            "$ref": "#/components/schemas/ReplanBlock"
+          },
+          "executionId": {
+            "title": "Executionid",
+            "type": "string"
+          },
+          "isDraft": {
+            "default": true,
+            "title": "Isdraft",
+            "type": "boolean"
+          },
+          "optionGroup": {
+            "enum": [
+              "DOWNSCOPE",
+              "RESCHEDULE",
+              "CARRY_OVER",
+              "PARK"
+            ],
+            "title": "Optiongroup",
+            "type": "string"
+          }
+        },
+        "required": [
+          "executionId",
+          "optionGroup",
+          "before",
+          "after"
+        ],
+        "title": "ReplanDiffResponse",
+        "type": "object"
+      },
       "ScheduledBlockPreview": {
         "description": "미리보기용 스케줄 블록 — DB scheduled_blocks 대응(미영속). 시각은 KST 응답.",
         "properties": {
@@ -6758,7 +6893,7 @@
     },
     "/replan/{execution_id}": {
       "get": {
-        "description": "S20 before/after diff — #20-B 후속.",
+        "description": "S20 before/after diff (Draft Layer) — 수락한 회복의 일정 변화 프리뷰 (#20-B).\n\nbefore = 원본 실패 카드의 계획 시각, after = 회복 카드의 제안 시각.\n이미 approve 로 블록이 배치됐으면 `alreadyApproved=true`.",
         "operationId": "get_replan_diff_replan__execution_id__get",
         "parameters": [
           {
@@ -6788,6 +6923,16 @@
           }
         ],
         "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReplanDiffResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
           "422": {
             "content": {
               "application/json": {
@@ -6797,14 +6942,6 @@
               }
             },
             "description": "Validation Error"
-          },
-          "501": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": "Successful Response"
           }
         },
         "summary": "Get Replan Diff",
@@ -6815,7 +6952,7 @@
     },
     "/replan/{execution_id}/approve": {
       "post": {
-        "description": "S20 최종 적용 (Idempotency) — #20-B 후속.",
+        "description": "S20 최종 적용 (Idempotency-Key 필수 — §1.7 미들웨어 enforce).\n\n회복 ActionItem 을 `scheduled_block`(source='recovery') 으로 배치한다. 멱등:\n이미 배치돼 있으면 같은 block 을 반환(중복 INSERT 방지). 원본 `action_item.status`\n는 변경하지 않는다 (AGENTS.md §2 — Resilience 지표 전제).",
         "operationId": "approve_replan_replan__execution_id__approve_post",
         "parameters": [
           {
@@ -6845,6 +6982,16 @@
           }
         ],
         "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReplanApproveResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
           "422": {
             "content": {
               "application/json": {
@@ -6854,14 +7001,6 @@
               }
             },
             "description": "Validation Error"
-          },
-          "501": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": "Successful Response"
           }
         },
         "summary": "Approve Replan",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -46,6 +46,7 @@ import type {
   RecoveryProposalsResponse,
   ReflectionBatchRequest,
   ReflectionPendingItem,
+  ReplanApproveResponse,
   ReplanDiff,
   SlotAnswerRequest,
   SlotCatalogEntry,
@@ -408,10 +409,11 @@ export const recoveryApi = {
 };
 
 export const replanApi = {
+  // GET /replan/{executionId} — before/after diff 프리뷰 (백엔드 #20-B 구현됨).
   diff: (executionId: string) => request<ReplanDiff>(`/replan/${executionId}`),
 
   approve: (executionId: string, idempotencyKey: string) =>
-    request<void>(`/replan/${executionId}/approve`, {
+    request<ReplanApproveResponse>(`/replan/${executionId}/approve`, {
       method: 'POST',
       body: {},
       idempotencyKey,

--- a/src/screens/RecoveredScreen.tsx
+++ b/src/screens/RecoveredScreen.tsx
@@ -1,9 +1,11 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { ArrowsClockwise, ArrowDown, XCircle, CheckCircle, Clock } from '@phosphor-icons/react';
 import { replanApi } from '../lib/api';
+import type { ReplanDiff } from '../types/api';
+import { DemoNotice } from '../components/DemoNotice';
 
 // 적용된 복구 내역 — RecoveryScreen 에서 사용자가 고른 제안 + 실패한 카드.
-// 백엔드 replan diff(501) 대신 클라이언트가 알고 있는 정보로 before→after 를 보여준다.
+// 백엔드 replan diff(#20-B) 가 응답하면 그 before/after 로 교체, 아니면 이 props 로 표시.
 export interface AppliedRecovery {
   taskTitle: string;
   failReason: string;
@@ -22,25 +24,55 @@ interface RecoveredScreenProps {
   executionId?: string;
 }
 
+// ISO date-time(KST +09:00) → "HH:MM–HH:MM" KST 표기. 런타임 TZ 와 무관하게 Asia/Seoul 고정.
+function formatKstRange(startAt: string, endAt: string): string {
+  try {
+    const fmt = (s: string) =>
+      new Date(s).toLocaleTimeString('ko-KR', {
+        timeZone: 'Asia/Seoul',
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: false,
+      });
+    return `${fmt(startAt)}–${fmt(endAt)}`;
+  } catch {
+    return '—';
+  }
+}
+
 export function RecoveredScreen({ recoveryCount, applied, onDone, executionId }: RecoveredScreenProps) {
-  // 진입 시 replan diff 조회 시도 — 실제 executionId 가 있을 때만.
-  // 백엔드 replan 미구현(501) 이면 props 의 applied 로 before→after 를 보여준다.
+  // mock-and-replace: 진입 시 replan diff 조회 — 실제 executionId 가 있을 때만.
+  // 백엔드(#20-B)가 before/after 를 주면 실데이터로 교체, 실패/없음이면 applied props fallback.
+  const [diff, setDiff] = useState<ReplanDiff | null>(null);
   useEffect(() => {
     if (!executionId) return;
     let cancelled = false;
     replanApi.diff(executionId).then(
-      (diff) => { if (!cancelled) { /* TODO(backend-#20-B): diff → AppliedRecovery 매핑 */ void diff; } },
-      () => { /* 501/미구현 ok — applied props 사용 */ },
+      (d) => { if (!cancelled && d?.before && d?.after) setDiff(d); },
+      () => { /* 미구현/오류 ok — applied props 사용 */ },
     );
     return () => { cancelled = true; };
   }, [executionId]);
 
+  // 표시 데이터: 백엔드 diff 가 있으면 우선, 없으면 클라이언트 applied.
+  const usingRealDiff = !!diff;
+  const view = diff
+    ? {
+        taskTitle: diff.before.title,
+        failReason: applied?.failReason ?? '',
+        proposalTitle: diff.after.title,
+        proposalDesc: applied?.proposalDesc ?? '',
+        proposalTime: formatKstRange(diff.after.startAt, diff.after.endAt),
+      }
+    : applied ?? null;
+
   const handleDone = () => {
     // 알겠어요 클릭 시 approve 시도 (Idempotency-Key). executionId 없으면 skip.
+    // 이미 approve 된(alreadyApproved) 경우에도 멱등이라 안전.
     if (executionId) {
       replanApi
         .approve(executionId, `replan-${Date.now()}`)
-        .catch(() => { /* 501/미구현 ok */ });
+        .catch(() => { /* 미구현/오류 ok */ });
     }
     onDone();
   };
@@ -53,15 +85,15 @@ export function RecoveredScreen({ recoveryCount, applied, onDone, executionId }:
       <div style={{ fontFamily: 'var(--font-display)', fontSize: 28, fontWeight: 500, letterSpacing: '-0.01em' }}>복구 계획이 준비됐어요</div>
 
       {/* Before → After — 무엇이 어떻게 바뀌었는지 한눈에. */}
-      {applied ? (
+      {view ? (
         <div style={{ width: '100%', maxWidth: 320, display: 'flex', flexDirection: 'column', gap: 8 }}>
           {/* BEFORE */}
           <div style={{ background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', borderRadius: 14, padding: '12px 14px', textAlign: 'left', display: 'flex', alignItems: 'flex-start', gap: 10 }}>
             <XCircle size={18} color="var(--danger)" style={{ flexShrink: 0, marginTop: 1 }} />
             <div style={{ flex: 1, minWidth: 0 }}>
               <div style={{ fontSize: 9, fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--text-3)', fontFamily: 'var(--font-mono)', marginBottom: 3 }}>이전</div>
-              <div style={{ fontSize: 14, fontWeight: 700, color: 'var(--text-2)', textDecoration: 'line-through', textDecorationColor: 'var(--sand-300)' }}>{applied.taskTitle}</div>
-              {applied.failReason && <div style={{ fontSize: 11, color: 'var(--text-3)', marginTop: 2 }}>막힌 이유: {applied.failReason}</div>}
+              <div style={{ fontSize: 14, fontWeight: 700, color: 'var(--text-2)', textDecoration: 'line-through', textDecorationColor: 'var(--sand-300)' }}>{view.taskTitle}</div>
+              {view.failReason && <div style={{ fontSize: 11, color: 'var(--text-3)', marginTop: 2 }}>막힌 이유: {view.failReason}</div>}
             </div>
           </div>
 
@@ -72,15 +104,28 @@ export function RecoveredScreen({ recoveryCount, applied, onDone, executionId }:
             <CheckCircle size={18} weight="fill" color="var(--brand)" style={{ flexShrink: 0, marginTop: 1 }} />
             <div style={{ flex: 1, minWidth: 0 }}>
               <div style={{ fontSize: 9, fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--coral-600)', fontFamily: 'var(--font-mono)', marginBottom: 3 }}>이렇게 다시</div>
-              <div style={{ fontSize: 14, fontWeight: 700, color: 'var(--text-1)' }}>{applied.proposalTitle}</div>
-              {applied.proposalDesc && <div style={{ fontSize: 12, color: 'var(--coral-700)', marginTop: 2, lineHeight: 1.5 }}>{applied.proposalDesc}</div>}
-              {applied.proposalTime && applied.proposalTime !== '—' && (
+              <div style={{ fontSize: 14, fontWeight: 700, color: 'var(--text-1)' }}>{view.proposalTitle}</div>
+              {view.proposalDesc && <div style={{ fontSize: 12, color: 'var(--coral-700)', marginTop: 2, lineHeight: 1.5 }}>{view.proposalDesc}</div>}
+              {view.proposalTime && view.proposalTime !== '—' && (
                 <div style={{ display: 'inline-flex', alignItems: 'center', gap: 4, marginTop: 6, height: 'var(--ctrl-xs)', padding: '0 8px', background: 'var(--surface-raised)', border: '1px solid var(--coral-200)', borderRadius: 9999, fontSize: 10, fontWeight: 600, color: 'var(--coral-700)' }}>
-                  <Clock size={10} weight="fill" /> {applied.proposalTime}
+                  <Clock size={10} weight="fill" /> {view.proposalTime}
                 </div>
               )}
             </div>
           </div>
+
+          {/* 백엔드 diff 가 응답하면 실제 일정 반영 확정, 아니면 미리보기임을 정직하게 알림. */}
+          {usingRealDiff ? (
+            <div style={{ display: 'inline-flex', alignItems: 'center', gap: 5, alignSelf: 'flex-start', marginTop: 2, fontSize: 10, fontWeight: 700, color: 'var(--success)', fontFamily: 'var(--font-mono)' }}>
+              <CheckCircle size={12} weight="fill" /> 실제 일정에 반영됐어요
+            </div>
+          ) : (
+            <div style={{ marginTop: 2 }}>
+              <DemoNotice storageKey="replan-diff">
+                바뀐 시간표는 백엔드 연동 전이라 미리보기예요. 연동되면 실제 일정으로 확정됩니다.
+              </DemoNotice>
+            </div>
+          )}
         </div>
       ) : (
         <p style={{ fontSize: 15, color: 'var(--text-2)', maxWidth: 260, lineHeight: 1.6, margin: 0 }}>10분 뒤에 알려드릴게요. 그 사이엔 폰을 잠시 내려놔도 좋아요.</p>

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -409,19 +409,38 @@ export interface RecoveryDecisionResponse {
   isDraft?: boolean;
 }
 
-export interface ReplanDiffBlock {
-  blockId: string;
+// GET /replan/{executionId} — S20 before/after diff (Draft Layer, 백엔드 #20-B 구현됨).
+// diff 의 한 면. start_at/end_at 은 KST(+09:00). before = 원본 실패 카드의 계획 시각,
+// after = 회복 카드의 제안 시각(원본 시간대를 회복 target_date 로 이동).
+export interface ReplanBlock {
+  actionItemId: string;
   title: string;
-  scheduledTime: string | null;
-  durationMinutes: number;
-  carryover?: boolean;
+  targetDate: string; // date (YYYY-MM-DD)
+  startAt: string; // date-time
+  endAt: string; // date-time
+  estimatedMinutes: number;
 }
 
 export interface ReplanDiff {
   executionId: string;
-  beforeBlocks: ReplanDiffBlock[];
-  afterBlocks: ReplanDiffBlock[];
-  summary: string;
+  optionGroup: 'DOWNSCOPE' | 'RESCHEDULE' | 'CARRY_OVER' | 'PARK';
+  before: ReplanBlock;
+  after: ReplanBlock;
+  // 아래 셋은 스키마 default 가 있어 응답에 항상 포함되지만 안전하게 optional.
+  aiSource?: 'llm' | 'rule';
+  alreadyApproved?: boolean;
+  isDraft?: boolean;
+}
+
+// POST /replan/{executionId}/approve — 최종 적용 (Idempotency-Key 필수).
+// 회복 ActionItem 을 scheduled_block(source=recovery) 으로 배치. 멱등.
+export interface ReplanApproveResponse {
+  executionId: string;
+  scheduledBlockId: string;
+  actionItemId: string;
+  startAt: string; // date-time
+  endAt: string; // date-time
+  isDraft?: boolean;
 }
 
 // ── Plans (S16) — 주간 보기/블록 수정은 아직 contract 추정(미구현) ──

--- a/src/types/openapi.d.ts
+++ b/src/types/openapi.d.ts
@@ -1000,7 +1000,10 @@ export interface paths {
         };
         /**
          * Get Replan Diff
-         * @description S20 before/after diff — #20-B 후속.
+         * @description S20 before/after diff (Draft Layer) — 수락한 회복의 일정 변화 프리뷰 (#20-B).
+         *
+         *     before = 원본 실패 카드의 계획 시각, after = 회복 카드의 제안 시각.
+         *     이미 approve 로 블록이 배치됐으면 `alreadyApproved=true`.
          */
         get: operations["get_replan_diff_replan__execution_id__get"];
         put?: never;
@@ -1022,7 +1025,11 @@ export interface paths {
         put?: never;
         /**
          * Approve Replan
-         * @description S20 최종 적용 (Idempotency) — #20-B 후속.
+         * @description S20 최종 적용 (Idempotency-Key 필수 — §1.7 미들웨어 enforce).
+         *
+         *     회복 ActionItem 을 `scheduled_block`(source='recovery') 으로 배치한다. 멱등:
+         *     이미 배치돼 있으면 같은 block 을 반환(중복 INSERT 방지). 원본 `action_item.status`
+         *     는 변경하지 않는다 (AGENTS.md §2 — Resilience 지표 전제).
          */
         post: operations["approve_replan_replan__execution_id__approve_post"];
         delete?: never;
@@ -2579,6 +2586,100 @@ export interface components {
         RefreshRequest: {
             /** Refreshtoken */
             refreshToken: string;
+        };
+        /**
+         * ReplanApproveResponse
+         * @description POST /replan/{executionId}/approve — 최종 적용 (명시 승인 → `is_draft=False`).
+         *
+         *     회복 ActionItem 을 `scheduled_block`(source=`recovery`) 으로 배치한다. 멱등:
+         *     이미 배치돼 있으면 같은 block 을 반환한다. 원본 `action_item.status` 불변.
+         */
+        ReplanApproveResponse: {
+            /** Actionitemid */
+            actionItemId: string;
+            /**
+             * Endat
+             * Format: date-time
+             */
+            endAt: string;
+            /** Executionid */
+            executionId: string;
+            /**
+             * Isdraft
+             * @default false
+             */
+            isDraft: boolean;
+            /** Scheduledblockid */
+            scheduledBlockId: string;
+            /**
+             * Startat
+             * Format: date-time
+             */
+            startAt: string;
+        };
+        /**
+         * ReplanBlock
+         * @description Replan diff 의 한 면(before/after) — 카드 1장 + 시간 배치 1건.
+         *
+         *     `start_at`/`end_at` 은 응답 시 KST(+09:00). before 는 원본 실패 카드의 계획 시각,
+         *     after 는 회복 카드의 제안 시각(원본 시간대를 회복 target_date 로 그대로 이동).
+         */
+        ReplanBlock: {
+            /** Actionitemid */
+            actionItemId: string;
+            /**
+             * Endat
+             * Format: date-time
+             */
+            endAt: string;
+            /** Estimatedminutes */
+            estimatedMinutes: number;
+            /**
+             * Startat
+             * Format: date-time
+             */
+            startAt: string;
+            /**
+             * Targetdate
+             * Format: date
+             */
+            targetDate: string;
+            /** Title */
+            title: string;
+        };
+        /**
+         * ReplanDiffResponse
+         * @description GET /replan/{executionId} — S20 before/after 프리뷰 (Draft Layer).
+         *
+         *     승인 전까지 `is_draft=True`. `already_approved=True` 면 이미 approve 로 블록이
+         *     배치된 상태(멱등 재조회).
+         */
+        ReplanDiffResponse: {
+            after: components["schemas"]["ReplanBlock"];
+            /**
+             * Aisource
+             * @default llm
+             * @enum {string}
+             */
+            aiSource: "llm" | "rule";
+            /**
+             * Alreadyapproved
+             * @default false
+             */
+            alreadyApproved: boolean;
+            before: components["schemas"]["ReplanBlock"];
+            /** Executionid */
+            executionId: string;
+            /**
+             * Isdraft
+             * @default true
+             */
+            isDraft: boolean;
+            /**
+             * Optiongroup
+             * @enum {string}
+             */
+            optionGroup: "DOWNSCOPE" | "RESCHEDULE" | "CARRY_OVER" | "PARK";
         };
         /**
          * ScheduledBlockPreview
@@ -4774,6 +4875,15 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ReplanDiffResponse"];
+                };
+            };
             /** @description Validation Error */
             422: {
                 headers: {
@@ -4781,15 +4891,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-            /** @description Successful Response */
-            501: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
                 };
             };
         };
@@ -4807,6 +4908,15 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ReplanApproveResponse"];
+                };
+            };
             /** @description Validation Error */
             422: {
                 headers: {
@@ -4814,15 +4924,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-            /** @description Successful Response */
-            501: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
                 };
             };
         };


### PR DESCRIPTION
백엔드(`hanium-reaction/reaction-backend`) OpenAPI 를 다시 덤프해 프론트 타입·래퍼·화면에 반영한 정기 동기화입니다.

## (a) 신규/변경 엔드포인트
경로/메서드 집합은 변화 없음(61개 동일). **응답 스키마**가 바뀐 곳이 핵심입니다:

- `GET /replan/{executionId}` — **501 stub → 200 구현**. 응답이 빈 스키마에서 `ReplanDiffResponse`(before/after diff, Draft Layer)로 바뀜.
- `POST /replan/{executionId}/approve` — **501 stub → 200 구현**. 응답이 `ReplanApproveResponse`(scheduled_block 배치 결과, Idempotency-Key 필수)로 바뀜.
- 신규 스키마 추가: `ReplanBlock`, `ReplanDiffResponse`, `ReplanApproveResponse`.

## (b) 화면 실연동
- **RecoveredScreen (복구 계획 준비됨)**: mock-and-replace 로 `replanApi.diff(executionId)` 의 백엔드 before/after 를 실연동.
  - 백엔드 diff 응답 시 → `before.title`/`after.title`/`after.startAt~endAt`(KST) 로 화면 교체 + “실제 일정에 반영됐어요” 확정 표시.
  - 미응답·미구현·`executionId` 없음 시 → 기존 `applied` props 로 fallback(데모 안 깨짐) + DemoNotice 노출.
- 추정 타입 교정: `ReplanDiff`/`ReplanBlock`/`ReplanApproveResponse` 를 실스키마(camelCase)로 교체, `replanApi.approve` 반환 타입 `void → ReplanApproveResponse`.

## (c) check:api 요약
```
openapi 경로 61개 · api.ts 호출 67개
✅ OK   64   (백엔드 구현됨, 메서드 일치)
⚠️ WARN  3   today focus pause/resume, reflection/pending (백엔드 미구현 — UI 그대로 유지)
❌ GONE  0   (계약 위반 없음)
🆕 NEW  10   (openapi 에 있으나 래퍼 없음 — 이번 변경과 무관, 백로그)
결과: PASS
```

검증 게이트 모두 통과: `check:api` GONE 0 · `tsc --noEmit` 클린 · `npm run build` 성공.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014QcKR95zpwc63kKKiWFx2s)_