### PR TITLE
fix: 인터뷰 답변 시 중복 nextQuestion 호출 제거

### DIFF
--- a/src/screens/GoalIntakeScreen.tsx
+++ b/src/screens/GoalIntakeScreen.tsx
@@ -188,12 +188,13 @@ export function GoalIntakeScreen({ onDone }: GoalIntakeScreenProps) {
     setIsTyping(true);
 
     try {
-      await interviewApi.submitAnswer(session.sessionId, {
+      // 백엔드 submitAnswer 응답에 이미 다음 질문(또는 종료 상태)이 들어있다.
+      // 별도 nextQuestion 호출은 user_agent_lock 을 한 번 더 잡아 실패 위험만 키우므로 제거.
+      const next = await interviewApi.submitAnswer(session.sessionId, {
         slotKey: answeredKey,
         value: trimmed,
         clientTurn: session.totalTurns,
       });
-      const next = await interviewApi.nextQuestion(session.sessionId);
 
       // 종료 신호: endReason 있음, currentQuestion null, 또는 이미 답한 슬롯이 또 옴(mock 한계).
       const noMoreQuestion = !next.currentQuestion;


### PR DESCRIPTION
## 배경
"목표 파악 인터뷰에서 답을 보내면 AI가 다음 질문을 안 준다" 증상.

## 원인 (백엔드 — 프론트로 완전 해결 불가)
- 인터뷰 에이전트가 답변 후 다음 질문을 **LLM(`gemini-2.0-flash-exp`, deprecated)** 으로 생성 → 실패 → `user_agent_lock`(세션단위 advisory lock) 누수 → 이후 인터뷰 요청이 `AGENT_CONCURRENT_ACCESS`. (첫 질문은 템플릿이라 LLM 없이 나옴)
- 새 백엔드(54.184.8.149)도 이미 stuck 락 상태(start가 409).

## 프론트 완화 (이 PR)
- 프론트가 `submitAnswer` 후 **불필요하게 `nextQuestion` 을 또 호출**해 락을 2번 잡던 것을 제거. `submitAnswer` 응답에 이미 다음 질문/종료 상태가 있으므로 그대로 사용. → 락 접촉면 절반, 두 번째 호출發 실패 제거.

## 백엔드에 필요한 근본 수정 (프론트 아님)
1. `LLM_MODEL` `gemini-2.0-flash-exp` → `gemini-2.0-flash`(GA) 로 변경 + GEMINI_API_KEY 유효성 확인
2. `orchestrator/_common.py` 의 락을 `pg_try_advisory_xact_lock`(트랜잭션 단위, 자동 해제)로 변경
3. 현재 stuck 락 해제 위해 백엔드 재시작

검증: build 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)