### PR TITLE
fix: /privacy/consent shape 불일치 렌더 크래시 (a.find is not a function)

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -448,7 +448,12 @@ export const settingsApi = {
 };
 
 export const privacyApi = {
-  consents: () => request<ConsentRecord[]>('/privacy/consent'),
+  // 백엔드는 `{consents: [...]}` 로 감싸서 준다. 배열/객체 두 shape 모두 안전하게 언랩.
+  // (배열로 기대하고 .find 하던 화면이 객체를 받아 크래시하던 문제 방지)
+  consents: () =>
+    request<{ consents: ConsentRecord[] } | ConsentRecord[]>('/privacy/consent').then((r) =>
+      Array.isArray(r) ? r : r?.consents ?? [],
+    ),
 
   updateConsent: (body: ConsentUpdateRequest) =>
     request<ConsentRecord>('/privacy/consent', { method: 'POST', body }),


### PR DESCRIPTION
## 증상
배포 사이트에서 `TypeError: a.find is not a function` 렌더 크래시 (SettingsScreen).

## 원인
백엔드 `/privacy/consent` 는 `{consents: [...]}` 객체를 반환하는데, 프론트 `privacyApi.consents()` 는 `ConsentRecord[]` 배열로 기대. SettingsScreen 의 `consents.find(...)`(consentGranted) 가 객체에 `.find` 호출 → 크래시.

## 수정
`privacyApi.consents()` 가 배열/객체 두 shape 모두 안전하게 언랩(`Array.isArray(r) ? r : r.consents ?? []`).

## 검증
- `tsc + vite build` 통과
- 라이브 `/privacy/consent` → `{consents:[...]}` 확인 (다른 배열 엔드포인트 /time-policies·/inbox·/habits·/fixed-schedules 는 정상 배열)

전부 프론트만 수정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)