### PR TITLE
feat: time-policies CRUD + fixed-schedules PATCH 배선 (정책 on/off 실동작)

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -22,6 +22,9 @@ import type {
   FirstPlanResponse,
   FixedSchedule,
   FixedScheduleCreateRequest,
+  FixedScheduleUpdateRequest,
+  TimePolicyCreateRequest,
+  TimePolicyUpdateRequest,
   FreeBusy,
   GoalCreateRequest,
   GoalDecomposition,
@@ -265,6 +268,15 @@ export const timePoliciesApi = {
       method: 'POST',
       body: {},
     }),
+
+  create: (body: TimePolicyCreateRequest) =>
+    request<TimePolicy>('/time-policies', { method: 'POST', body }),
+
+  update: (policyId: string, body: TimePolicyUpdateRequest) =>
+    request<TimePolicy>(`/time-policies/${policyId}`, { method: 'PATCH', body }),
+
+  remove: (policyId: string) =>
+    request<void>(`/time-policies/${policyId}`, { method: 'DELETE' }),
 };
 
 // ── Fixed Schedules (S05) ─────────────────────────────────────
@@ -273,6 +285,9 @@ export const fixedSchedulesApi = {
 
   create: (body: FixedScheduleCreateRequest) =>
     request<FixedSchedule>('/fixed-schedules', { method: 'POST', body }),
+
+  update: (scheduleId: string, body: FixedScheduleUpdateRequest) =>
+    request<FixedSchedule>(`/fixed-schedules/${scheduleId}`, { method: 'PATCH', body }),
 
   remove: (scheduleId: string) =>
     request<void>(`/fixed-schedules/${scheduleId}`, { method: 'DELETE' }),

--- a/src/screens/SetupScreen.tsx
+++ b/src/screens/SetupScreen.tsx
@@ -136,6 +136,16 @@ export function SetupScreen({ onDone }: SetupScreenProps) {
     setSchedules((s) => s.filter((x) => x.scheduleId !== id));
   };
 
+  // 정책 on/off — optimistic 후 PATCH /time-policies/{id}. 실패 시 롤백.
+  const togglePolicy = async (policyId: string, next: boolean) => {
+    setPolicies((ps) => ps.map((p) => (p.policyId === policyId ? { ...p, isActive: next } : p)));
+    try {
+      await timePoliciesApi.update(policyId, { isActive: next });
+    } catch {
+      setPolicies((ps) => ps.map((p) => (p.policyId === policyId ? { ...p, isActive: !next } : p)));
+    }
+  };
+
   const patchSettings = (partial: Partial<NotificationSettings>) => {
     if (!settings) return;
     setSettings({ ...settings, ...partial });
@@ -262,7 +272,7 @@ export function SetupScreen({ onDone }: SetupScreenProps) {
             const meta = TYPE_META[p.policyType] ?? TYPE_META.custom;
             const Icon = meta.Icon;
             return (
-              <div key={p.policyId} style={{ background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', borderRadius: 12, padding: '10px 12px', display: 'flex', alignItems: 'center', gap: 10 }}>
+              <div key={p.policyId} style={{ background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', borderRadius: 12, padding: '10px 12px', display: 'flex', alignItems: 'center', gap: 10, opacity: p.isActive ? 1 : 0.55 }}>
                 <div style={{ width: 28, height: 28, borderRadius: 9, background: 'var(--sand-100)', color: 'var(--text-2)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
                   <Icon size={14} weight="fill" />
                 </div>
@@ -270,6 +280,14 @@ export function SetupScreen({ onDone }: SetupScreenProps) {
                   <div style={{ fontWeight: 700, fontSize: 12, color: 'var(--text-1)' }}>{meta.label}</div>
                   <div className="tnum" style={{ fontSize: 11, color: 'var(--text-2)', marginTop: 1 }}>{summarize(p)}</div>
                 </div>
+                {/* 정책 on/off — PATCH /time-policies/{id} 실배선. */}
+                <button
+                  onClick={() => togglePolicy(p.policyId, !p.isActive)}
+                  aria-label={`${meta.label} ${p.isActive ? '끄기' : '켜기'}`}
+                  style={{ width: 30, height: 18, borderRadius: 9999, background: p.isActive ? 'var(--brand)' : 'var(--sand-300)', position: 'relative', flexShrink: 0, border: 'none', cursor: 'pointer', padding: 0 }}
+                >
+                  <span style={{ position: 'absolute', top: 2, left: p.isActive ? 14 : 2, width: 14, height: 14, borderRadius: 9999, background: '#fff', transition: 'left 160ms' }} />
+                </button>
               </div>
             );
           })}

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -161,6 +161,26 @@ export interface FixedScheduleCreateRequest {
   endTime: string;
 }
 
+// PATCH /fixed-schedules/{id} — 부분 수정.
+export interface FixedScheduleUpdateRequest {
+  title?: string | null;
+  daysOfWeek?: DayOfWeek[] | null;
+  startTime?: string | null;
+  endTime?: string | null;
+}
+
+// POST /time-policies — 정책 생성.
+export interface TimePolicyCreateRequest {
+  policyType: PolicyType | string;
+  payload: Record<string, unknown>;
+}
+
+// PATCH /time-policies/{id} — payload 또는 isActive 부분 수정.
+export interface TimePolicyUpdateRequest {
+  payload?: Record<string, unknown> | null;
+  isActive?: boolean | null;
+}
+
 // ── Calendar (S04) ─────────────────────────────────────────────
 export interface CalendarConnection {
   provider: string;


### PR DESCRIPTION
## 요약
미연동 상태였던 백엔드 엔드포인트에 api.ts 래퍼를 추가하고, SetupScreen 정책 토글을 실배선.

## 변경
- **api.ts 래퍼 추가** (+타입):
  - `timePoliciesApi.create/update/remove` → POST/PATCH/DELETE `/time-policies`
  - `fixedSchedulesApi.update` → PATCH `/fixed-schedules/{id}`
  - 타입: `TimePolicyCreateRequest`, `TimePolicyUpdateRequest`, `FixedScheduleUpdateRequest`
- **SetupScreen '지킬 시간'**: 정책 행에 on/off 토글 추가 → `PATCH /time-policies/{id} {isActive}` optimistic(실패 롤백), 비활성 시 흐리게 표시.
- `/policy-snapshot/current` 은 백엔드 **501(미구현)** 이라 UI 배선 제외(추후) — WeeklyReview 정책 섹션은 기존 `reviews.policyUpdateCandidates` 유지.

## 검증
- `check:api` PASS: OK 64→**69**, NEW 10→**6**, GONE 0
- `tsc + vite build` 통과
- 라이브: `POST /time-policies` → `PATCH {isActive:false}` **200** 확인

## 남은 NEW(6)
`/health`(래퍼 불필요), `/habits/{}` PATCH(습관 편집), `/calendar/*`(P1 베타), `/policy-snapshot/current`(501). 목업→실연동 로드맵에서 계속.

전부 프론트만 수정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)