### PR TITLE
feat: 로딩 스켈레톤 + 인터뷰 세션 409 이어하기

### DIFF
--- a/src/screens/GoalIntakeScreen.tsx
+++ b/src/screens/GoalIntakeScreen.tsx
@@ -80,19 +80,47 @@ export function GoalIntakeScreen({ onDone }: GoalIntakeScreenProps) {
   useEffect(() => {
     let cancelled = false;
     setIsTyping(true);
-    interviewApi
-      .start()
-      .then((s) => {
-        if (cancelled) return;
-        initialAmbiguity.current = s.ambiguityScore || REQUIRED_SLOTS_INIT;
-        setSession(s);
-        setInterviewSessionId(s.sessionId);
-        if (s.currentQuestion) {
-          setMessages([{ id: newMsgId('ai'), who: 'ai', text: s.currentQuestion.text }]);
-        }
-      })
+    // 백엔드는 유저당 인터뷰 1개만 허용한다(중복 start → 409 INTERVIEW_SESSION_EXISTS).
+    // 그래서 만든 세션 id 를 저장해 두고, 재진입/409 시 그 id 로 이어간다(resume).
+    const STORE_KEY = 'reaction.interviewSessionId';
+    const stored =
+      (typeof window !== 'undefined' && window.localStorage.getItem(STORE_KEY)) || null;
+
+    const applySession = (s: InterviewSession) => {
+      if (cancelled) return;
+      if (typeof window !== 'undefined') window.localStorage.setItem(STORE_KEY, s.sessionId);
+      initialAmbiguity.current = s.ambiguityScore || REQUIRED_SLOTS_INIT;
+      setSession(s);
+      setInterviewSessionId(s.sessionId);
+      if (s.currentQuestion) {
+        setMessages([{ id: newMsgId('ai'), who: 'ai', text: s.currentQuestion.text }]);
+      }
+    };
+
+    // 저장된 세션이 '진행 중'이면 이어가고, 끝났거나 없으면 새로 시작한다.
+    const resumeOrStart: Promise<InterviewSession> = stored
+      ? interviewApi.get(stored).then(
+          (s) => (s.endReason == null && s.currentQuestion ? s : interviewApi.start()),
+          () => interviewApi.start(),
+        )
+      : interviewApi.start();
+
+    resumeOrStart
+      .then(applySession)
       .catch((err: unknown) => {
         if (cancelled) return;
+        // 409: 이미 진행 중인 세션이 있다. 저장된 id 로 이어가 본다.
+        if (err instanceof ApiError && err.code === 'INTERVIEW_SESSION_EXISTS') {
+          if (stored) {
+            interviewApi.get(stored).then(applySession, () => {
+              if (!cancelled) setError('이미 진행 중인 인터뷰가 있어요. 잠시 후 다시 시도하거나 아래에서 다음 단계로 넘어가 주세요.');
+            });
+          } else {
+            // 우리가 만든 적 없는(id 모르는) 세션이 남아있음 — 친절히 안내하고 진행을 막지 않는다.
+            setError('이미 진행 중인 인터뷰가 있어요. 잠시 후 자동 정리돼요. 아래에서 다음 단계로 넘어가 주세요.');
+          }
+          return;
+        }
         const msg =
           err instanceof ApiError
             ? `[${err.code}] ${err.message}`
@@ -247,8 +275,12 @@ export function GoalIntakeScreen({ onDone }: GoalIntakeScreenProps) {
       {/* Chat feed */}
       <div ref={bodyRef} style={{ flex: 1, overflowY: 'auto', padding: '14px 16px', display: 'flex', flexDirection: 'column', gap: 10 }}>
         {error && (
-          <div style={{ background: '#FAE2D8', border: '1px solid var(--coral-200)', color: 'var(--coral-700)', borderRadius: 10, padding: '10px 12px', fontSize: 12 }}>
-            {error}
+          <div style={{ background: '#FAE2D8', border: '1px solid var(--coral-200)', color: 'var(--coral-700)', borderRadius: 10, padding: '10px 12px', fontSize: 12, display: 'flex', flexDirection: 'column', gap: 8 }}>
+            <span>{error}</span>
+            {/* 인터뷰 시작/이어가기가 막혀도(예: 기존 세션 409) 온보딩을 진행할 수 있게 한다. */}
+            <button onClick={onDone} style={{ alignSelf: 'flex-start', height: 'var(--ctrl-sm)', padding: '0 12px', borderRadius: 9999, border: '1px solid var(--coral-200)', background: 'var(--surface-raised)', color: 'var(--coral-700)', fontSize: 12, fontWeight: 700, fontFamily: 'inherit', cursor: 'pointer', display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+              다음 단계로 넘어가기 <ArrowRight size={12} />
+            </button>
           </div>
         )}
         {messages.map((m) => (

--- a/src/screens/TodayScreen.tsx
+++ b/src/screens/TodayScreen.tsx
@@ -179,6 +179,8 @@ export function MergedTodayScreen({ tasks: dummyTasks, onOpen, onMarkDone, onPar
   const [tasks, setTasks] = useState<Task[]>(dummyTasks);
   // agenda fetch 성공 = 백엔드 연결됨. 빈 응답이어도 true (연결 ≠ 데이터 존재).
   const [usingRealAgenda, setUsingRealAgenda] = useState(false);
+  // 첫 agenda fetch 가 settle 되기 전엔 더미가 깜빡이지 않도록 스켈레톤만 노출.
+  const [agendaLoading, setAgendaLoading] = useState(true);
 
   // 실데이터를 아직 못 받았을 때만 부모의 더미 변경(완료/부분/실패 등)을 반영.
   // 실데이터로 전환된 뒤엔 부모 더미를 무시한다.
@@ -197,7 +199,7 @@ export function MergedTodayScreen({ tasks: dummyTasks, onOpen, onMarkDone, onPar
         setTasks((agenda.cards ?? []).map(actionToTask));
       },
       () => { /* 네트워크/오류 — 더미 그대로, usingRealAgenda=false */ },
-    );
+    ).finally(() => { if (!cancelled) setAgendaLoading(false); });
     return () => { cancelled = true; };
   }, []);
 
@@ -342,42 +344,50 @@ export function MergedTodayScreen({ tasks: dummyTasks, onOpen, onMarkDone, onPar
           </div>
         </div>
 
-        {!usingRealAgenda ? (
-          <DemoNotice storageKey="today-agenda">
-            오늘 일정을 서버에서 불러오지 못했어요. 예시를 표시 중이에요.
-          </DemoNotice>
-        ) : tasks.length === 0 ? (
-          <div style={{ padding: '10px 12px', borderRadius: 12, background: 'var(--surface-raised)', border: '1px dashed var(--sand-200)', fontSize: 12, color: 'var(--text-2)', lineHeight: 1.5 }}>
-            오늘 등록된 일정이 없어요. 주간 계획에서 일정을 추가하면 여기에 표시돼요.
-          </div>
-        ) : null}
+        {/* 첫 agenda fetch 가 끝나기 전엔 더미→실데이터 깜빡임을 막기 위해 스켈레톤만 노출.
+            배너·hero·task row 는 모두 fetch 결과에 의존하므로 함께 가린다. */}
+        {agendaLoading ? (
+          <AgendaSkeleton />
+        ) : (
+          <>
+            {!usingRealAgenda ? (
+              <DemoNotice storageKey="today-agenda">
+                오늘 일정을 서버에서 불러오지 못했어요. 예시를 표시 중이에요.
+              </DemoNotice>
+            ) : tasks.length === 0 ? (
+              <div style={{ padding: '10px 12px', borderRadius: 12, background: 'var(--surface-raised)', border: '1px dashed var(--sand-200)', fontSize: 12, color: 'var(--text-2)', lineHeight: 1.5 }}>
+                오늘 등록된 일정이 없어요. 주간 계획에서 일정을 추가하면 여기에 표시돼요.
+              </div>
+            ) : null}
 
-        {/* Hero — 지금 할 일. row 에서 promote 한 카드 또는 진행 중 카드. */}
-        <HeroTaskCard
-          task={heroTask}
-          done={doneTasks.length}
-          total={tasks.length}
-          onComplete={() => heroTask && (onMarkDone(heroTask.id), showToast('완료!'))}
-          onPartial={() => heroTask && setPartialSheet(heroTask.id)}
-          onFail={() => heroTask && (setFailSheet(heroTask.id), setFailReason(''))}
-          onStart={(id) => onOpen(id)}
-        />
+            {/* Hero — 지금 할 일. row 에서 promote 한 카드 또는 진행 중 카드. */}
+            <HeroTaskCard
+              task={heroTask}
+              done={doneTasks.length}
+              total={tasks.length}
+              onComplete={() => heroTask && (onMarkDone(heroTask.id), showToast('완료!'))}
+              onPartial={() => heroTask && setPartialSheet(heroTask.id)}
+              onFail={() => heroTask && (setFailSheet(heroTask.id), setFailReason(''))}
+              onStart={(id) => onOpen(id)}
+            />
 
-        {/* 나머지 카드 — 모두 한 줄 row 통일. hero 에 떠 있는 카드는 제외. */}
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-          {tasks
-            .filter((t) => t.id !== heroTask?.id)
-            .map((t) => (
-              <TaskRow
-                key={t.id}
-                task={t}
-                // 대기/진행 row 클릭 = hero 로 promote (실제 시작 X)
-                onSelect={() => setSelectedTaskId(t.id)}
-                onFailedRecover={() => onFail(t.id, t.failReason || '')}
-                onPartialRecover={onOpenRecovery}
-              />
-            ))}
-        </div>
+            {/* 나머지 카드 — 모두 한 줄 row 통일. hero 에 떠 있는 카드는 제외. */}
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+              {tasks
+                .filter((t) => t.id !== heroTask?.id)
+                .map((t) => (
+                  <TaskRow
+                    key={t.id}
+                    task={t}
+                    // 대기/진행 row 클릭 = hero 로 promote (실제 시작 X)
+                    onSelect={() => setSelectedTaskId(t.id)}
+                    onFailedRecover={() => onFail(t.id, t.failReason || '')}
+                    onPartialRecover={onOpenRecovery}
+                  />
+                ))}
+            </div>
+          </>
+        )}
 
         {/* Habit Tracker */}
         <div>
@@ -480,6 +490,30 @@ export function MergedTodayScreen({ tasks: dummyTasks, onOpen, onMarkDone, onPar
           </div>
         </div>
       )}
+    </div>
+  );
+}
+
+// ── Agenda Skeleton ───────────────────────────────────────────
+// 첫 /today/agenda fetch 가 settle 될 때까지 hero+task row 자리를 채우는
+// 가벼운 placeholder. 더미→실데이터 깜빡임 방지용. (전역 CSS 없이 인라인만.)
+function AgendaSkeleton() {
+  const box = (h: number, radius: number, bg: string): React.CSSProperties => ({
+    height: h,
+    borderRadius: radius,
+    background: bg,
+    opacity: 0.6,
+  });
+  return (
+    <div aria-hidden style={{ display: 'flex', flexDirection: 'column', gap: 18 }}>
+      {/* hero 자리 */}
+      <div style={box(140, 24, 'var(--sand-100)')} />
+      {/* task row 자리 — 3개 muted placeholder */}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        {[0, 1, 2].map((i) => (
+          <div key={i} style={box(64, 12, 'var(--surface-raised)')} />
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/screens/WeeklyCalendarScreen.tsx
+++ b/src/screens/WeeklyCalendarScreen.tsx
@@ -162,11 +162,15 @@ export function WeeklyCalendarScreenV2() {
   const setBlocks = isThisWeek ? setThisWeekBlocks : setNextWeekBlocks;
   // 백엔드 실제 주간 계획이 들어왔는지 — true 면 더미가 아니라 진짜 데이터.
   const [usingRealPlan, setUsingRealPlan] = useState(false);
+  // weekly 페치가 진행 중인지 — true 면 더미가 번쩍이지 않게 스켈레톤을 보여준다.
+  // 주차 전환(weekStartStr 변경)마다 effect 가 재실행되어 true 로 리셋된다.
+  const [planLoading, setPlanLoading] = useState(true);
 
   // 주차 바뀔 때마다 /plans/weekly(#21 구현됨) 시도. 실데이터 오면 더미 교체, 없으면 더미 유지.
   useEffect(() => {
     let cancelled = false;
     setUsingRealPlan(false);
+    setPlanLoading(true);
     plansApi.weekly(weekStartStr).then(
       (res) => {
         if (cancelled) return;
@@ -177,7 +181,10 @@ export function WeeklyCalendarScreenV2() {
         setUsingRealPlan(true);
       },
       () => { /* 네트워크/오류 — 더미 유지 + '예시' 배너 */ },
-    );
+    ).finally(() => {
+      // 성공/실패 모두 settle 시점에 로딩 해제 (취소된 effect 는 무시).
+      if (!cancelled) setPlanLoading(false);
+    });
     return () => { cancelled = true; };
   }, [weekStartStr]);
 
@@ -423,7 +430,7 @@ export function WeeklyCalendarScreenV2() {
           <span style={{ fontSize: 9, fontFamily: 'var(--font-mono)', color: 'var(--text-3)', letterSpacing: '0.08em' }}>{weekLabel}</span>
         </div>
         <p style={{ fontSize: 11, color: 'var(--text-3)', margin: '0 0 8px' }}>블록을 탭하면 수정, 길게 누른 채 끌면 15분 단위로 이동돼요.</p>
-        {!usingRealPlan ? (
+        {planLoading ? null : !usingRealPlan ? (
           <div style={{ marginBottom: 8 }}>
             <DemoNotice storageKey="weekly-calendar">
               주간 계획을 서버에서 불러오지 못했어요. 예시를 표시 중이며, 편집은 임시 저장돼요.
@@ -477,13 +484,44 @@ export function WeeklyCalendarScreenV2() {
               <div key={d} style={{ position: 'absolute', left: i * COL_W, top: 0, bottom: 0, width: 1, background: 'var(--sand-200)' }} />
             ))}
             {isThisWeek && <div style={{ position: 'absolute', left: TODAY * COL_W, top: 0, bottom: 0, width: COL_W, background: 'rgba(226,109,78,0.03)' }} />}
+            {/* 로딩 중: weekly 페치가 settle 될 때까지 더미/실데이터 대신 스켈레톤 placeholder.
+                pulse @keyframes 가 index.css 에 없어 정적 muted 박스로 처리(전역 CSS 미추가). */}
+            {planLoading && [
+              { day: 0, min: 14 * 60, dur: 60 },
+              { day: 1, min: 16 * 60, dur: 90 },
+              { day: 2, min: 15 * 60, dur: 45 },
+              { day: 3, min: 18 * 60, dur: 60 },
+              { day: 4, min: 14 * 60 + 30, dur: 75 },
+              { day: 5, min: 20 * 60, dur: 60 },
+            ].map((s, i) => {
+              const y = toY(s.min);
+              const bh = Math.max((s.dur * HOUR_PX / 60) - 2, 20);
+              return (
+                <div
+                  key={`sk-${i}`}
+                  aria-hidden
+                  style={{
+                    position: 'absolute',
+                    left: s.day * COL_W + 2,
+                    top: y + 1,
+                    width: COL_W - 4,
+                    height: bh,
+                    borderRadius: 6,
+                    background: i % 2 === 0 ? 'var(--sand-100)' : 'var(--surface-raised)',
+                    border: '1px solid var(--sand-200)',
+                    opacity: 0.7,
+                    zIndex: 1,
+                  }}
+                />
+              );
+            })}
             {/* Now line — 이번 주 + 현재 시각이 START_H~END_H 구간일 때만 노출 */}
-            {isThisWeek && nowMin >= START_H * 60 && nowMin <= END_H * 60 && (
+            {!planLoading && isThisWeek && nowMin >= START_H * 60 && nowMin <= END_H * 60 && (
               <div style={{ position: 'absolute', left: TODAY * COL_W, width: COL_W, top: toY(nowMin), height: 2, background: 'var(--brand)', borderRadius: 9999, zIndex: 5 }}>
                 <div style={{ position: 'absolute', left: -3, top: -3, width: 7, height: 7, borderRadius: 9999, background: 'var(--brand)' }} />
               </div>
             )}
-            {blocks.map((b) => {
+            {!planLoading && blocks.map((b) => {
               // 드래그 중인 블록은 ghost 위치로 미리 표시.
               const isDragging = dragGhost?.id === b.id;
               const day = isDragging ? dragGhost!.day : b.day;

--- a/src/screens/WeeklyReviewScreen.tsx
+++ b/src/screens/WeeklyReviewScreen.tsx
@@ -130,6 +130,8 @@ export function WeeklyReviewScreenV2() {
   const { setScreen, setTab, setWeekOffset } = useNavigation();
   // 백엔드 실제 주간 리뷰. 들어오면 hero 점수/복구율/한줄요약을 실데이터로 덮는다.
   const [real, setReal] = useState<WeeklyReviewResponse | null>(null);
+  // 주간 리뷰 fetch가 끝날 때까지 true. 끝나기 전엔 더미 대신 스켈레톤을 보여 플래시를 막는다.
+  const [reviewLoading, setReviewLoading] = useState(true);
 
   // "다음 주 계획 확인" — 다음 주(weekOffset=1)로 주간 계획 화면 이동.
   const goToNextWeekPlan = () => {
@@ -141,10 +143,11 @@ export function WeeklyReviewScreenV2() {
   // /reviews/weekly(#21 구현됨) 시도. 실데이터 오면 일부 지표를 덮고, 없으면 더미 유지.
   useEffect(() => {
     let cancelled = false;
+    setReviewLoading(true);
     reviewsApi.weekly(thisMonday()).then(
       (res) => { if (!cancelled) setReal(res); },
       () => { /* 미구현/오류 — 더미 유지 */ },
-    );
+    ).finally(() => { if (!cancelled) setReviewLoading(false); });
     return () => { cancelled = true; };
   }, []);
 
@@ -181,7 +184,7 @@ export function WeeklyReviewScreenV2() {
         <div>
           <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--text-3)', fontFamily: 'var(--font-mono)', marginBottom: 3 }}>{week}</div>
           <h1 style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 24, letterSpacing: '-0.02em', margin: '0 0 10px' }}>이번 주, 잘 했어요</h1>
-          {!usingReal ? (
+          {reviewLoading ? null : !usingReal ? (
             <DemoNotice storageKey="weekly-review">
               주간 리뷰를 서버에서 불러오지 못했어요. 예시 통계를 표시 중이에요.
             </DemoNotice>
@@ -192,6 +195,17 @@ export function WeeklyReviewScreenV2() {
           ) : null}
         </div>
 
+        {reviewLoading ? (
+          /* 데이터 의존 영역 스켈레톤 — fetch가 끝날 때까지 더미 KPI 대신 표시. */
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }} aria-hidden="true">
+            {[0, 1, 2, 3].map((i) => (
+              <div key={i} style={{ height: 104, borderRadius: 14, border: '1px solid var(--sand-200)', background: 'var(--surface-raised)', position: 'relative', overflow: 'hidden' }}>
+                <div style={{ position: 'absolute', inset: 12, borderRadius: 10, background: 'var(--sand-100)' }} />
+              </div>
+            ))}
+          </div>
+        ) : (
+        <>
         {/* Hero: Score donut */}
         <div style={{ background: 'linear-gradient(135deg, var(--coral-50) 0%, var(--surface-raised) 100%)', border: '1px solid var(--coral-200)', borderRadius: 18, padding: '14px 16px', display: 'flex', alignItems: 'center', gap: 14, minWidth: 0 }}>
           <ScoreDonut score={score} />
@@ -332,6 +346,8 @@ export function WeeklyReviewScreenV2() {
             </div>
           </div>
         </div>
+        )}
+        </>
         )}
 
         <div style={{ height: 8 }} />


### PR DESCRIPTION
## 요약
실데이터 로딩 시 더미가 잠깐 보이는 '번쩍임'을 스켈레톤으로 없애고, 인터뷰 세션 중복(409)을 이어하기로 처리합니다.

## 변경
- **로딩 스켈레톤** (Today · 주간계획 · 주간리뷰): `/today/agenda`·`/plans/weekly`·`/reviews/weekly` fetch가 끝날 때까지 muted placeholder를 보여줘 더미→실데이터 flash 제거. 헤더 등 데이터 무관 chrome은 유지.
- **인터뷰 409 이어하기** (GoalIntake): 백엔드는 유저당 인터뷰 1개만 허용(중복 `POST /interview/sessions` → 409 `INTERVIEW_SESSION_EXISTS`). 세션 id를 `localStorage`에 저장 → 재진입/409 시 `GET /interview/sessions/{id}`로 **이어서 진행**. 복구 불가(우리가 만든 적 없는 세션) 시 친절히 안내하고 "다음 단계로 넘어가기" 버튼으로 온보딩을 막지 않음.

## 검증
- `tsc + vite build` 통과
- API 계약 체크 PASS — 위반 0
- 409 응답(`INTERVIEW_SESSION_EXISTS`) / 세션 상태(`endReason`) 라이브 확인

## 비고
전부 프론트(`reaction-frontend`)만 수정. 백엔드 변경 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)