### PR TITLE
fix: 더미→실데이터 flash 제거 (MorningBrief·GoalClassify·습관 로딩 스켈레톤)

### DIFF
--- a/src/screens/GoalClassificationScreen.tsx
+++ b/src/screens/GoalClassificationScreen.tsx
@@ -30,7 +30,8 @@ function flatten(byTier: GoalsByTier): Goal[] {
 }
 
 export function GoalClassificationScreen({ onNext }: GoalClassificationScreenProps) {
-  const [goals, setGoals] = useState<Goal[]>(INIT_GOALS);
+  // 초기값 비움 → 로딩 중 스켈레톤, 실패 시에만 INIT_GOALS 더미 fallback (더미 flash 방지).
+  const [goals, setGoals] = useState<Goal[]>([]);
   const [selected, setSelected] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -51,6 +52,8 @@ export function GoalClassificationScreen({ onNext }: GoalClassificationScreenPro
       })
       .catch((err: unknown) => {
         if (cancelled) return;
+        // 실패 시에만 더미로 fallback (로딩 끝난 뒤 표시되어 flash 없음).
+        setGoals(INIT_GOALS);
         const msg =
           err instanceof ApiError
             ? `[${err.code}] ${err.message}`
@@ -116,7 +119,10 @@ export function GoalClassificationScreen({ onNext }: GoalClassificationScreenPro
         )}
 
         <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-          {usingReal && goals.length === 0 && (
+          {isLoading && [0, 1, 2].map((i) => (
+            <div key={`sk${i}`} style={{ height: 68, borderRadius: 14, border: '1px solid var(--sand-200)', background: 'var(--surface-raised)', opacity: 0.6 }} aria-hidden="true" />
+          ))}
+          {!isLoading && usingReal && goals.length === 0 && (
             <div style={{ padding: '14px 16px', borderRadius: 12, background: 'var(--surface-raised)', border: '1px dashed var(--sand-200)', fontSize: 12, color: 'var(--text-2)', lineHeight: 1.5 }}>
               아직 등록된 목표가 없어요. 목표 파악 인터뷰를 완료하면 여기에 표시돼요.
             </div>

--- a/src/screens/MorningBriefScreen.tsx
+++ b/src/screens/MorningBriefScreen.tsx
@@ -56,11 +56,14 @@ export function MorningBriefScreen({ onStart }: MorningBriefScreenProps) {
 
   // mock-and-replace: /today/agenda 로 오늘 실행 카드, /goals·/reviews 로 헤더 지표.
   // 각 호출은 best-effort — 실패/미구현이면 더미 유지, 성공하면 실데이터로 교체.
-  const [blocks, setBlocks] = useState<BriefBlock[]>(MORNING_DATA.blocks);
-  const [goalName, setGoalName] = useState<string>(MORNING_DATA.goalName);
-  const [weekProgress, setWeekProgress] = useState<number>(MORNING_DATA.weekProgress);
+  // 초기값은 비워두고(로딩 중 스켈레톤 표시), 실패 시에만 더미로 fallback → 더미 flash 방지.
+  const [blocks, setBlocks] = useState<BriefBlock[]>([]);
+  const [goalName, setGoalName] = useState<string>('');
+  const [weekProgress, setWeekProgress] = useState<number | null>(null);
   // /today/agenda 가 응답했는지 — true 면 blocks 가 실데이터(비어있어도)라 더미 이월 안내를 숨긴다.
   const [usingReal, setUsingReal] = useState(false);
+  // 초기 로드 중 — 더미/실데이터 겹침 대신 스켈레톤을 보여준다.
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     let cancelled = false;
@@ -69,8 +72,16 @@ export function MorningBriefScreen({ onStart }: MorningBriefScreenProps) {
         if (cancelled) return;
         setBlocks((a.cards ?? []).map(cardToBlock));
         setUsingReal(true);
+        setLoading(false);
       },
-      () => { /* 미동작 — 더미 유지 */ },
+      () => {
+        if (cancelled) return;
+        // 백엔드 미동작 — 더미로 fallback (로딩이 끝난 뒤에만 표시되어 flash 없음).
+        setBlocks(MORNING_DATA.blocks);
+        setGoalName((g) => g || MORNING_DATA.goalName);
+        setWeekProgress((w) => (w == null ? MORNING_DATA.weekProgress : w));
+        setLoading(false);
+      },
     );
     goalsApi.list().then(
       (g) => {
@@ -121,21 +132,21 @@ export function MorningBriefScreen({ onStart }: MorningBriefScreenProps) {
           <div style={{ display: 'flex', gap: 20 }}>
             <div>
               <div style={{ fontSize: 9, fontFamily: 'var(--font-mono)', color: 'rgba(250,246,238,.4)', marginBottom: 2 }}>오늘 할 일</div>
-              <div className="tnum" style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 26, color: '#FAF6EE', letterSpacing: '-0.02em' }}>{blocks.length}</div>
+              <div className="tnum" style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 26, color: '#FAF6EE', letterSpacing: '-0.02em' }}>{loading ? '·' : blocks.length}</div>
             </div>
             <div>
               <div style={{ fontSize: 9, fontFamily: 'var(--font-mono)', color: 'rgba(250,246,238,.4)', marginBottom: 2 }}>주간 달성</div>
-              <div className="tnum" style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 26, color: '#FAF6EE', letterSpacing: '-0.02em' }}>{weekProgress}%</div>
+              <div className="tnum" style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 26, color: '#FAF6EE', letterSpacing: '-0.02em' }}>{loading ? '·' : `${weekProgress ?? '—'}%`}</div>
             </div>
             <div>
               <div style={{ fontSize: 9, fontFamily: 'var(--font-mono)', color: 'rgba(250,246,238,.4)', marginBottom: 2 }}>핵심 목표</div>
