### PR TITLE
feat(settings): 인터뷰 다시하기 진입점 추가

### DIFF
--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { CaretLeft, Sparkle, BellRinging, BellSlash, Shield, Warning, Check } from '@phosphor-icons/react';
+import { CaretLeft, Sparkle, BellRinging, BellSlash, Shield, Warning, Check, ArrowClockwise } from '@phosphor-icons/react';
 import { ApiError, notificationsApi, privacyApi, settingsApi } from '../lib/api';
 import { subscribePush, unsubscribePush, getPushPermission } from '../lib/push';
 import { useNavigation } from '../contexts/NavigationContext';
@@ -24,6 +24,7 @@ export function SettingsScreen() {
   const [pushEnabled, setPushEnabled] = useState(false);
   const [pushBusy, setPushBusy] = useState(false);
   const [confirmAnonymize, setConfirmAnonymize] = useState(false);
+  const [confirmRestartInterview, setConfirmRestartInterview] = useState(false);
   const [toast, setToast] = useState<string | null>(null);
 
   useEffect(() => {
@@ -202,6 +203,30 @@ export function SettingsScreen() {
               );
             })}
           </div>
+        </section>
+
+        {/* Onboarding */}
+        <section>
+          <SectionLabel icon={<ArrowClockwise size={11} weight="fill" />}>온보딩</SectionLabel>
+          <button
+            onClick={() => setConfirmRestartInterview(true)}
+            style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '12px 14px', width: '100%', background: 'var(--surface-raised)', border: '1.5px solid var(--sand-200)', borderRadius: 12, cursor: 'pointer', fontFamily: 'inherit', textAlign: 'left' }}
+          >
+            <div style={{ flex: 1 }}>
+              <div style={{ fontWeight: 600, fontSize: 13, color: 'var(--text-1)' }}>인터뷰 다시하기</div>
+              <div style={{ fontSize: 11, color: 'var(--text-3)', marginTop: 2 }}>목표 파악 질문을 처음부터 다시 진행해요. 기존 목표는 그대로 남아요.</div>
+            </div>
+          </button>
+          {confirmRestartInterview && (
+            <div style={{ marginTop: 8, padding: 12, background: 'var(--brand-soft)', border: '1px solid var(--coral-200)', borderRadius: 12 }}>
+              <div style={{ fontSize: 12, fontWeight: 700, color: 'var(--coral-700)', marginBottom: 6 }}>지금 인터뷰를 다시 시작할까요?</div>
+              <div style={{ fontSize: 11, color: 'var(--coral-700)', marginBottom: 10, lineHeight: 1.5 }}>목표 파악부터 다시 진행돼요. 기존 목표는 삭제되지 않고 그대로 남아있어요 — 새 인터뷰로 목표를 더 추가하게 돼요.</div>
+              <div style={{ display: 'flex', gap: 8 }}>
+                <button onClick={() => setConfirmRestartInterview(false)} style={{ flex: 1, height: 36, borderRadius: 10, border: '1px solid var(--sand-200)', background: 'var(--surface-raised)', color: 'var(--text-2)', fontWeight: 600, fontSize: 12, cursor: 'pointer', fontFamily: 'inherit' }}>취소</button>
+                <button onClick={() => setScreen('goal-intake')} style={{ flex: 1, height: 36, borderRadius: 10, border: 'none', background: 'var(--brand)', color: '#FFFCF6', fontWeight: 700, fontSize: 12, cursor: 'pointer', fontFamily: 'inherit' }}>다시 시작</button>
+              </div>
+            </div>
+          )}
         </section>
 
         {/* Danger zone */}


### PR DESCRIPTION
## 배경

사용자가 이미 온보딩을 마친 계정으로도 목표 파악 인터뷰를 다시 진행하고 싶어하는 경우(계정에 처음 보는/원치 않는 목표가 들어있거나, 상황이 바뀌어 인터뷰를 다시 받고 싶을 때)가 있는데, 지금까지는 온보딩이 끝나면(`onboarding_state=ACTIVE`) 다시 인터뷰로 들어갈 방법이 프론트에 전혀 없었다.

## 조사 결과

- 백엔드 `POST /interview/sessions`는 `onboarding_state`를 전혀 체크하지 않는다 — 이미 ACTIVE인 유저도 API 레벨에서는 인터뷰를 다시 시작할 수 있다. 막고 있는 건 순전히 프론트(진입 UI 부재)뿐이었다.
- 세션 재시작("restart-wins": 기존 진행 중 세션을 `abandoned` 처리 후 새로 시작)도 이미 구현돼 있어 백엔드 변경이 필요 없다.
- 재인터뷰 시 기존 목표를 어떻게 처리할지 고민했고(전부 보관 처리 vs 그대로 두기 vs 매번 선택), **가장 단순한 "기존 목표는 그대로 두고 인터뷰만 재실행"**으로 정했다. 새 인터뷰가 끝나면 First Plan 생성 단계에서 목표가 추가되는 방식이라, 결과적으로 기존 목표 위에 새 목표가 더해진다(참고: Focus≤3/Maintain≤5 tier 한도에 걸릴 수 있음 — 추후 필요시 별도 처리).

## 변경 사항

- `src/screens/SettingsScreen.tsx`: "온보딩" 섹션에 "인터뷰 다시하기" 버튼 + 인라인 확인(기존 anonymize 버튼과 동일한 확인 패턴) 추가.
- 확인 시 `setScreen('goal-intake')`로 이동 — `GoalIntakeScreen`이 마운트되며 기존 로직대로 새 인터뷰 세션을 시작한다(추가 배선 불필요).

## 검증

- `tsc && vite build` 클린 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)