### PR TITLE
fix(app-shell): 모바일/데스크탑 동시 마운트로 API 2배 호출 수정 (#69)

### DIFF
--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -26,7 +26,26 @@ function stubIdToken(): string {
   return `demo:${deviceId}`;
 }
 
+// 데스크탑/모바일 레이아웃을 항상 둘 다 마운트해두고 CSS display:none 으로만 가리면
+// 안 보이는 트리도 useEffect 데이터 페칭을 그대로 실행해 모든 GET 이 2배로 나간다
+// (#69). matchMedia 로 실제 뷰포트에 맞는 트리 하나만 마운트한다.
+// index.css 의 .app-mobile/.app-desktop 분기 기준(1024px)과 반드시 맞춰야 한다.
+const DESKTOP_QUERY = '(min-width: 1024px)';
+function useIsDesktop(): boolean {
+  const [isDesktop, setIsDesktop] = useState(
+    () => typeof window !== 'undefined' && window.matchMedia(DESKTOP_QUERY).matches,
+  );
+  useEffect(() => {
+    const mql = window.matchMedia(DESKTOP_QUERY);
+    const onChange = (e: MediaQueryListEvent) => setIsDesktop(e.matches);
+    mql.addEventListener('change', onChange);
+    return () => mql.removeEventListener('change', onChange);
+  }, []);
+  return isDesktop;
+}
+
 export function AppShell() {
+  const isDesktop = useIsDesktop();
   const [screen, setScreen] = useState<ScreenId>('intro');
   const [tab, setTab] = useState<TabId>('today');
   const [user, setUser] = useState<UserProfile | null>(null);
@@ -201,20 +220,21 @@ export function AppShell() {
       value={{ screen, tab, setScreen, setTab, user, onboardingState, isBootstrapping, weekOffset, setWeekOffset, interviewSessionId, setInterviewSessionId }}
     >
       <ToastProvider>
-        {/* ── 모바일 (< 1024px): 단일 컬럼 ── */}
-        <div className="app-mobile">
-          <div className="app-container">
-            <ReActionMerged />
+        {/* 뷰포트에 맞는 트리 하나만 마운트(둘 다 마운트 후 CSS 로만 숨기면 데이터 페칭이 2배로 나감). */}
+        {isDesktop ? (
+          <div className="app-desktop">
+            <DesktopSidebar />
+            <main className="app-main">
+              <ReActionMerged hideTabs />
+            </main>
           </div>
-        </div>
-
-        {/* ── 데스크탑 (≥ 1024px): 사이드바 + 콘텐츠 ── */}
-        <div className="app-desktop">
-          <DesktopSidebar />
-          <main className="app-main">
-            <ReActionMerged hideTabs />
-          </main>
-        </div>
+        ) : (
+          <div className="app-mobile">
+            <div className="app-container">
+              <ReActionMerged />
+            </div>
+          </div>
+        )}
       </ToastProvider>
     </NavigationContext.Provider>
   );


### PR DESCRIPTION
Closes #69

## 증상
Today/Weekly/Review 진입만으로 `/today/agenda`, `/habits`, `/habit-instances`, `/plans/weekly`, `/reviews/weekly` 등 **모든 GET 요청이 정확히 2번씩** 나감(StrictMode 이중 호출 아님, prod 빌드에서도 재현). 동일 접근성 라벨(예: "시작하기") 엘리먼트도 DOM에 2개 존재.

## 원인
`AppShell` 이 `.app-mobile`/`.app-desktop` 두 레이어를 **뷰포트와 무관하게 항상 둘 다 렌더**하고, CSS 미디어쿼리(`min-width:1024px`)로 `display:none` 만 적용. 숨겨진 트리도 DOM에 남아 `<ReActionMerged/>` 가 실제로 **2개 마운트**되고, 각자의 `useEffect` 데이터 페칭이 독립적으로 실행되어 모든 GET이 2배가 됨.

## 수정
`window.matchMedia('(min-width: 1024px)')` 기반 `useIsDesktop()` 훅으로 **뷰포트에 맞는 트리 하나만 마운트**(CSS 브레이크포인트와 동일 값, resize/orientation 변경 시 갱신).

## 검증
`tsc --noEmit` 클린 · `check:api` PASS · `vite build` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)