### PR TITLE
feat(auth): 실제 Google 로그인 화면 추가 (LoginScreen + GIS)

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,8 @@
     <link rel="icon" type="image/svg+xml" href="/icon.svg" />
     <link rel="apple-touch-icon" href="/icon.svg" />
     <title>Re:Action — 계획 실행 복구 코치</title>
+    <!-- Google Identity Services — 실제 구글 로그인 버튼용. -->
+    <script src="https://accounts.google.com/gsi/client" async defer></script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { ReActionMerged } from './ReActionMerged';
 import { DesktopSidebar } from './DesktopSidebar';
+import { LoginScreen } from '../screens/LoginScreen';
 import { NavigationContext, STATE_TO_SCREEN } from '../contexts/NavigationContext';
 import { ToastProvider } from '../contexts/ToastContext';
 import { ApiError, authApi, onboardingApi, setAccessToken } from '../lib/api';
@@ -33,6 +34,76 @@ export function AppShell() {
   const [isBootstrapping, setIsBootstrapping] = useState(true);
   const [weekOffset, setWeekOffset] = useState(0);
   const [interviewSessionId, setInterviewSessionId] = useState<string | null>(null);
+  // 실제 로그인 화면(구글/데모)을 보여줘야 하는지 — stub 자동 로그인이 꺼졌거나(?login=1) 401 뒤 재로그인 필요할 때.
+  const [needsLogin, setNeedsLogin] = useState(false);
+  const [authBusy, setAuthBusy] = useState(false);
+  const [authError, setAuthError] = useState<string | null>(null);
+
+  // /auth/me(또는 로그인) 성공 응답을 화면 상태에 반영 — 부팅 시와 로그인 버튼 클릭 시 공용.
+  const applyProfile = useCallback((profile: UserProfile) => {
+    const force = new URLSearchParams(window.location.search).get('force') as ScreenId | null;
+    const onboardingDone = window.localStorage.getItem('reaction.onboardingDone') === '1';
+    setUser(profile);
+    setOnboardingState(profile.onboardingState);
+
+    // /onboarding/status 로 교차 검증 (best-effort). 실패해도 흐름 영향 없음 — source-of-truth 는 /auth/me.
+    onboardingApi
+      .status()
+      .then((status) => {
+        if (status.currentState !== profile.onboardingState) {
+          console.warn(
+            '[auth] onboardingState mismatch:',
+            `auth/me=${profile.onboardingState}`,
+            `onboarding/status=${status.currentState}`,
+          );
+        }
+      })
+      .catch(() => { /* 엔드포인트 없거나 401 — 무시 */ });
+
+    if (!force && onboardingDone) {
+      const target = STATE_TO_SCREEN[profile.onboardingState] ?? 'intro';
+      setScreen(target);
+      if (target === 'today' || target === 'weekly' || target === 'review') {
+        setTab(target);
+      }
+    }
+  }, []);
+
+  // 실제 Google 로그인 — LoginScreen 의 GIS 콜백에서 받은 id_token 을 백엔드로 전달.
+  const handleGoogleCredential = useCallback(async (idToken: string) => {
+    setAuthBusy(true);
+    setAuthError(null);
+    try {
+      const session = await authApi.loginWithGoogle(idToken);
+      setAccessToken(session.accessToken);
+      applyProfile(session.user);
+      setNeedsLogin(false);
+    } catch (err) {
+      setAuthError(
+        err instanceof ApiError ? `[${err.code}] ${err.message}` : '로그인에 실패했어요. 다시 시도해주세요.',
+      );
+    } finally {
+      setAuthBusy(false);
+    }
+  }, [applyProfile]);
+
+  // 데모 계정 명시적 진입 — 로그인 화면에서 사용자가 직접 눌렀을 때만(자동 아님).
+  const handleDemoLogin = useCallback(async () => {
+    setAuthBusy(true);
+    setAuthError(null);
+    try {
+      const session = await authApi.loginWithGoogle(stubIdToken());
+      setAccessToken(session.accessToken);
+      applyProfile(session.user);
+      setNeedsLogin(false);
+    } catch (err) {
+      setAuthError(
+        err instanceof ApiError ? `[${err.code}] ${err.message}` : '로그인에 실패했어요. 다시 시도해주세요.',
+      );
+    } finally {
+      setAuthBusy(false);
+    }
+  }, [applyProfile]);
 
   // 부팅 — /auth/me 로 사용자 상태 확인 후 진입 화면 결정.
   // dev/시연 편의: ?force=goal-intake 같은 쿼리로 강제 override 가능.
@@ -69,50 +140,31 @@ export function AppShell() {
         // 1) 저장된 토큰으로 /auth/me 시도. 토큰 없거나 만료(401) 이면
         //    백엔드 stub login (#16) 으로 새 JWT 발급 받기.
         //    stub login 은 dev/demo 전용 — prod 배포에서는
-        //    VITE_ALLOW_STUB_LOGIN=false 로 꺼서 가짜 토큰 자동 발급을 막는다.
+        //    VITE_ALLOW_STUB_LOGIN=false 로 꺼서 가짜 토큰 자동 발급을 막고
+        //    실제 Google 로그인 화면(LoginScreen)을 보여준다.
+        //    ?login=1 로 강제로 로그인 화면을 확인할 수 있다(수동 테스트용).
+        const forceLogin = new URLSearchParams(window.location.search).get('login') === '1';
         let profile;
         try {
           profile = await authApi.me();
         } catch (err) {
-          const stubLoginAllowed = import.meta.env.VITE_ALLOW_STUB_LOGIN !== 'false';
-          if (err instanceof ApiError && err.status === 401 && stubLoginAllowed) {
-            const session = await authApi.loginWithGoogle(stubIdToken());
-            setAccessToken(session.accessToken);
-            profile = session.user;
+          const stubLoginAllowed = import.meta.env.VITE_ALLOW_STUB_LOGIN !== 'false' && !forceLogin;
+          if (err instanceof ApiError && err.status === 401) {
+            if (stubLoginAllowed) {
+              const session = await authApi.loginWithGoogle(stubIdToken());
+              setAccessToken(session.accessToken);
+              profile = session.user;
+            } else {
+              // 실제 로그인 필요 — 로그인 화면으로 전환하고 부팅을 종료한다(아래 finally).
+              if (!cancelled) setNeedsLogin(true);
+              return;
+            }
           } else {
             throw err;
           }
         }
         if (cancelled) return;
-        setUser(profile);
-        setOnboardingState(profile.onboardingState);
-
-        // /onboarding/status 로 교차 검증 (best-effort).
-        // /auth/me 의 onboardingState 와 다르면 콘솔에만 경고만 남기고 진행.
-        // 실패해도 흐름 영향 없음 — source-of-truth 는 /auth/me.
-        onboardingApi
-          .status()
-          .then((status) => {
-            if (cancelled) return;
-            if (status.currentState !== profile.onboardingState) {
-              console.warn(
-                '[bootstrap] onboardingState mismatch:',
-                `auth/me=${profile.onboardingState}`,
-                `onboarding/status=${status.currentState}`,
-              );
-            }
-          })
-          .catch(() => {
-            // 엔드포인트 없거나 401 — 무시.
-          });
-
-        if (!force && onboardingDone) {
-          const target = STATE_TO_SCREEN[profile.onboardingState] ?? 'intro';
-          setScreen(target);
-          if (target === 'today' || target === 'weekly' || target === 'review') {
-            setTab(target);
-          }
-        }
+        applyProfile(profile);
       } catch (err) {
         // 백엔드 미기동/네트워크 오류는 그냥 로컬 데모 모드(intro 시작)로 fallback.
         if (!(err instanceof ApiError)) {
@@ -131,6 +183,17 @@ export function AppShell() {
 
   if (isBootstrapping) {
     return <BootSplash />;
+  }
+
+  if (needsLogin) {
+    return (
+      <LoginScreen
+        onGoogleCredential={handleGoogleCredential}
+        onDemoLogin={handleDemoLogin}
+        isBusy={authBusy}
+        error={authError}
+      />
+    );
   }
 
   return (

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -1,0 +1,149 @@
+import { useEffect, useRef, useState } from 'react';
+import { Sparkle } from '@phosphor-icons/react';
+
+// Google Identity Services 는 CDN 스크립트(index.html)가 window.google 을 채운다.
+// 공식 타입 패키지 없이 최소 shape 만 선언 — 실제로 쓰는 필드만.
+interface GoogleIdCredentialResponse {
+  credential: string; // Google ID token (JWT) — 그대로 백엔드 POST /auth/google 로 전달
+}
+interface GoogleAccountsId {
+  initialize: (config: { client_id: string; callback: (r: GoogleIdCredentialResponse) => void }) => void;
+  renderButton: (parent: HTMLElement, options: Record<string, unknown>) => void;
+}
+declare global {
+  interface Window {
+    google?: { accounts?: { id?: GoogleAccountsId } };
+  }
+}
+
+const CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID;
+
+interface LoginScreenProps {
+  onGoogleCredential: (idToken: string) => void;
+  onDemoLogin: () => void;
+  isBusy: boolean;
+  error?: string | null;
+}
+
+// 실제 로그인 화면 — Google Identity Services 버튼 + (부가) 데모 체험 진입.
+// 백엔드가 아직 stub 모드(AUTH_STUB_MODE=true)면 실제 계정으로 로그인해도
+// 서버가 데모 유저로 응답할 수 있다 — 그건 백엔드 설정이 반영되면 자동으로 해결된다.
+export function LoginScreen({ onGoogleCredential, onDemoLogin, isBusy, error }: LoginScreenProps) {
+  const buttonRef = useRef<HTMLDivElement>(null);
+  const [buttonReady, setButtonReady] = useState(false);
+
+  useEffect(() => {
+    if (!CLIENT_ID) return;
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout>;
+
+    // index.html 의 GSI 스크립트가 async 라 로드 시점을 보장할 수 없다 — 준비될 때까지 짧게 폴링.
+    const tryInit = () => {
+      if (cancelled) return;
+      const id = window.google?.accounts?.id;
+      if (!id || !buttonRef.current) {
+        timer = setTimeout(tryInit, 150);
+        return;
+      }
+      id.initialize({
+        client_id: CLIENT_ID,
+        callback: (r) => onGoogleCredential(r.credential),
+      });
+      id.renderButton(buttonRef.current, {
+        type: 'standard',
+        theme: 'outline',
+        size: 'large',
+        shape: 'pill',
+        text: 'continue_with',
+        logo_alignment: 'left',
+        width: 280,
+      });
+      setButtonReady(true);
+    };
+    tryInit();
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [onGoogleCredential]);
+
+  return (
+    <div
+      style={{
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 28,
+        padding: '32px 24px',
+        background: 'var(--surface-ground)',
+        textAlign: 'center',
+      }}
+    >
+      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 12 }}>
+        <div
+          style={{
+            width: 56,
+            height: 56,
+            borderRadius: 18,
+            background: 'var(--sand-950)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <Sparkle size={26} weight="fill" color="#FAF6EE" />
+        </div>
+        <div style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 24, letterSpacing: '-0.02em', color: 'var(--text-1)' }}>
+          Re:Action
+        </div>
+        <p style={{ fontSize: 13, color: 'var(--text-3)', margin: 0, maxWidth: 260, lineHeight: 1.6 }}>
+          계획이 흔들려도 괜찮아요. 로그인하고 계속해봐요.
+        </p>
+      </div>
+
+      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 14, width: '100%', maxWidth: 300 }}>
+        {CLIENT_ID ? (
+          <>
+            <div ref={buttonRef} style={{ minHeight: 44 }} />
+            {!buttonReady && (
+              <span style={{ fontSize: 11, color: 'var(--text-3)', fontFamily: 'var(--font-mono)' }}>
+                Google 로그인 준비 중…
+              </span>
+            )}
+          </>
+        ) : (
+          <div style={{ fontSize: 12, color: 'var(--text-3)', padding: '10px 14px', border: '1px dashed var(--sand-200)', borderRadius: 12 }}>
+            Google 로그인이 아직 설정되지 않았어요.
+          </div>
+        )}
+
+        {error && (
+          <div style={{ background: '#FAE2D8', border: '1px solid var(--coral-200)', color: 'var(--coral-700)', borderRadius: 10, padding: '10px 12px', fontSize: 12, width: '100%' }}>
+            {error}
+          </div>
+        )}
+
+        <button
+          onClick={onDemoLogin}
+          disabled={isBusy}
+          style={{
+            marginTop: 4,
+            background: 'transparent',
+            border: 'none',
+            color: 'var(--text-3)',
+            fontSize: 12,
+            fontFamily: 'var(--font-mono)',
+            letterSpacing: '0.04em',
+            textDecoration: 'underline',
+            cursor: isBusy ? 'wait' : 'pointer',
+            opacity: isBusy ? 0.6 : 1,
+          }}
+        >
+          {isBusy ? '로그인 중…' : '데모 계정으로 체험하기'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -4,6 +4,8 @@ interface ImportMetaEnv {
   readonly VITE_API_BASE_URL?: string;
   readonly VITE_VAPID_PUBLIC_KEY?: string;
   readonly VITE_ALLOW_STUB_LOGIN?: string;
+  // Google OAuth Client ID (공개값) — 백엔드 GOOGLE_OAUTH_CLIENT_ID 와 동일해야 id_token.aud 검증 통과.
+  readonly VITE_GOOGLE_CLIENT_ID?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## 배경
백엔드에서 실제 Google OAuth 검증(`GOOGLE_OAUTH_CLIENT_ID` + `AUTH_STUB_MODE=false`)을 준비 중이라, 프론트에도 실제 로그인 경로를 추가.

기존엔 stub 계정(`demo:<deviceId>`) 자동 로그인만 있었고, `VITE_ALLOW_STUB_LOGIN=false`로 꺼도 로그인 화면 없이 프로필 없는 상태로 방치되던 **미완성 분기**였음(코드 주석에 이미 그 의도가 남아 있었음).

## 변경
- **`index.html`**: Google Identity Services 스크립트 추가.
- **`LoginScreen`(신규)**: 공식 GIS 로그인 버튼(`client_id=VITE_GOOGLE_CLIENT_ID`) + "데모 계정으로 체험하기" 명시적 버튼. client_id 미설정이면 안내만 표시(에러 아님).
- **`AppShell`**: `/auth/me` 401 시 stub 로그인이 꺼져있으면(`VITE_ALLOW_STUB_LOGIN=false`) 또는 **`?login=1`**(수동 테스트용)이면 `LoginScreen`을 보여주고 부팅 종료. 부팅 시/실로그인 시/데모 로그인 시 공용으로 쓰이도록 `applyProfile` 로 리팩터.
- 타입: `VITE_GOOGLE_CLIENT_ID` env 타입 추가.

## 주의
백엔드가 아직 `AUTH_STUB_MODE=true` 라, 실제 구글 계정으로 로그인해도 서버가 데모 유저로 응답할 수 있음 — 백엔드 설정이 배포되면 자동으로 실제 신원이 반영됨(프론트 추가 변경 불필요).

## 배포 시 필요한 것 (Vercel, 사용자 액션)
- 환경변수 `VITE_GOOGLE_CLIENT_ID` = 백엔드와 동일한 client_id 추가
- (선택) 실제 로그인을 기본값으로 하려면 `VITE_ALLOW_STUB_LOGIN=false` 도 추가 — 안 하면 기존처럼 자동 데모 로그인 유지, `?login=1` 로만 새 화면 확인 가능

## 검증
- `tsc --noEmit` 클린 · `check:api` PASS · `vite build` 통과(dist 에 GSI 스크립트 포함 확인)
- dev 서버에서 `LoginScreen`/`AppShell` 모듈 정상 로드 확인

전부 프론트만 수정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)