### PR TITLE
fix: 구버전 공유 계정 토큰 자동 마이그레이션 (인터뷰 409 잔존 해소)

### DIFF
--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -13,13 +13,15 @@ import type { OnboardingState, UserProfile } from '../types/api';
 //  - `?demo=stub`: 발표용 시드 데모 계정(예: "GROUP BY 재도전" 시나리오).
 function stubIdToken(): string {
   if (typeof window === 'undefined') return 'stub';
-  const params = new URLSearchParams(window.location.search);
-  if (params.get('demo') === 'stub') return 'stub';
+  // deviceId 는 "전용 계정 로그인 시스템을 거쳤음" 마커도 겸한다(마이그레이션 판별용).
+  // stub 계정으로 로그인하더라도 항상 세팅해 둔다.
   let deviceId = window.localStorage.getItem('reaction.deviceId');
   if (!deviceId) {
     deviceId = crypto.randomUUID();
     window.localStorage.setItem('reaction.deviceId', deviceId);
   }
+  const params = new URLSearchParams(window.location.search);
+  if (params.get('demo') === 'stub') return 'stub';
   return `demo:${deviceId}`;
 }
 
@@ -51,6 +53,17 @@ export function AppShell() {
       // force 쿼리가 있으면 어떤 경우든 그것을 최우선으로 적용한다.
       if (force) setScreen(force);
       else if (!onboardingDone) setScreen('intro');
+
+      // 마이그레이션: 전용 계정(deviceId) 도입 이전의 '공유 데모 계정' 토큰이 남아있으면 버린다.
+      // 그 토큰으로 /auth/me 가 성공하면 세션·락이 꼬인 공유 계정에 계속 붙어 인터뷰 409 가 반복된다.
+      // deviceId 없이 토큰만 있음 = 구버전 토큰 → 제거해 전용 계정으로 재로그인 유도.
+      if (
+        typeof window !== 'undefined' &&
+        window.localStorage.getItem('reaction.accessToken') &&
+        !window.localStorage.getItem('reaction.deviceId')
+      ) {
+        setAccessToken(null);
+      }
 
       try {
         // 1) 저장된 토큰으로 /auth/me 시도. 토큰 없거나 만료(401) 이면


### PR DESCRIPTION
## 증상
per-device 계정 배포(#49) 후에도 일부 브라우저에서 인터뷰 **409 지속**.

## 원인
전용 계정 도입 전 저장된 **공유 데모 계정(김민수) accessToken** 이 localStorage 에 남아있으면, 부트스트랩의 `/auth/me` 가 그 토큰으로 성공 → 전용 계정 로그인 경로를 안 타고 **세션·advisory lock 이 꼬인 공유 계정**에 계속 붙음 → 인터뷰 시작 시 409.

## 수정
- 부트스트랩에서 `accessToken` 있음 + `reaction.deviceId` 없음 = 구버전 공유 토큰으로 판별 → 토큰 제거 → 401 → 전용 계정(`demo:<deviceId>`)으로 재로그인.
- `stubIdToken()` 이 stub 로그인 시에도 deviceId 를 항상 세팅(마커).

## 검증
- 라이브 번들에 per-device 코드 배포·프록시 정상 확인.
- 전용 계정 인터뷰 E2E: start(201) → answer(200) → finish(200) → restart(201), **409 없음**.
- build 통과.

전부 프론트만 수정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)