### PR TITLE
feat(today,recovery): G3 — 실패→회복 루프 실 API 배선

### DIFF
--- a/src/app/ReActionMerged.tsx
+++ b/src/app/ReActionMerged.tsx
@@ -19,6 +19,7 @@ import { EveningCheckInScreen } from '../screens/EveningCheckInScreen';
 import { WeeklyCalendarScreenV2 } from '../screens/WeeklyCalendarScreen';
 import { WeeklyReviewScreenV2 } from '../screens/WeeklyReviewScreen';
 import { BASE_TASKS, MERGED_PROPOSALS } from '../data';
+import { todayApi, reflectionApi } from '../lib/api';
 import { useNavigation } from '../contexts/NavigationContext';
 import type { ScreenId, TabId, Task } from '../types';
 
@@ -110,10 +111,23 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
       : t
     ));
 
-  const markFailed = (id: string, reason: string) => {
-    setTasks((ts) => ts.map((t) => t.id === id ? { ...t, status: 'failed', failReason: reason } : t));
-    setActiveTask(tasks.find((t) => t.id === id) || null);
-    setFailReason(reason);
+  // 실패 기록 — "실패를 데이터로 기억"의 실연동(G3). 낙관적 UI 먼저, 네트워크는 뒤.
+  // 실 actionItemId + tagCode 가 있고 첫 실패면: start → check-in(failed) → tagExecution.
+  // 더미 카드(actionItemId 없음)거나 백엔드 오류면 조용히 로컬 흐름만(데모 안전).
+  const markFailed = async (id: string, tagCode: string, label: string) => {
+    const t = tasks.find((x) => x.id === id) ?? null;
+    setTasks((ts) => ts.map((x) => x.id === id ? { ...x, status: 'failed', failReason: label || x.failReason } : x));
+    setFailReason(label || t?.failReason || '');
+    let executionId = t?.executionId;
+    if (t?.actionItemId && !executionId && tagCode) {
+      try {
+        const started = await todayApi.start(t.actionItemId);
+        executionId = started.executionId;
+        await todayApi.checkIn({ executionId, completionStatus: 'failed' }, crypto.randomUUID());
+        await reflectionApi.tagExecution(executionId, { tagCodes: [tagCode] });
+      } catch { /* 데모 안전: 백엔드 미동작이어도 화면 흐름 유지 */ }
+    }
+    setActiveTask(t ? { ...t, status: 'failed', failReason: label || t.failReason, executionId } : null);
     setScreen('recovery');
   };
 
@@ -208,6 +222,7 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
             onFail={markFailed}
             onOpenRecovery={openRecovery}
             onEvening={() => setScreen('evening')}
+            onTasksLoaded={setTasks}
           />
         )}
         {screen === 'focus' && activeTask && (

--- a/src/screens/RecoveryScreen.tsx
+++ b/src/screens/RecoveryScreen.tsx
@@ -64,10 +64,12 @@ export function MergedRecoveryScreen({ task, failReason, onAccept, onDismiss }: 
     );
   }
 
-  // mock-and-replace: 진입 시 LLM 회복 제안 생성 시도. 백엔드 501 → 더미 그대로.
+  // mock-and-replace: 진입 시 LLM 회복 제안 생성 시도. 백엔드 미연동/오류 → 더미 그대로.
+  // executionId 는 실패 체크인(start→check-in)에서 발급된 실 id. 더미 task 면 task.id 로 폴백.
+  const executionId = task.executionId ?? task.id;
   useEffect(() => {
     let cancelled = false;
-    recoveryApi.generateProposals(task.id).then(
+    recoveryApi.generateProposals(executionId).then(
       (res) => {
         if (cancelled) return;
         // 실데이터 매핑: cards 가 있으면 더미를 실제 복구 카드로 교체.
@@ -79,20 +81,18 @@ export function MergedRecoveryScreen({ task, failReason, onAccept, onDismiss }: 
       () => { /* 미구현/오류 — 더미 그대로 */ },
     );
     return () => { cancelled = true; };
-  }, [task]);
+  }, [executionId]);
 
   const accept = () => {
     if (!sel) return;
-    // mock-and-replace: 사용자 선택 저장 시도. Idempotency-Key 동봉.
-    // sel 은 데모 제안 id — 실제 백엔드 attemptId 매핑(backend-#20) 전까지 그대로 전달.
-    if (task) {
-      recoveryApi
-        .decide(
-          { executionId: task.id, decision: 'accept', acceptedAttemptId: sel },
-          `rec-${task.id}-${sel}`,
-        )
-        .catch(() => { /* 미구현/오류 ok — 데모 흐름 유지 */ });
-    }
+    // 사용자 선택 저장. Idempotency-Key 동봉. 실데이터면 sel = 실 attemptId(cardToProposal),
+    // 더미면 MERGED_PROPOSALS id. executionId 도 실/더미 동일 폴백. 실패해도 데모 흐름 유지.
+    recoveryApi
+      .decide(
+        { executionId, decision: 'accept', acceptedAttemptId: sel },
+        `rec-${executionId}-${sel}`,
+      )
+      .catch(() => { /* 미구현/오류 ok — 데모 흐름 유지 */ });
     setAccepted(true);
     setTimeout(() => onAccept(sel), 1400);
   };

--- a/src/screens/TodayScreen.tsx
+++ b/src/screens/TodayScreen.tsx
@@ -65,17 +65,7 @@ interface MergedTodayScreenProps {
   onTasksLoaded?: (tasks: Task[]) => void;
 }
 
-// "14:30" → "오후 2:30" (HH:MM 24h → 한글 오전/오후). 없으면 '—'.
-function fmtTime(hhmm: string | null): string {
-  if (!hhmm) return '—';
-  const [h, m] = hhmm.split(':').map(Number);
-  if (Number.isNaN(h)) return hhmm;
-  const ampm = h < 12 ? '오전' : '오후';
-  const h12 = h % 12 === 0 ? 12 : h % 12;
-  return `${ampm} ${h12}:${String(m || 0).padStart(2, '0')}`;
-}
-
-// 백엔드 ActionItem.status → 화면 TaskStatus (알 수 없으면 todo).
+// 백엔드 AgendaCard.status → 화면 TaskStatus (알 수 없으면 todo).
 function mapActionStatus(s: string): Task['status'] {
   switch (s) {
     case 'done': return 'done';
@@ -176,18 +166,15 @@ export function MergedTodayScreen({ tasks, onOpen, onMarkDone, onPartial, onFail
     let cancelled = false;
     todayApi.agenda().then(
       (agenda) => {
-        if (cancelled || !agenda.actions?.length || !onTasksLoaded) return;
+        if (cancelled || !agenda.cards?.length || !onTasksLoaded) return;
         onTasksLoaded(
-          agenda.actions.map((a) => ({
-            id: a.actionItemId,
-            actionItemId: a.actionItemId,
-            title: a.title,
-            status: mapActionStatus(a.status),
-            time: fmtTime(a.scheduledTime),
-            dur: `${a.durationMinutes}분`,
-            goal: a.goalId ?? undefined,
-            carryover: a.carryover,
-            failReason: a.failReason ?? undefined,
+          agenda.cards.map((c) => ({
+            id: c.actionId,            // 실 actionItemId — 실패→회복 루프의 키
+            actionItemId: c.actionId,
+            title: c.title,
+            status: mapActionStatus(c.status),
+            time: '—',                // ⚠️ agenda 카드엔 시각 없음(estimatedMinutes 만)
+            dur: `${c.estimatedMinutes}분`,
           })),
         );
       },

--- a/src/screens/TodayScreen.tsx
+++ b/src/screens/TodayScreen.tsx
@@ -57,9 +57,33 @@ interface MergedTodayScreenProps {
   onOpen: (id: string) => void;
   onMarkDone: (id: string) => void;
   onPartial: (id: string, pct: number) => void;
-  onFail: (id: string, reason: string) => void;
+  // tagCode = 백엔드 실패 태그 코드(예 'AMBIGUITY'), label = 화면 표시용. 더미면 tagCode=''.
+  onFail: (id: string, tagCode: string, label: string) => void;
   onOpenRecovery: () => void;
   onEvening: () => void;
+  // /today/agenda 실데이터를 Task[] 로 매핑해 상위(tasks 소유자)로 끌어올린다.
+  onTasksLoaded?: (tasks: Task[]) => void;
+}
+
+// "14:30" → "오후 2:30" (HH:MM 24h → 한글 오전/오후). 없으면 '—'.
+function fmtTime(hhmm: string | null): string {
+  if (!hhmm) return '—';
+  const [h, m] = hhmm.split(':').map(Number);
+  if (Number.isNaN(h)) return hhmm;
+  const ampm = h < 12 ? '오전' : '오후';
+  const h12 = h % 12 === 0 ? 12 : h % 12;
+  return `${ampm} ${h12}:${String(m || 0).padStart(2, '0')}`;
+}
+
+// 백엔드 ActionItem.status → 화면 TaskStatus (알 수 없으면 todo).
+function mapActionStatus(s: string): Task['status'] {
+  switch (s) {
+    case 'done': return 'done';
+    case 'failed': return 'failed';
+    case 'partial_done': return 'partial_done';
+    case 'in_progress': return 'in_progress';
+    default: return 'todo';
+  }
 }
 
 function Ring({ task }: { task: Task }) {
@@ -141,23 +165,36 @@ function todayShortKo(): string {
   return `${d.getMonth() + 1}월 ${d.getDate()}일 · ${days[d.getDay()]}요일`;
 }
 
-export function MergedTodayScreen({ tasks, onOpen, onMarkDone, onPartial, onFail, onOpenRecovery, onEvening }: MergedTodayScreenProps) {
+export function MergedTodayScreen({ tasks, onOpen, onMarkDone, onPartial, onFail, onOpenRecovery, onEvening, onTasksLoaded }: MergedTodayScreenProps) {
   const { user } = useNavigation();
   const userName = user?.name ?? '친구';
 
-  // mock-and-replace: /today/agenda 가 현재 백엔드에서 501. 채워지면 응답을
-  // tasks 로 매핑할 자리. 실패는 조용히 — 더미 흐름을 끊지 않는다.
+  // mock-and-replace: /today/agenda 실데이터가 오면 Task[] 로 매핑해 상위로 끌어올린다.
+  // 실 actionItemId 가 task.id 가 되어 실패→회복 루프(start/check-in/tag/recovery)가 진짜로 동작.
+  // 실패/빈 응답이면 조용히 — 더미(BASE_TASKS) 흐름을 끊지 않는다(데모 안전).
   useEffect(() => {
     let cancelled = false;
     todayApi.agenda().then(
       (agenda) => {
-        if (cancelled) return;
-        // TODO(backend-#19): agenda.actions → Task[] 매핑 + setTasks 갱신
-        void agenda;
+        if (cancelled || !agenda.actions?.length || !onTasksLoaded) return;
+        onTasksLoaded(
+          agenda.actions.map((a) => ({
+            id: a.actionItemId,
+            actionItemId: a.actionItemId,
+            title: a.title,
+            status: mapActionStatus(a.status),
+            time: fmtTime(a.scheduledTime),
+            dur: `${a.durationMinutes}분`,
+            goal: a.goalId ?? undefined,
+            carryover: a.carryover,
+            failReason: a.failReason ?? undefined,
+          })),
+        );
       },
       () => { /* 501/네트워크 — 더미 그대로 */ },
     );
     return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const [failSheet, setFailSheet] = useState<string | null>(null);
@@ -170,12 +207,19 @@ export function MergedTodayScreen({ tasks, onOpen, onMarkDone, onPartial, onFail
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [failReason, setFailReason] = useState('');
   const [toast, setToast] = useState<string | null>(null);
-  // 실패 사유 목록 — 백엔드 실패 태그 카탈로그(#17)가 오면 그 labelKo 로, 없으면 더미.
-  const [failReasons, setFailReasons] = useState<string[]>(FAIL_REASONS);
+  // 실패 사유 목록 — 백엔드 실패 태그 카탈로그(#17)가 오면 {tagCode,label}, 없으면 더미(code 빈값).
+  // tagCode 는 실패 기록(reflectionApi.tagExecution)에 필요하므로 label 과 함께 보존한다.
+  const [failReasons, setFailReasons] = useState<{ code: string; label: string }[]>(
+    FAIL_REASONS.map((label) => ({ code: '', label })),
+  );
   useEffect(() => {
     let cancelled = false;
     reflectionApi.failureTags().then(
-      (tags) => { if (!cancelled && tags.length) setFailReasons(tags.map((t) => t.labelKo)); },
+      (tags) => {
+        if (!cancelled && tags.length) {
+          setFailReasons(tags.map((t) => ({ code: t.tagCode, label: t.labelKo })));
+        }
+      },
       () => { /* 미구현/오류 — 더미 그대로 */ },
     );
     return () => { cancelled = true; };
@@ -253,7 +297,8 @@ export function MergedTodayScreen({ tasks, onOpen, onMarkDone, onPartial, onFail
 
   const submitFail = () => {
     if (!failReason || !failSheet) return;
-    onFail(failSheet, failReason);
+    const picked = failReasons.find((r) => r.label === failReason);
+    onFail(failSheet, picked?.code ?? '', failReason);
     setFailSheet(null);
     setFailReason('');
   };
@@ -326,7 +371,7 @@ export function MergedTodayScreen({ tasks, onOpen, onMarkDone, onPartial, onFail
                 task={t}
                 // 대기/진행 row 클릭 = hero 로 promote (실제 시작 X)
                 onSelect={() => setSelectedTaskId(t.id)}
-                onFailedRecover={() => onFail(t.id, t.failReason || '')}
+                onFailedRecover={() => onFail(t.id, '', t.failReason || '')}
                 onPartialRecover={onOpenRecovery}
               />
             ))}
@@ -407,7 +452,7 @@ export function MergedTodayScreen({ tasks, onOpen, onMarkDone, onPartial, onFail
             <p style={{ fontSize: 12, color: 'var(--text-3)', marginBottom: 14 }}>이유를 기록하면 더 잘 맞는 복구안을 제안해드려요.</p>
             <div style={{ display: 'flex', flexDirection: 'column', gap: 6, marginBottom: 14 }}>
               {failReasons.map((r) => (
-                <button key={r} onClick={() => setFailReason(r)} style={{ padding: '12px 14px', borderRadius: 12, textAlign: 'left', background: failReason === r ? 'var(--text-1)' : 'var(--surface-raised)', color: failReason === r ? '#FAF6EE' : 'var(--text-1)', border: `1px solid ${failReason === r ? 'var(--text-1)' : 'var(--sand-200)'}`, fontSize: 14, fontWeight: 500, cursor: 'pointer', fontFamily: 'inherit', transition: 'all 160ms' }}>{r}</button>
+                <button key={r.label} onClick={() => setFailReason(r.label)} style={{ padding: '12px 14px', borderRadius: 12, textAlign: 'left', background: failReason === r.label ? 'var(--text-1)' : 'var(--surface-raised)', color: failReason === r.label ? '#FAF6EE' : 'var(--text-1)', border: `1px solid ${failReason === r.label ? 'var(--text-1)' : 'var(--sand-200)'}`, fontSize: 14, fontWeight: 500, cursor: 'pointer', fontFamily: 'inherit', transition: 'all 160ms' }}>{r.label}</button>
               ))}
             </div>
             <button onClick={submitFail} disabled={!failReason} style={{ width: '100%', height: 44, borderRadius: 12, border: 'none', background: 'var(--text-1)', color: '#FAF6EE', fontWeight: 700, fontSize: 14, fontFamily: 'inherit', cursor: 'pointer', opacity: failReason ? 1 : 0.35 }}>기록하고 복구안 보기</button>

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -271,9 +271,23 @@ export interface ActionItem {
   failReason?: string | null;
 }
 
+// S10 어젠다 카드(조회 표현) — 백엔드 AgendaCard. ⚠️ 시각(scheduledTime) 없음, estimatedMinutes 만.
+export interface AgendaCard {
+  actionId: string;
+  title: string;
+  category: string;
+  status: string;
+  priority: number;
+  estimatedMinutes: number;
+  source: string;
+  whyNow: string | null;
+  firstStep: string | null;
+}
+
 export interface TodayAgenda {
-  brief: DailyBrief;
-  actions: ActionItem[];
+  date: string;
+  brief: DailyBrief | null;
+  cards: AgendaCard[];
   habits: HabitInstance[];
   fixedSchedules: FixedSchedule[];
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -46,6 +46,10 @@ export interface Task {
   progress?: number;
   failReason?: string;
   tag?: { tone: ChipTone; label: string };
+  // 백엔드 연동용 — agenda 매핑 시 실 actionItemId, 실패 체크인 후 executionId.
+  // 더미(BASE_TASKS)에는 없으며, 없으면 회복 루프가 mock 으로 동작(데모 안전).
+  actionItemId?: string;
+  executionId?: string;
 }
 
 export interface Goal {


### PR DESCRIPTION
## G3 — 실패→회복 루프 실 API 배선 (데모 크리티컬)

데모 시나리오의 핵심("어제 실패한 GROUP BY가 5분 카드로 다시 태어남")에서, **실패 기록과 새 카드 생성 2-hop 이 mock** 이던 것을 실 API로 배선했습니다. 백엔드(#53·#54)는 이미 실연동·테스트 완료였고, **FE가 그걸 데모 경로에서 호출하지 않던 것**이 유일한 갭이었습니다.

> ⚠️ **Draft — 장준혁(choigod1023) 검토 요청.** PM이 데모 일정 때문에 먼저 배선했습니다. 본인 도메인이니 검토 후 조정/흡수해주세요.

### 무엇이 바뀌었나
| 파일 | 변경 |
|---|---|
| `types/index.ts` | `Task` 에 `actionItemId?`·`executionId?` 추가 (더미엔 없음) |
| `screens/TodayScreen.tsx` | `/today/agenda` → `Task[]` 매핑 후 `onTasksLoaded` 로 상위에 끌어올림(실 id 확보). 실패 사유 칩이 `tagCode` 보존. 빈/실패 응답 시 `BASE_TASKS` 폴백 |
| `app/ReActionMerged.tsx` | `markFailed` 가 `start → check-in('failed') → tagExecution` 실호출 + `executionId` 보관. `onTasksLoaded={setTasks}` 연결 |
| `screens/RecoveryScreen.tsx` | `generateProposals`/`decide` 가 `task.id`(=actionItemId) 대신 **`task.executionId`** 사용 |

### 동작
1. Today가 agenda 실데이터를 받으면 `task.id = 실 actionItemId`
2. [못함] + 사유칩 → `start`→`check-in(failed)`→`tagExecution(tagCode)` → **실패가 DB에 기록**
3. Recovery 카드 = `generateProposals(executionId)` 실 LLM/룰 응답
4. [수락] → `decide(executionId, attemptId)` → 백엔드가 새 ActionItem 생성
5. Today 복귀 시 agenda 재조회 → **새 5분 카드 등장**

### 데모 안전
- 전 hop `try/catch` + mock 폴백 유지 → **백엔드 없이도 화면 안 끊김**
- 더미 카드(actionItemId 없음)는 기존 mock 흐름 그대로
- `tsc && vite build` 통과

### 후속(검토 포인트)
- `RecoveredScreen` before→after 카드가 **실데이터일 때 제목이 일반값** — 새 ActionItem 생성은 정상이나, 표시 개선하려면 `onAccept` 로 선택 제안을 넘기면 됨
- `acceptRecovery` 의 로컬 `status:'done'` 마킹은 복귀 시 agenda 재조회로 덮어써짐(원본은 서버에서 failed 유지)
- 실 DB E2E는 staging 에서 1회 필요(G7 리허설)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
