### PR TITLE
fix(today,habits): 빈 실데이터 empty-state (더미 습관 은폐 제거)

### DIFF
--- a/src/screens/TodayScreen.tsx
+++ b/src/screens/TodayScreen.tsx
@@ -230,12 +230,16 @@ export function MergedTodayScreen({ tasks: dummyTasks, onOpen, onMarkDone, onPar
   ]);
   const [addingHabit, setAddingHabit] = useState(false);
   const [newHabitName, setNewHabitName] = useState('');
+  // /habits 가 성공했는지 — true 면 습관 목록이 실데이터(비어있어도)라 더미로 가리지 않는다.
+  const [usingRealHabits, setUsingRealHabits] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
     Promise.all([habitsApi.list(), habitsApi.instancesForWeek(thisMonday())])
       .then(([apiHabits, instances]) => {
-        if (cancelled || apiHabits.length === 0) return;
+        if (cancelled) return;
+        // fetch 성공 = 연동됨. 비어있어도 실데이터로 처리 — 더미 습관으로 가리지 않는다.
+        setUsingRealHabits(true);
         const mapped: Habit[] = apiHabits.map((h) => {
           const inst = instances.find((i) => i.habitId === h.habitId);
           return {
@@ -399,6 +403,11 @@ export function MergedTodayScreen({ tasks: dummyTasks, onOpen, onMarkDone, onPar
             >+ 습관 추가</button>
           </div>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+            {usingRealHabits && habits.length === 0 && !addingHabit && (
+              <div style={{ padding: '12px 14px', borderRadius: 12, background: 'var(--surface-raised)', border: '1px dashed var(--sand-200)', fontSize: 12, color: 'var(--text-2)', lineHeight: 1.5 }}>
+                아직 추적 중인 습관이 없어요. 위 <b>+ 습관 추가</b>로 만들어보세요.
+              </div>
+            )}
             {habits.map(h => {
               const done = h.doneDays >= h.targetDays;
               return (


### PR DESCRIPTION
## 요약
습관 추적이 `/habits` 에 연동돼 있으나, 빈 실데이터일 때 더미 습관(피트니스·명상)을 계속 보여줘 "미연결처럼" 보이던 문제 수정. (Inbox 는 이미 완전 실연동이라 변경 없음)

## 확인
- 라이브 스키마 = 프론트 타입 **일치**: `Habit`/`HabitInstance`/`InboxItem` (consent 같은 shape 버그 없음)
- 습관 생성(HabitCreateRequest 필수필드 완비)·체크(instanceId)·삭제 배선 정상

## 변경 (TodayScreen.tsx)
- `/habits` fetch 의 `apiHabits.length===0` early-return 제거 → 성공이면 `usingRealHabits` + 실데이터 그대로(비어있어도 더미로 안 가림)
- 빈 습관이면 "아직 추적 중인 습관이 없어요 · + 습관 추가" empty-state

## 검증
- `tsc + vite build` 통과

전부 프론트만 수정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)