### PR TITLE
feat: 백엔드 새 호스트 same-origin 프록시 연동 (Mixed Content 회피)

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -62,7 +62,9 @@ import type {
   WeeklyReviewResponse,
 } from '../types/api';
 
-const BASE_URL = (import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8000').replace(/\/$/, '');
+// 기본값 `/api` = same-origin 프록시 경로 (dev=vite proxy, prod=vercel.json rewrite → 백엔드).
+// http 백엔드를 HTTPS 페이지에서 직접 부르면 Mixed Content 로 차단되므로 프록시를 기본으로 한다.
+const BASE_URL = (import.meta.env.VITE_API_BASE_URL ?? '/api').replace(/\/$/, '');
 const TOKEN_KEY = 'reaction.accessToken';
 
 export class ApiError extends Error {

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/api/:path*", "destination": "http://54.184.8.149:8000/:path*" }
+  ]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,20 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
+// 백엔드는 http://54.184.8.149:8000 (staging). 브라우저가 HTTPS 페이지에서 http 백엔드를
+// 직접 부르면 Mixed Content 로 차단되므로, 프론트는 항상 same-origin `/api/*` 를 부르고
+// dev 는 아래 프록시가, prod 는 vercel.json rewrite 가 http 백엔드로 중계한다.
+const API_TARGET = 'http://54.184.8.149:8000';
+
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': {
+        target: API_TARGET,
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ''),
+      },
+    },
+  },
 });


### PR DESCRIPTION
## 요약
백엔드가 `http://54.184.8.149:8000`(staging)로 이전. `http`+생 IP라 HTTPS Vercel 배포에서 직접 호출 시 브라우저가 **Mixed Content**로 차단하므로, **same-origin `/api/*` 프록시**로 우회한다.

## 변경
- `vercel.json`(신규): `/api/:path*` → `http://54.184.8.149:8000/:path*` rewrite (prod, Vercel 서버가 중계 → 브라우저는 HTTPS same-origin만 호출)
- `vite.config.ts`: dev server `/api` 프록시 → 백엔드 (로컬)
- `src/lib/api.ts`: `BASE_URL` 기본값 `http://localhost:8000` → `/api`
- `.env.local`(로컬): `VITE_API_BASE_URL=/api`

## 검증
- `tsc + vite build` 통과
- dev 프록시로 `/api/health`(200, db ok) · `/api/auth/google`(로그인 성공) 실동작 확인
- 새 백엔드 CORS는 Vercel·localhost 둘 다 허용 확인(프록시라 CORS 자체는 불필요)

## ⚠️ 배포 시 (Vercel)
기존 `VITE_API_BASE_URL`(옛 Render URL)을 **삭제**하거나 **`/api`로 변경** 후 재배포해야 함. (env var가 코드 기본값을 덮어씀)

전부 프론트만 수정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)