-              <div style={{ fontSize: 11, color: 'rgba(250,246,238,.65)', marginTop: 4, lineHeight: 1.3 }}>{goalName}</div>
+              <div style={{ fontSize: 11, color: 'rgba(250,246,238,.65)', marginTop: 4, lineHeight: 1.3 }}>{loading ? '불러오는 중…' : (goalName || '—')}</div>
             </div>
           </div>
         </div>
 
-        {/* Carryover notice — 더미 모드에서만. AgendaCard 에 이월 신호가 없어 실데이터 땐 숨긴다. */}
-        {!usingReal && (
+        {/* Carryover notice — 로딩 끝난 뒤 더미(에러 fallback) 모드에서만. 실데이터/로딩 중엔 숨긴다. */}
+        {!loading && !usingReal && (
           <div style={{ padding: '10px 14px', background: '#FBEEDA', border: '1px solid #F2D29A', borderRadius: 12, display: 'flex', gap: 10, alignItems: 'flex-start' }}>
             <ArrowCounterClockwise size={16} color="var(--warning)" style={{ flexShrink: 0 }} />
             <div>
@@ -148,7 +159,13 @@ export function MorningBriefScreen({ onStart }: MorningBriefScreenProps) {
         {/* Today's blocks */}
         <div style={{ paddingBottom: 16 }}>
           <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--text-3)', fontFamily: 'var(--font-mono)', marginBottom: 10 }}>오늘의 실행 계획</div>
-          {usingReal && blocks.length === 0 ? (
+          {loading ? (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }} aria-hidden="true">
+              {[0, 1].map((i) => (
+                <div key={i} style={{ height: 64, borderRadius: 16, background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', opacity: 0.6 }} />
+              ))}
+            </div>
+          ) : usingReal && blocks.length === 0 ? (
             <div style={{ padding: '14px 16px', borderRadius: 16, background: 'var(--surface-raised)', border: '1px dashed var(--sand-200)', fontSize: 12, color: 'var(--text-2)', lineHeight: 1.5 }}>
               오늘 계획된 실행이 없어요. 주간 계획에서 일정을 추가하면 여기에 표시돼요.
             </div>

--- a/src/screens/TodayScreen.tsx
+++ b/src/screens/TodayScreen.tsx
@@ -223,15 +223,14 @@ export function MergedTodayScreen({ tasks: dummyTasks, onOpen, onMarkDone, onPar
     );
     return () => { cancelled = true; };
   }, []);
-  // 백엔드 /habits + /habit-instances 동기. 더미 fallback (백엔드 미동작 시).
-  const [habits, setHabits] = useState<Habit[]>([
-    { id: 'h1', instanceId: null, name: '피트니스 센터 헬스장 가기', targetDays: 3, doneDays: 2 },
-    { id: 'h2', instanceId: null, name: '마음 챙김 명상', targetDays: 3, doneDays: 0 },
-  ]);
+  // 초기값 비움 → 로딩 중 스켈레톤. 백엔드 미동작 시에만 더미 fallback (flash 방지).
+  const [habits, setHabits] = useState<Habit[]>([]);
   const [addingHabit, setAddingHabit] = useState(false);
   const [newHabitName, setNewHabitName] = useState('');
   // /habits 가 성공했는지 — true 면 습관 목록이 실데이터(비어있어도)라 더미로 가리지 않는다.
   const [usingRealHabits, setUsingRealHabits] = useState(false);
+  // 초기 습관 로드 중 — 더미/실데이터 겹침 대신 스켈레톤.
+  const [habitsLoading, setHabitsLoading] = useState(true);
 
   useEffect(() => {
     let cancelled = false;
@@ -252,7 +251,15 @@ export function MergedTodayScreen({ tasks: dummyTasks, onOpen, onMarkDone, onPar
         });
         setHabits(mapped);
       })
-      .catch(() => { /* 백엔드 미동작 — 더미 그대로 */ });
+      .catch(() => {
+        if (cancelled) return;
+        // 백엔드 미동작 — 더미로 fallback (로딩이 끝난 뒤에만 표시되어 flash 없음).
+        setHabits([
+          { id: 'h1', instanceId: null, name: '피트니스 센터 헬스장 가기', targetDays: 3, doneDays: 2 },
+          { id: 'h2', instanceId: null, name: '마음 챙김 명상', targetDays: 3, doneDays: 0 },
+        ]);
+      })
+      .finally(() => { if (!cancelled) setHabitsLoading(false); });
     return () => { cancelled = true; };
   }, []);
 
@@ -403,7 +410,10 @@ export function MergedTodayScreen({ tasks: dummyTasks, onOpen, onMarkDone, onPar
             >+ 습관 추가</button>
           </div>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-            {usingRealHabits && habits.length === 0 && !addingHabit && (
+            {habitsLoading && [0, 1].map((i) => (
+              <div key={`hsk${i}`} style={{ height: 52, borderRadius: 14, background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', opacity: 0.6 }} aria-hidden="true" />
+            ))}
+            {!habitsLoading && usingRealHabits && habits.length === 0 && !addingHabit && (
               <div style={{ padding: '12px 14px', borderRadius: 12, background: 'var(--surface-raised)', border: '1px dashed var(--sand-200)', fontSize: 12, color: 'var(--text-2)', lineHeight: 1.5 }}>
                 아직 추적 중인 습관이 없어요. 위 <b>+ 습관 추가</b>로 만들어보세요.
               </div>


### PR DESCRIPTION
## 문제
mock-and-replace 로 **더미를 먼저 그린 뒤 실데이터로 교체**해 화면이 겹쳐 보이는 flash. (사용자 리포트: "이전 목업이 나왔다가 로딩되며 사라짐")

## 해결 — 로딩 패턴 통일
초기값을 비워 **로딩 중엔 스켈레톤만** 표시 → fetch 성공이면 실데이터, **실패 시에만 더미 fallback**(로딩 끝난 뒤라 flash 없음).
- **MorningBriefScreen**: 히어로 지표(오늘 할 일·주간 달성·핵심 목표) + 블록 스켈레톤
- **GoalClassificationScreen**: 목표 목록 스켈레톤 (INIT_GOALS 는 에러 fallback 전용)
- **TodayScreen 습관**: 더미 습관 init 제거 + 습관 스켈레톤

> Today 실행·주간계획·주간리뷰는 이미 스켈레톤 있음(#44). 이번에 나머지 flash 화면을 마저 정리.

## 검증
- `check:api` PASS · `tsc + vite build` 통과

전부 프론트만 수정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)