### PR TITLE
fix(today): 부모/자식 task 상태 분리로 시작/완료/실패 무반응 수정 (#66)

### DIFF
--- a/src/app/ReActionMerged.tsx
+++ b/src/app/ReActionMerged.tsx
@@ -208,6 +208,9 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
             onFail={markFailed}
             onOpenRecovery={openRecovery}
             onEvening={() => setScreen('evening')}
+            // /today/agenda 실데이터가 오면 부모 tasks 자체를 교체 — openTask 등이
+            // 실제 카드 id 를 찾을 수 있게 단일 소스로 유지한다(#66).
+            onAgendaLoaded={setTasks}
           />
         )}
         {screen === 'focus' && activeTask && (

--- a/src/screens/TodayScreen.tsx
+++ b/src/screens/TodayScreen.tsx
@@ -54,6 +54,8 @@ function HeaderMenu() {
 }
 
 interface MergedTodayScreenProps {
+  // 단일 진실 소스는 부모(ReActionMerged)의 tasks — openTask/markDone/markPartial/markFailed 가
+  // 바로 이 목록을 대상으로 동작하므로, 이 화면은 로컬 사본을 만들지 않고 그대로 렌더한다.
   tasks: Task[];
   onOpen: (id: string) => void;
   onMarkDone: (id: string) => void;
@@ -61,6 +63,10 @@ interface MergedTodayScreenProps {
   onFail: (id: string, reason: string) => void;
   onOpenRecovery: () => void;
   onEvening: () => void;
+  // /today/agenda 실데이터 로드 성공 시 부모의 tasks 를 이 목록으로 교체한다.
+  // (기존엔 이 화면이 자체 로컬 tasks 상태로만 반영해, 부모가 들고 있는 openTask 등이
+  // 실제 카드 id 를 못 찾아 무반응이었다 — #66 대응)
+  onAgendaLoaded: (tasks: Task[]) => void;
 }
 
 function Ring({ task }: { task: Task }) {
@@ -170,33 +176,26 @@ function todayShortKo(): string {
   return `${d.getMonth() + 1}월 ${d.getDate()}일 · ${days[d.getDay()]}요일`;
 }
 
-export function MergedTodayScreen({ tasks: dummyTasks, onOpen, onMarkDone, onPartial, onFail, onOpenRecovery, onEvening }: MergedTodayScreenProps) {
+export function MergedTodayScreen({ tasks, onOpen, onMarkDone, onPartial, onFail, onOpenRecovery, onEvening, onAgendaLoaded }: MergedTodayScreenProps) {
   const { user } = useNavigation();
   const userName = user?.name ?? '친구';
 
-  // 화면이 렌더하는 실제 task 목록. 기본은 부모가 내려준 더미(BASE_TASKS).
-  // /today/agenda 가 성공하면 실데이터로 교체한다.
-  const [tasks, setTasks] = useState<Task[]>(dummyTasks);
   // agenda fetch 성공 = 백엔드 연결됨. 빈 응답이어도 true (연결 ≠ 데이터 존재).
   const [usingRealAgenda, setUsingRealAgenda] = useState(false);
   // 첫 agenda fetch 가 settle 되기 전엔 더미가 깜빡이지 않도록 스켈레톤만 노출.
   const [agendaLoading, setAgendaLoading] = useState(true);
 
-  // 실데이터를 아직 못 받았을 때만 부모의 더미 변경(완료/부분/실패 등)을 반영.
-  // 실데이터로 전환된 뒤엔 부모 더미를 무시한다.
-  useEffect(() => {
-    if (!usingRealAgenda) setTasks(dummyTasks);
-  }, [dummyTasks, usingRealAgenda]);
-
-  // /today/agenda 연동. 성공 시 actions → Task[] 매핑(빈 배열이어도 연결로 간주),
-  // 실패 시 더미 유지(usingRealAgenda=false).
+  // /today/agenda 연동. 성공 시 actions → Task[] 매핑(빈 배열이어도 연결로 간주)해
+  // 부모(ReActionMerged)의 tasks 를 이걸로 교체한다 — openTask/markDone 등이 같은
+  // 목록을 보게 되어 실제 카드 id 로도 정상 동작한다(#66).
+  // 실패 시 더미 유지(usingRealAgenda=false, 부모 tasks 그대로).
   useEffect(() => {
     let cancelled = false;
     todayApi.agenda().then(
       (agenda) => {
         if (cancelled) return;
         setUsingRealAgenda(true);
-        setTasks((agenda.cards ?? []).map(actionToTask));
+        onAgendaLoaded((agenda.cards ?? []).map(actionToTask));
       },
       () => { /* 네트워크/오류 — 더미 그대로, usingRealAgenda=false */ },
     ).finally(() => { if (!cancelled) setAgendaLoading(false); });


### PR DESCRIPTION
Closes #66

## 증상
실데이터(agenda)로 채워진 Today hero 카드에서 "시작하기"/완료/부분/실패가 **전부 무반응**. `POST /today/actions/{id}/start` 등 네트워크 요청 자체가 안 나감.

## 원인 (이슈에서 정확히 짚어준 그대로)
`ReActionMerged`(부모)가 `tasks` 를 `BASE_TASKS` 더미로 소유하고 `openTask`/`markDone`/`markPartial`/`markFailed` 가 그 목록에서 `tasks.find(id)` 로 조회. `TodayScreen`(자식)은 `/today/agenda` 실데이터를 **자신의 로컬 `tasks` state 로만** 반영해 부모 목록은 영원히 더미인 채 남음. 실제 카드는 UUID 라 부모 더미 목록(`t1~t5`)에 없어 `find` 가 항상 `undefined` → 조용히 no-op.

## 수정
상태 소유권을 **부모 하나로 통합**:
- `TodayScreen` 은 더 이상 로컬 `tasks` 사본을 만들지 않고, 부모가 내려준 `tasks` prop 을 그대로 렌더.
- agenda fetch 성공 시 새 `onAgendaLoaded` prop 으로 **부모의 `tasks` 자체**를 실데이터로 교체.
- `openTask`/`markDone`/`markPartial`/`markFailed` 가 이제 화면에 보이는 것과 **동일한 목록**(실제 UUID 포함)을 대상으로 동작.

## 검증
`tsc --noEmit` 클린 · `check:api` PASS · `vite build` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)