### PR TITLE
fix: 인터뷰 정상 완료가 가짜 에러로 빠지던 완료 게이팅 수정

### DIFF
--- a/src/screens/GoalIntakeScreen.tsx
+++ b/src/screens/GoalIntakeScreen.tsx
@@ -191,9 +191,14 @@ export function GoalIntakeScreen({ onDone }: GoalIntakeScreenProps) {
         clientTurn: session.totalTurns,
       });
 
-      // 종료 신호: 서버가 종료를 표시했고 남은 필수 슬롯 수가 0일 때만 다음 단계로 간다.
-      // clarity 부족으로 같은 slotKey 를 재질문하는 것은 정상 흐름이므로 종료로 보지 않는다.
-      const ended = next.endReason !== null && next.ambiguityScore <= 0;
+      // 종료 신호는 서버의 endReason 하나로 판정한다(completed/early_user/abandoned 모두 terminal).
+      // 서버는 아직 물을 게 남으면 endReason=null 로 두고 currentQuestion 을 준다(clarity 부족으로
+      // 같은 slotKey 를 재질문하는 것도 endReason=null 이라 종료로 오인하지 않는다).
+      //
+      // 과거엔 `&& ambiguityScore <= 0` 을 추가로 요구했으나, 서버는 남은 필수 슬롯이 있어도
+      // 요약(summary)+outcome 을 실어 completed 로 마감한다(ambiguityScore>0 인 채 종료). 그 결과
+      // 정상 완료가 완료로 인식되지 못하고 아래 "다음 질문 없음" 에러로 잘못 빠지던 버그를 고친다.
+      const ended = next.endReason !== null;
 
       if (ended) {
         setSession({


### PR DESCRIPTION
## 문제 (회귀 #53)

온보딩 **목표 파악 인터뷰**를 정상적으로 끝내도 완료로 인식되지 않고, 빨간 에러
**"아직 남은 질문이 있는데 다음 질문을 받지 못했어요. 다시 시도해주세요."** 가 뜬다.
성공 전환 메시지("완벽해요… 다음 단계로 넘어갈게요")는 아예 표시되지 않는다.

## 근본 원인

`GoalIntakeScreen.tsx` 의 완료 판정:

```js
const ended = next.endReason !== null && next.ambiguityScore <= 0;
```

API 의 `ambiguityScore` 는 **"남은 미해결 필수 슬롯 수"** 이고, 서버는 남은 슬롯이 있어도
요약(summary)+outcome 을 실어 `endReason="completed"` 로 마감한다. 즉 **정상 완료 시점에
`ambiguityScore` 는 0 이 아니다.** 따라서 `&& ambiguityScore <= 0` 조건이 정상 완료에서
절대 참이 되지 않아, 완료가 아래 `if (!next.currentQuestion)` 가짜 에러 분기로 빠졌다.

이 조건은 직전 PR #53 이 "재질문 오종료"를 막으려다 추가한 것인데, 과교정으로 완료 자체를
못 잡게 되는 회귀를 만들었다.

### 라이브 스테이징 재현 (`54.184.8.149:8000`)

인터뷰를 자연 완료까지 진행하면 종료 턴에서:
- `endReason="completed"`, `ambiguityScore=8~11` (0 아님), `currentQuestion=null`, `summary`+`outcome` 존재
- 기존 로직 → **ERROR(가짜)** / 수정 로직 → **COMPLETE** 로 정확히 전환됨

## 수정

완료 판정을 서버의 권위 있는 신호인 **`endReason` 단독**으로 되돌린다. 재질문(clarity 부족)은
서버가 `endReason=null` + `currentQuestion` 으로 주므로 종료로 오인하지 않는다.

```js
const ended = next.endReason !== null;
```

`if (!next.currentQuestion)` 분기는 "endReason 도 없고 질문도 없는" 진짜 이상 상황의
안전망으로 그대로 둔다.

## 검증

- `tsc && vite build` 클린 통과
- 라이브 백엔드로 자연 완료 / 재질문 반복 / `충분해요`(early_user) 경로 모두 정상 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)