### PR TITLE
feat: 라이브 백엔드 실데이터 연동 + 정직한 빈/미연결 상태 구분

### DIFF
--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -14,6 +14,7 @@ export function AppShell() {
   const [onboardingState, setOnboardingState] = useState<OnboardingState | null>(null);
   const [isBootstrapping, setIsBootstrapping] = useState(true);
   const [weekOffset, setWeekOffset] = useState(0);
+  const [interviewSessionId, setInterviewSessionId] = useState<string | null>(null);
 
   // 부팅 — /auth/me 로 사용자 상태 확인 후 진입 화면 결정.
   // dev/시연 편의: ?force=goal-intake 같은 쿼리로 강제 override 가능.
@@ -105,7 +106,7 @@ export function AppShell() {
 
   return (
     <NavigationContext.Provider
-      value={{ screen, tab, setScreen, setTab, user, onboardingState, isBootstrapping, weekOffset, setWeekOffset }}
+      value={{ screen, tab, setScreen, setTab, user, onboardingState, isBootstrapping, weekOffset, setWeekOffset, interviewSessionId, setInterviewSessionId }}
     >
       <ToastProvider>
         {/* ── 모바일 (< 1024px): 단일 컬럼 ── */}

--- a/src/contexts/NavigationContext.tsx
+++ b/src/contexts/NavigationContext.tsx
@@ -17,6 +17,10 @@ export interface NavigationContextType {
   // 주간 리뷰의 "다음 주 계획 확인" 이 1 로 세팅 후 weekly 로 이동한다.
   weekOffset: number;
   setWeekOffset: (n: number) => void;
+  // 온보딩 인터뷰(S02)에서 만든 세션 id. weekly-plan(S06) 의 /plans/generate 가
+  // interviewSessionId 로 실제 계획을 생성할 때 사용한다. 인터뷰 전이면 null.
+  interviewSessionId: string | null;
+  setInterviewSessionId: (id: string | null) => void;
 }
 
 export const NavigationContext = createContext<NavigationContextType>({
@@ -29,6 +33,8 @@ export const NavigationContext = createContext<NavigationContextType>({
   isBootstrapping: false,
   weekOffset: 0,
   setWeekOffset: () => {},
+  interviewSessionId: null,
+  setInterviewSessionId: () => {},
 });
 
 export const useNavigation = () => useContext(NavigationContext);

--- a/src/screens/EveningCheckInScreen.tsx
+++ b/src/screens/EveningCheckInScreen.tsx
@@ -19,12 +19,14 @@ export function EveningCheckInScreen({ onDone }: EveningCheckInScreenProps) {
   const [step, setStep] = useState(0);
   const [energy, setEnergy] = useState<number | null>(null);
 
-  // mock-and-replace: 최종 step 진입 시 /reflection/batch 일괄 처리 호출 시도.
-  // 백엔드 501 이라 실패는 조용히, 더미 흐름은 그대로.
+  // 최종 step 진입 시 /reflection/batch 일괄 처리 호출 시도(best-effort).
+  // 이 엔드포인트는 아직 백엔드 미구현(404)이라 실패는 조용히 무시하고 화면 흐름은 유지.
+  // 이 화면은 에너지 1종만 수집하고 executionId·completionStatus 가 없어
+  // /today/check-ins 로는 깔끔히 매핑되지 않으므로 정직 배너를 유지한다.
   useEffect(() => {
     if (step !== 2) return;
     const idempotencyKey = `evening-${Date.now()}`;
-    reflectionApi.batch({ items: [] }, idempotencyKey).catch(() => { /* 501 ok */ });
+    reflectionApi.batch({ items: [] }, idempotencyKey).catch(() => { /* 미구현(404) ok */ });
   }, [step]);
 
   if (step === 2) {
@@ -41,7 +43,7 @@ export function EveningCheckInScreen({ onDone }: EveningCheckInScreenProps) {
         </div>
         <div style={{ width: '100%' }}>
           <DemoNotice storageKey="evening-batch">
-            회고 일괄 저장은 백엔드 연동 전이라 아직 서버에 기록되지 않아요.
+            저녁 회고 일괄 저장 기능은 아직 서버에서 준비 중이에요. 입력은 임시 저장돼요.
           </DemoNotice>
         </div>
         <button onClick={onDone} style={{ width: '100%', height: 44, borderRadius: 12, border: 'none', background: 'var(--text-1)', color: '#FAF6EE', fontWeight: 700, fontSize: 14, fontFamily: 'inherit', cursor: 'pointer' }}>주간 계획 보기 →</button>

--- a/src/screens/GoalIntakeScreen.tsx
+++ b/src/screens/GoalIntakeScreen.tsx
@@ -3,6 +3,7 @@ import { Sparkle, ArrowUp, ArrowRight } from '@phosphor-icons/react';
 import { ApiError, interviewApi } from '../lib/api';
 import type { InterviewQuestion, InterviewSession, SlotCatalogEntry } from '../types/api';
 import { SetupProgress } from '../components/SetupProgress';
+import { useNavigation } from '../contexts/NavigationContext';
 
 interface GoalIntakeScreenProps {
   onDone: () => void;
@@ -35,6 +36,8 @@ function omxStatus(clarity: number) {
 }
 
 export function GoalIntakeScreen({ onDone }: GoalIntakeScreenProps) {
+  // 인터뷰 세션 id 를 전역에 올려, weekly-plan(S06) 에서 /plans/generate 가 쓸 수 있게 한다.
+  const { setInterviewSessionId } = useNavigation();
   const [session, setSession] = useState<InterviewSession | null>(null);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [inputText, setInputText] = useState('');
@@ -83,6 +86,7 @@ export function GoalIntakeScreen({ onDone }: GoalIntakeScreenProps) {
         if (cancelled) return;
         initialAmbiguity.current = s.ambiguityScore || REQUIRED_SLOTS_INIT;
         setSession(s);
+        setInterviewSessionId(s.sessionId);
         if (s.currentQuestion) {
           setMessages([{ id: newMsgId('ai'), who: 'ai', text: s.currentQuestion.text }]);
         }

--- a/src/screens/RecoveredScreen.tsx
+++ b/src/screens/RecoveredScreen.tsx
@@ -122,7 +122,7 @@ export function RecoveredScreen({ recoveryCount, applied, onDone, executionId }:
           ) : (
             <div style={{ marginTop: 2 }}>
               <DemoNotice storageKey="replan-diff">
-                바뀐 시간표는 백엔드 연동 전이라 미리보기예요. 연동되면 실제 일정으로 확정됩니다.
+                이 회복 미리보기는 실제 실행에 연결되면 일정에 반영돼요.
               </DemoNotice>
             </div>
           )}

--- a/src/screens/RecoveryScreen.tsx
+++ b/src/screens/RecoveryScreen.tsx
@@ -43,9 +43,13 @@ interface MergedRecoveryScreenProps {
   failReason?: string;
   onAccept: (optionId: string) => void;
   onDismiss: () => void;
+  // 시작/실패한 실제 실행의 executionId. 데모 task 엔 없으므로 optional.
+  // 있으면 백엔드 LLM 회복 제안(POST /recovery/proposals/generate)과 연동한다.
+  // task.id 는 task id 일 뿐 executionId 가 아니라서 그것으로는 호출하지 않는다.
+  executionId?: string;
 }
 
-export function MergedRecoveryScreen({ task, failReason, onAccept, onDismiss }: MergedRecoveryScreenProps) {
+export function MergedRecoveryScreen({ task, failReason, onAccept, onDismiss, executionId }: MergedRecoveryScreenProps) {
   const [sel, setSel] = useState<string | null>(null);
   const [showWhy, setShowWhy] = useState<string | null>(null);
   const [accepted, setAccepted] = useState(false);
@@ -64,34 +68,38 @@ export function MergedRecoveryScreen({ task, failReason, onAccept, onDismiss }: 
     );
   }
 
-  // mock-and-replace: 진입 시 LLM 회복 제안 생성 시도. 백엔드 501 → 더미 그대로.
+  // 진입 시 LLM 회복 제안 생성 시도 — 단, 실제 executionId 가 있을 때만.
+  // 엔드포인트는 구현돼 있으나 실제 실행(executionId)을 요구하므로, 데모 task 처럼
+  // executionId 가 없으면 호출하지 않고 예시안(MERGED_PROPOSALS)을 유지한다.
   useEffect(() => {
+    if (!executionId) return;
     let cancelled = false;
-    recoveryApi.generateProposals(task.id).then(
+    recoveryApi.generateProposals(executionId).then(
       (res) => {
         if (cancelled) return;
-        // 실데이터 매핑: cards 가 있으면 더미를 실제 복구 카드로 교체.
+        // 실데이터 매핑: cards 가 있으면 예시안을 실제 복구 카드로 교체(배너 숨김).
         if (res.cards?.length) {
           setProposals(res.cards.map(cardToProposal));
           setUsingRealProposals(true);
         }
       },
-      () => { /* 미구현/오류 — 더미 그대로 */ },
+      () => { /* 오류 — 예시안 그대로 */ },
     );
     return () => { cancelled = true; };
-  }, [task]);
+  }, [executionId]);
 
   const accept = () => {
     if (!sel) return;
-    // mock-and-replace: 사용자 선택 저장 시도. Idempotency-Key 동봉.
-    // sel 은 데모 제안 id — 실제 백엔드 attemptId 매핑(backend-#20) 전까지 그대로 전달.
-    if (task) {
+    // 사용자 선택 저장 — 실제 executionId 가 있을 때만(없으면 task.id 는 executionId 가
+    // 아니라 백엔드에서 실패하므로 호출하지 않는다). usingRealProposals 면 sel 은 실제
+    // attemptId 이므로 그대로 전달. Idempotency-Key 동봉.
+    if (executionId) {
       recoveryApi
         .decide(
-          { executionId: task.id, decision: 'accept', acceptedAttemptId: sel },
-          `rec-${task.id}-${sel}`,
+          { executionId, decision: 'accept', acceptedAttemptId: sel },
+          `rec-${executionId}-${sel}`,
         )
-        .catch(() => { /* 미구현/오류 ok — 데모 흐름 유지 */ });
+        .catch(() => { /* 오류 ok — 흐름 유지 */ });
     }
     setAccepted(true);
     setTimeout(() => onAccept(sel), 1400);
@@ -136,7 +144,7 @@ export function MergedRecoveryScreen({ task, failReason, onAccept, onDismiss }: 
           {!usingRealProposals && (
             <div style={{ marginBottom: 14 }}>
               <DemoNotice storageKey="recovery-proposals">
-                AI 복구 제안은 백엔드 연동 전이라 예시안을 보여드려요.
+                이 복구 제안은 예시예요. 실제 실행 중 막혔을 때 켜지는 AI 제안과 연동됩니다.
               </DemoNotice>
             </div>
           )}

--- a/src/screens/TodayScreen.tsx
+++ b/src/screens/TodayScreen.tsx
@@ -6,7 +6,8 @@ import {
   X,
   Trash,
 } from '@phosphor-icons/react';
-import type { Task } from '../types';
+import type { Task, TaskStatus } from '../types';
+import type { AgendaCard } from '../types/api';
 import { FAIL_REASONS } from '../data';
 import { useNavigation } from '../contexts/NavigationContext';
 import { habitsApi, reflectionApi, todayApi } from '../lib/api';
@@ -134,6 +135,34 @@ function thisMonday(): string {
   return d.toISOString().slice(0, 10);
 }
 
+// 백엔드 AgendaCard.status(string) → 화면 Task.status. 'pending' 은 'todo' 로,
+// 나머지 6종은 그대로 매핑. 모르는 값은 안전하게 'todo'.
+function actionStatusToTaskStatus(s: string): TaskStatus {
+  switch (s) {
+    case 'in_progress':
+    case 'done':
+    case 'partial_done':
+    case 'failed':
+    case 'recovery_pending':
+      return s;
+    case 'pending':
+    default:
+      return 'todo';
+  }
+}
+
+// /today/agenda 의 AgendaCard → 화면 Task 베스트에포트 매핑.
+// AgendaCard 에는 예약시각/이월/실패사유 필드가 없다 (estimatedMinutes·category 만 사용).
+function actionToTask(a: AgendaCard): Task {
+  return {
+    id: a.actionId,
+    title: a.title,
+    status: actionStatusToTaskStatus(a.status),
+    dur: a.estimatedMinutes ? `${a.estimatedMinutes}분` : undefined,
+    goal: a.category || undefined,
+  };
+}
+
 // "5월 24일 · 일요일" — Today 헤더용
 function todayShortKo(): string {
   const d = new Date();
@@ -141,21 +170,33 @@ function todayShortKo(): string {
   return `${d.getMonth() + 1}월 ${d.getDate()}일 · ${days[d.getDay()]}요일`;
 }
 
-export function MergedTodayScreen({ tasks, onOpen, onMarkDone, onPartial, onFail, onOpenRecovery, onEvening }: MergedTodayScreenProps) {
+export function MergedTodayScreen({ tasks: dummyTasks, onOpen, onMarkDone, onPartial, onFail, onOpenRecovery, onEvening }: MergedTodayScreenProps) {
   const { user } = useNavigation();
   const userName = user?.name ?? '친구';
 
-  // mock-and-replace: /today/agenda 가 현재 백엔드에서 501. 채워지면 응답을
-  // tasks 로 매핑할 자리. 실패는 조용히 — 더미 흐름을 끊지 않는다.
+  // 화면이 렌더하는 실제 task 목록. 기본은 부모가 내려준 더미(BASE_TASKS).
+  // /today/agenda 가 성공하면 실데이터로 교체한다.
+  const [tasks, setTasks] = useState<Task[]>(dummyTasks);
+  // agenda fetch 성공 = 백엔드 연결됨. 빈 응답이어도 true (연결 ≠ 데이터 존재).
+  const [usingRealAgenda, setUsingRealAgenda] = useState(false);
+
+  // 실데이터를 아직 못 받았을 때만 부모의 더미 변경(완료/부분/실패 등)을 반영.
+  // 실데이터로 전환된 뒤엔 부모 더미를 무시한다.
+  useEffect(() => {
+    if (!usingRealAgenda) setTasks(dummyTasks);
+  }, [dummyTasks, usingRealAgenda]);
+
+  // /today/agenda 연동. 성공 시 actions → Task[] 매핑(빈 배열이어도 연결로 간주),
+  // 실패 시 더미 유지(usingRealAgenda=false).
   useEffect(() => {
     let cancelled = false;
     todayApi.agenda().then(
       (agenda) => {
         if (cancelled) return;
-        // TODO(backend-#19): agenda.actions → Task[] 매핑 + setTasks 갱신
-        void agenda;
+        setUsingRealAgenda(true);
+        setTasks((agenda.cards ?? []).map(actionToTask));
       },
-      () => { /* 501/네트워크 — 더미 그대로 */ },
+      () => { /* 네트워크/오류 — 더미 그대로, usingRealAgenda=false */ },
     );
     return () => { cancelled = true; };
   }, []);
@@ -301,9 +342,15 @@ export function MergedTodayScreen({ tasks, onOpen, onMarkDone, onPartial, onFail
           </div>
         </div>
 
-        <DemoNotice storageKey="today-agenda">
-          오늘 할 일 목록은 백엔드 연동 전이라 예시예요. 습관 추적은 실제로 저장됩니다.
-        </DemoNotice>
+        {!usingRealAgenda ? (
+          <DemoNotice storageKey="today-agenda">
+            오늘 일정을 서버에서 불러오지 못했어요. 예시를 표시 중이에요.
+          </DemoNotice>
+        ) : tasks.length === 0 ? (
+          <div style={{ padding: '10px 12px', borderRadius: 12, background: 'var(--surface-raised)', border: '1px dashed var(--sand-200)', fontSize: 12, color: 'var(--text-2)', lineHeight: 1.5 }}>
+            오늘 등록된 일정이 없어요. 주간 계획에서 일정을 추가하면 여기에 표시돼요.
+          </div>
+        ) : null}
 
         {/* Hero — 지금 할 일. row 에서 promote 한 카드 또는 진행 중 카드. */}
         <HeroTaskCard

--- a/src/screens/WeeklyCalendarScreen.tsx
+++ b/src/screens/WeeklyCalendarScreen.tsx
@@ -171,13 +171,12 @@ export function WeeklyCalendarScreenV2() {
       (res) => {
         if (cancelled) return;
         planIdRef.current = res.planId;
-        const mapped = weeklyToBlocks(res);
-        if (mapped.length) {
-          setBlocks(mapped);
-          setUsingRealPlan(true);
-        }
+        // 200 응답 = 백엔드 연동 성공. 블록이 0개여도 '예시'가 아니라
+        // '아직 계획 없음'인 실데이터다 — 더미로 가리지 않고 그대로 교체한다.
+        setBlocks(weeklyToBlocks(res));
+        setUsingRealPlan(true);
       },
-      () => { /* 미구현/네트워크 — 더미 유지 */ },
+      () => { /* 네트워크/오류 — 더미 유지 + '예시' 배너 */ },
     );
     return () => { cancelled = true; };
   }, [weekStartStr]);
@@ -424,13 +423,17 @@ export function WeeklyCalendarScreenV2() {
           <span style={{ fontSize: 9, fontFamily: 'var(--font-mono)', color: 'var(--text-3)', letterSpacing: '0.08em' }}>{weekLabel}</span>
         </div>
         <p style={{ fontSize: 11, color: 'var(--text-3)', margin: '0 0 8px' }}>블록을 탭하면 수정, 길게 누른 채 끌면 15분 단위로 이동돼요.</p>
-        {!usingRealPlan && (
+        {!usingRealPlan ? (
           <div style={{ marginBottom: 8 }}>
             <DemoNotice storageKey="weekly-calendar">
-              주간 계획은 백엔드 연동 전이라 예시예요. 편집은 임시 저장되며 서버 연결 후 동기화됩니다.
+              주간 계획을 서버에서 불러오지 못했어요. 예시를 표시 중이며, 편집은 임시 저장돼요.
             </DemoNotice>
           </div>
-        )}
+        ) : blocks.length === 0 ? (
+          <div style={{ marginBottom: 8, padding: '10px 12px', borderRadius: 12, background: 'var(--surface-raised)', border: '1px dashed var(--sand-200)', fontSize: 12, color: 'var(--text-2)', lineHeight: 1.5 }}>
+            이번 주에 등록된 계획이 없어요. 온보딩에서 주간 계획을 생성하면 여기에 표시돼요.
+          </div>
+        ) : null}
         <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
           {[
             { label: '완료', n: blocks.filter((b) => b.status === 'done').length, bg: '#E5EFE3', bd: '#b4dfc8', fg: 'var(--success)' },

--- a/src/screens/WeeklyPlanGenerationScreen.tsx
+++ b/src/screens/WeeklyPlanGenerationScreen.tsx
@@ -5,8 +5,9 @@ import { SetupProgress } from '../components/SetupProgress';
 import { AiDraftCard } from '../components/AiDraftCard';
 import { DemoNotice } from '../components/DemoNotice';
 import { plansApi } from '../lib/api';
+import { useNavigation } from '../contexts/NavigationContext';
 import type { Block } from '../types';
-import type { ScheduledBlockPreview } from '../types/api';
+import type { FirstPlanGenerateRequest, ScheduledBlockPreview } from '../types/api';
 
 // 백엔드 ScheduledBlockPreview(start/end KST ISO) → 화면 Block(day/time/dur).
 function previewToBlock(b: ScheduledBlockPreview, i: number): Block {
@@ -115,26 +116,41 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
   const [generating, setGenerating] = useState(true);
   // 백엔드 실제 플랜이 들어왔는지 — true 면 더미가 아니라 진짜 데이터.
   const [usingRealPlan, setUsingRealPlan] = useState(false);
+  // 라이브 호출을 실제로 시도했으나 실패했는지 — 배너 문구를 정직하게 맞추는 용도.
+  const [genFailed, setGenFailed] = useState(false);
   const planIdRef = React.useRef<string | null>(null);
 
-  // mock-and-replace: /plans/generate 시도. 501 → 더미 시뮬레이션.
+  // POST /plans/generate 는 outcome 또는 interviewSessionId 중 하나가 필수다(빈 본문 → 422).
+  // 온보딩 인터뷰(S02)에서 만든 sessionId 를 GoalIntakeScreen 이 NavigationContext 에
+  // 올려두므로(setInterviewSessionId), 이 화면이 진입할 땐 이미 채워져 있다.
+  //   → sessionId 가 있으면 실연동 호출, 없으면(인터뷰 건너뜀) 예시 유지.
+  const { interviewSessionId } = useNavigation();
+  const generateInput: FirstPlanGenerateRequest | null = interviewSessionId
+    ? { interviewSessionId }
+    : null;
+
+  // /plans/generate 실연동: 유효 입력이 있으면 호출해 실데이터로 더미를 교체.
   // useCallback 으로 빼서 진입 시 + AiDraftCard 재생성 버튼에서 재사용.
   const generatePlan = React.useCallback(() => {
     setGenerating(true);
+    setGenFailed(false);
     const minDelay = new Promise<void>((r) => setTimeout(r, 1400));
-    const fetchPlan = plansApi.generate().then(
-      (plan) => {
-        planIdRef.current = plan.planId;
-        // 실데이터 매핑: blocks 가 있으면 더미를 진짜 플랜으로 교체. 없으면 더미 유지.
-        if (plan.blocks?.length) {
-          setBlocks(plan.blocks.map(previewToBlock));
-          setUsingRealPlan(true);
-        }
-      },
-      () => { /* 미구현/네트워크 — 더미 그대로 */ },
-    );
+    // 유효 입력이 없으면 422 가 보장된 호출을 보내지 않고 더미를 유지한다.
+    const fetchPlan: Promise<void> = generateInput
+      ? plansApi.generate(generateInput).then(
+          (plan) => {
+            planIdRef.current = plan.planId;
+            // 실데이터 매핑: blocks 가 있으면 더미를 진짜 플랜으로 교체. 없으면 더미 유지.
+            if (plan.blocks?.length) {
+              setBlocks(plan.blocks.map(previewToBlock));
+              setUsingRealPlan(true);
+            }
+          },
+          () => { setGenFailed(true); /* 네트워크/422 등 — 더미 유지, 배너로 정직하게 알림 */ },
+        )
+      : Promise.resolve();
     Promise.all([minDelay, fetchPlan]).finally(() => setGenerating(false));
-  }, []);
+  }, [interviewSessionId]);
 
   useEffect(() => {
     generatePlan();
@@ -195,7 +211,9 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
         <p style={{ fontSize: 12, color: 'var(--text-2)', margin: '0 0 8px' }}>블록을 탭하면 수정할 수 있어요.</p>
         {!usingRealPlan && (
           <DemoNotice storageKey="weekly-plan-gen">
-            AI 계획 생성은 백엔드 연동 전이라 예시 시간표를 보여드려요. 수정·추가는 정상 동작합니다.
+            {genFailed
+              ? 'AI 계획을 서버에서 생성하지 못했어요. 예시 시간표를 표시 중이에요. 수정·추가는 정상 동작합니다.'
+              : 'AI 자동 계획은 인터뷰 세션 정보가 연결돼야 생성돼요. 지금은 예시 시간표를 보여드려요. 수정·추가는 정상 동작합니다.'}
           </DemoNotice>
         )}
       </div>

--- a/src/screens/WeeklyReviewScreen.tsx
+++ b/src/screens/WeeklyReviewScreen.tsx
@@ -148,7 +148,10 @@ export function WeeklyReviewScreenV2() {
     return () => { cancelled = true; };
   }, []);
 
+  // 성공 응답이면(필드가 모두 null이어도) 연동된 것으로 본다. 실패(catch)일 때만 false.
   const usingReal = !!real;
+  // 연동은 됐지만 이번 주 집계할 활동이 없어 KPI가 비어있는 상태.
+  const connectedEmpty = usingReal && real?.adherenceRate == null;
   const score = toPct(real?.adherenceRate) ?? scoreOutOf100;
   const recoveryPct = toPct(real?.resilienceRate) ?? stats.recovery;
 
@@ -178,11 +181,15 @@ export function WeeklyReviewScreenV2() {
         <div>
           <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--text-3)', fontFamily: 'var(--font-mono)', marginBottom: 3 }}>{week}</div>
           <h1 style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 24, letterSpacing: '-0.02em', margin: '0 0 10px' }}>이번 주, 잘 했어요</h1>
-          {!usingReal && (
+          {!usingReal ? (
             <DemoNotice storageKey="weekly-review">
-              주간 리뷰 집계는 백엔드 연동 전이라 예시 통계를 보여드려요.
+              주간 리뷰를 서버에서 불러오지 못했어요. 예시 통계를 표시 중이에요.
             </DemoNotice>
-          )}
+          ) : connectedEmpty ? (
+            <div style={{ border: '1px dashed var(--sand-200)', borderRadius: 12, padding: '12px 14px', fontSize: 12, color: 'var(--text-3)', lineHeight: 1.5 }}>
+              이번 주는 아직 집계할 활동이 없어요. 주간 계획을 실행하면 리뷰가 채워져요.
+            </div>
+          ) : null}
         </div>
 
         {/* Hero: Score donut */}
@@ -226,7 +233,9 @@ export function WeeklyReviewScreenV2() {
           </div>
         )}
 
-        {/* KPI grid — 실데이터 모드면 백엔드 지표로, 아니면 더미 */}
+        {/* KPI grid — 실데이터 모드면 백엔드 지표로, 아니면 더미.
+            연동됐지만 지표가 비어있으면(connectedEmpty) 더미 KPI를 노출하지 않는다. */}
+        {(!usingReal || realKpi.length > 0) && (
         <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }}>
           {kpiData.map((k, i) => {
             const pctOfTarget = Math.min((k.val / (k.unit === '분' ? 30 : 100)) * 100, 100);
@@ -252,6 +261,7 @@ export function WeeklyReviewScreenV2() {
             );
           })}
         </div>
+        )}
 
         {/* 실패 이유 분해 — 백엔드 리뷰가 사유별 집계를 주지 않아 실데이터 모드에선 숨김. */}
         {!usingReal && (

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -271,9 +271,24 @@ export interface ActionItem {
   failReason?: string | null;
 }
 
+// GET /today/agenda 의 카드 1건 (백엔드 AgendaCard 스키마와 정렬).
+// 주의: scheduledTime/durationMinutes 같은 필드는 없다 — estimatedMinutes 만 있다.
+export interface AgendaCard {
+  actionId: string;
+  title: string;
+  category: string;
+  status: string;
+  priority: number;
+  estimatedMinutes: number;
+  source: string;
+  whyNow: string | null;
+  firstStep: string | null;
+}
+
 export interface TodayAgenda {
-  brief: DailyBrief;
-  actions: ActionItem[];
+  date: string;
+  brief: DailyBrief | null;
+  cards: AgendaCard[];
   habits: HabitInstance[];
   fixedSchedules: FixedSchedule[];
 }


### PR DESCRIPTION
## 요약
프론트의 더미/하드코딩 화면들을 Render에 배포된 실제 백엔드(`/today/agenda`, `/plans/generate`, `/reviews/weekly` 등)에 연동하고, **연결됐지만 데이터가 없는 상태**를 **미연결**로 오인하던 문제를 바로잡았습니다.

## 변경
- **Today**: `/today/agenda` 의 `cards` → 화면 `Task` 매핑. `TodayAgenda`/`AgendaCard` 타입을 런타임 스키마(`cards`, `estimatedMinutes` …)에 정렬 (기존 `actions`/`scheduledTime` 드리프트 수정).
- **WeeklyCalendar · WeeklyReview**: 200 성공이면 '연동됨'으로 처리. 빈 데이터를 '예시(연동 전)'로 표기하던 게이팅 버그 수정 → 거짓 배너 대신 "아직 ~없어요" empty-state.
- **WeeklyPlanGeneration**: 온보딩 인터뷰 `sessionId` 를 `NavigationContext` 로 올려(`AppShell`/`GoalIntakeScreen` 배선) `/plans/generate` 실연동. 인터뷰 완료 시 실제 주간 계획 생성.
- **Recovery · Recovered · Evening**: 실제 `executionId` 가 있을 때만 실연동 호출. 백엔드가 연결됐는데 "연동 전"이라 표기하던 오해성 문구 정직화. (`/reflection/pending` 은 백엔드 미구현이라 정직한 준비중 안내 유지.)

## 검증
- `tsc + vite build` 통과
- API 계약 체크(`check:api`) PASS — 위반(GONE) 0
- 라이브 백엔드 end-to-end 확인: 로그인 → `/auth/me`·`/goals`·`/today/agenda`·`/reviews/weekly` 200, 인터뷰 → `/plans/generate {interviewSessionId}` 200(실제 planId)

## 비고
- 전부 프론트(`reaction-frontend`)만 수정. 백엔드 변경 없음.
- 백엔드는 Render 임시 배포(`reaction-backend-lgwb.onrender.com`, Supabase DB), 데모용 `AUTH_STUB_MODE=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)