### PR TITLE
fix: stub 로그인 브라우저별 전용 계정 (demo:deviceId) — 인터뷰 세션 충돌 해소

### DIFF
--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -7,6 +7,22 @@ import { ApiError, authApi, onboardingApi, setAccessToken } from '../lib/api';
 import type { ScreenId, TabId } from '../types';
 import type { OnboardingState, UserProfile } from '../types/api';
 
+// stub 로그인 idToken 결정 (백엔드 AUTH_STUB 모드).
+//  - 기본: 브라우저별 전용 계정 `demo:<deviceId>` — 여러 테스터/탭이 같은 데모 계정을
+//    공유해 인터뷰 세션·advisory lock 이 충돌하던 문제를 방지한다.
+//  - `?demo=stub`: 발표용 시드 데모 계정(예: "GROUP BY 재도전" 시나리오).
+function stubIdToken(): string {
+  if (typeof window === 'undefined') return 'stub';
+  const params = new URLSearchParams(window.location.search);
+  if (params.get('demo') === 'stub') return 'stub';
+  let deviceId = window.localStorage.getItem('reaction.deviceId');
+  if (!deviceId) {
+    deviceId = crypto.randomUUID();
+    window.localStorage.setItem('reaction.deviceId', deviceId);
+  }
+  return `demo:${deviceId}`;
+}
+
 export function AppShell() {
   const [screen, setScreen] = useState<ScreenId>('intro');
   const [tab, setTab] = useState<TabId>('today');
@@ -47,7 +63,7 @@ export function AppShell() {
         } catch (err) {
           const stubLoginAllowed = import.meta.env.VITE_ALLOW_STUB_LOGIN !== 'false';
           if (err instanceof ApiError && err.status === 401 && stubLoginAllowed) {
-            const session = await authApi.loginWithGoogle('demo-id-token');
+            const session = await authApi.loginWithGoogle(stubIdToken());
             setAccessToken(session.accessToken);
             profile = session.user;
           } else {


### PR DESCRIPTION
## 원인
모든 브라우저/탭이 `idToken='demo-id-token'` 하나를 공유 → **같은 데모 유저** → 인터뷰 세션·`user_agent_lock`(advisory lock)을 공유. 느린 에이전트(~10s) + 프론트 중복 호출 + 다중 탭이 겹치면 `AGENT_CONCURRENT_ACCESS` → "답은 받는데 다음 질문이 안 옴".

## 수정 (임형준 제안)
- `localStorage.reaction.deviceId`(UUID) 기반 `demo:<deviceId>` 로그인 → **브라우저별 전용 계정** (백엔드 AUTH_STUB 지원 확인: 서로 다른 uuid → 서로 다른 user).
- `?demo=stub` → 발표용 시드 데모 계정(`stub` = 김민수, "GROUP BY 재도전" 시나리오).

## 검증
- 백엔드: `demo:<uuidA>`/`demo:<uuidB>` → 별개 계정, `stub` → 김민수 확인.
- 새 전용 계정으로 인터뷰 E2E: start(201) → 답변 제출 → **다음 질문 200 응답**(ambiguity 감소, turns 증가) 실제 확인.
- build 통과.

## 관련
- #48: 중복 `nextQuestion` 호출 제거(락 접촉면 감소)와 함께 인터뷰 흐름 정상화.
- 백엔드 advisory lock 은 여전히 세션단위(`pg_try_advisory_lock`)라, 단일 계정 내 동시 작업 시 누수 여지 있음 → `pg_try_advisory_xact_lock` 권장(백엔드). 다만 전용 계정으로 일상 충돌은 해소.

전부 프론트만 수정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)