### PR TITLE
chore(api): 백엔드 API 동기화 (routine)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -108,8 +108,8 @@
             "type": "string"
           },
           "estimatedMinutes": {
-            "exclusiveMinimum": 0.0,
             "maximum": 60.0,
+            "minimum": 1.0,
             "title": "Estimatedminutes",
             "type": "integer"
           },
@@ -792,6 +792,54 @@
           "ok"
         ],
         "title": "DbStatus",
+        "type": "object"
+      },
+      "ExecutionEventResponse": {
+        "description": "POST /today/focus/{id}/pause·resume 응답 — 집중 세션 일시정지/재개 (#83).\n\npause 는 interruption_events(user_pause) 를 열고, resume 은 그 구간을 닫아\nexecution.pause_total_minutes 에 누적한다. execution 자체는 in_progress 유지.",
+        "properties": {
+          "actionItemId": {
+            "title": "Actionitemid",
+            "type": "string"
+          },
+          "endedAt": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Endedat"
+          },
+          "executionId": {
+            "title": "Executionid",
+            "type": "string"
+          },
+          "pauseTotalMinutes": {
+            "title": "Pausetotalminutes",
+            "type": "integer"
+          },
+          "startedAt": {
+            "format": "date-time",
+            "title": "Startedat",
+            "type": "string"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "executionId",
+          "actionItemId",
+          "startedAt",
+          "endedAt",
+          "status",
+          "pauseTotalMinutes"
+        ],
+        "title": "ExecutionEventResponse",
         "type": "object"
       },
       "ExecutionStartResponse": {
@@ -2541,9 +2589,11 @@
             ],
             "title": "Breakpattern"
           },
-          "downscopeOk": {
-            "title": "Downscopeok",
-            "type": "boolean"
+          "downscopeUnitMin": {
+            "default": 10,
+            "minimum": 1.0,
+            "title": "Downscopeunitmin",
+            "type": "integer"
           },
           "focusDurationMin": {
             "anyOf": [
@@ -2578,8 +2628,7 @@
         },
         "required": [
           "recoveryTone",
-          "restOk",
-          "downscopeOk"
+          "restOk"
         ],
         "title": "PreferenceProfile",
         "type": "object"
@@ -2608,7 +2657,7 @@
         "type": "object"
       },
       "Question": {
-        "description": "인터뷰 질문 — 세션의 currentQuestion.",
+        "description": "인터뷰 질문 — 세션의 currentQuestion.\n\n`options` = 카탈로그 고정 보기 (chip/select 의 유효 선택지, 정적 진실 소스).\n`suggested_answers` = LLM 이 슬롯 맥락에 맞춰 추천한 답변 카드 — 주로 고정 보기가 없는\n자유서술 슬롯(goals.list·success_image·time.fixed_blocks 등)에서 탭/참고용으로 채워진다.",
         "properties": {
           "answerType": {
             "title": "Answertype",
@@ -2624,6 +2673,13 @@
           "slotKey": {
             "title": "Slotkey",
             "type": "string"
+          },
+          "suggestedAnswers": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Suggestedanswers",
+            "type": "array"
           },
           "text": {
             "title": "Text",
@@ -5515,7 +5571,7 @@
     },
     "/interview/sessions": {
       "post": {
-        "description": "딥 인터뷰 세션 시작 — FSM 이 고른 첫 필수 슬롯 질문 1개 생성.\n\n단일 활성 세션 enforce: 이미 진행 중(end_reason IS NULL)인 세션이 있으면 409.\n동시성 lock(ADR-0005 §7.6) 안에서 검사+생성해 다중 디바이스 race 를 막는다.",
+        "description": "딥 인터뷰 세션 시작 — FSM 이 고른 첫 필수 슬롯 질문 1개 생성.\n\n재시작 승리(restart-wins): 진행 중(end_reason IS NULL) 세션이 있으면 `abandoned` 로\n닫고 새로 시작한다 — 항상 201. FE 가 sessionId 를 잃어도(새로고침·localStorage 유실)\n재시작만으로 복구된다. 이어하기는 기존 `next-question` 재개 경로 그대로.\n동시성 lock(ADR-0005 §7.6) 안에서 검사+생성해 다중 디바이스 race 를 막는다.",
         "operationId": "start_session_interview_sessions_post",
         "parameters": [
           {
@@ -7922,6 +7978,124 @@
           }
         },
         "summary": "Quick Check In",
+        "tags": [
+          "today"
+        ]
+      }
+    },
+    "/today/focus/{execution_id}/pause": {
+      "post": {
+        "description": "[⏸] 집중 세션 일시정지 (#83) — user_pause interruption 을 연다.\n\nexecution 은 in_progress 유지. 이미 정지 중이면 409. 재개 시 누적 시간이 반영된다.",
+        "operationId": "pause_focus_today_focus__execution_id__pause_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "execution_id",
+            "required": true,
+            "schema": {
+              "title": "Execution Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExecutionEventResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Pause Focus",
+        "tags": [
+          "today"
+        ]
+      }
+    },
+    "/today/focus/{execution_id}/resume": {
+      "post": {
+        "description": "[▶ 계속] 집중 세션 재개 (#83) — 열린 정지 구간을 닫고 pause_total_minutes 누적.\n\n정지 중이 아니면 409. 정지 시작(created_at)부터 지금까지를 지연분으로 기록한다.",
+        "operationId": "resume_focus_today_focus__execution_id__resume_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "execution_id",
+            "required": true,
+            "schema": {
+              "title": "Execution Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExecutionEventResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Resume Focus",
         "tags": [
           "today"
         ]

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -298,7 +298,7 @@ export const habitsApi = {
 };
 
 // ── Today / Execution (S10-S13) ───────────────────────────────
-// start·check-ins 는 백엔드 #13 구현됨. agenda/action 상세·pause/resume 은 미구현.
+// start·check-ins 는 백엔드 #13 구현됨. focus pause/resume 은 백엔드 #83 구현됨.
 export const todayApi = {
   agenda: () => request<TodayAgenda>('/today/agenda'),
 

--- a/src/screens/FocusScreen.tsx
+++ b/src/screens/FocusScreen.tsx
@@ -5,6 +5,11 @@ import { ReButton } from '../components/ReButton';
 import { todayApi } from '../lib/api';
 import type { Task } from '../types';
 
+// 집중 세션 executionId 를 task.id 별로 모듈 스코프에 보관한다.
+// FocusScreen 은 일시정지 시 unmount 되므로 컴포넌트 ref 로는 유지되지 않는다.
+// 이 맵 덕에 같은 task 로 재진입하면 start 대신 resume(#83) 을 호출할 수 있다.
+const focusExecutions = new Map<string, string>();
+
 interface FocusScreenProps {
   // 잘못된 상태(force navigation, 빈 tasks 등)로 마운트되어도 폭발하지 않도록 null 허용.
   task: Task | null;
@@ -16,18 +21,29 @@ interface FocusScreenProps {
 }
 
 export function FocusScreen({ task, elapsedMin, totalMin, onPause, onComplete, onBack }: FocusScreenProps) {
-  // mock-and-replace: 백엔드 /today/* 가 501. 시작/일시정지/완료를 mock 으로 시도하되
-  // 실패는 조용히 — 화면 흐름(onPause/onComplete) 은 그대로 진행.
+  // mock-and-replace: start·check-ins(#13)·pause·resume(#83) 을 실제로 호출하되
+  // 실패는 조용히 — 화면 흐름(onPause/onComplete) 은 그대로 진행(fallback).
   const executionIdRef = useRef<string | null>(null);
 
-  // 첫 진입 시 시작 호출 (executionId 확보 시도)
+  // 진입 시: 이 task 의 열린 세션이 있으면 resume(#83), 없으면 start(#13).
   React.useEffect(() => {
     if (!task) return;
     let cancelled = false;
-    todayApi.start(task.id).then(
-      (e) => { if (!cancelled) executionIdRef.current = e.executionId; },
-      () => { /* 501 — 그냥 진행 */ },
-    );
+    const existing = focusExecutions.get(task.id);
+    if (existing) {
+      executionIdRef.current = existing;
+      // 정지 중이 아니면 백엔드가 409 — 조용히 무시하고 진행.
+      todayApi.resume(existing).catch(() => {});
+    } else {
+      todayApi.start(task.id).then(
+        (e) => {
+          if (cancelled) return;
+          executionIdRef.current = e.executionId;
+          focusExecutions.set(task.id, e.executionId);
+        },
+        () => { /* 미구현/실패 — 그냥 진행 */ },
+      );
+    }
     return () => { cancelled = true; };
   }, [task?.id]);
 
@@ -59,6 +75,8 @@ export function FocusScreen({ task, elapsedMin, totalMin, onPause, onComplete, o
         )
         .catch(() => {});
     }
+    // 세션 종료 — 재진입 시 새 start 를 타도록 보관한 executionId 를 비운다.
+    if (task) focusExecutions.delete(task.id);
     onComplete();
   };
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -280,13 +280,15 @@ export interface TodayAgenda {
 
 export type CompletionStatus = 'done' | 'partial_done' | 'failed' | 'over_done';
 
-// /today/focus/{executionId}/pause·resume 는 아직 contract 추정(미구현).
+// /today/focus/{executionId}/pause·resume 응답 — ExecutionEventResponse (#83, 구현됨).
+// pause 는 user_pause 구간을 열고, resume 은 닫아 pauseTotalMinutes 에 누적한다.
 export interface ExecutionEvent {
   executionId: string;
   actionItemId: string;
   startedAt: string; // KST ISO
   endedAt: string | null;
   status: CompletionStatus | 'started' | string;
+  pauseTotalMinutes: number;
 }
 
 // POST /today/actions/{actionId}/start (#13)

--- a/src/types/openapi.d.ts
+++ b/src/types/openapi.d.ts
@@ -535,7 +535,9 @@ export interface paths {
          * Start Session
          * @description 딥 인터뷰 세션 시작 — FSM 이 고른 첫 필수 슬롯 질문 1개 생성.
          *
-         *     단일 활성 세션 enforce: 이미 진행 중(end_reason IS NULL)인 세션이 있으면 409.
+         *     재시작 승리(restart-wins): 진행 중(end_reason IS NULL) 세션이 있으면 `abandoned` 로
+         *     닫고 새로 시작한다 — 항상 201. FE 가 sessionId 를 잃어도(새로고침·localStorage 유실)
+         *     재시작만으로 복구된다. 이어하기는 기존 `next-question` 재개 경로 그대로.
          *     동시성 lock(ADR-0005 §7.6) 안에서 검사+생성해 다중 디바이스 race 를 막는다.
          */
         post: operations["start_session_interview_sessions_post"];
@@ -1346,6 +1348,50 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/today/focus/{execution_id}/pause": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Pause Focus
+         * @description [⏸] 집중 세션 일시정지 (#83) — user_pause interruption 을 연다.
+         *
+         *     execution 은 in_progress 유지. 이미 정지 중이면 409. 재개 시 누적 시간이 반영된다.
+         */
+        post: operations["pause_focus_today_focus__execution_id__pause_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/today/focus/{execution_id}/resume": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Resume Focus
+         * @description [▶ 계속] 집중 세션 재개 (#83) — 열린 정지 구간을 닫고 pause_total_minutes 누적.
+         *
+         *     정지 중이 아니면 409. 정지 시작(created_at)부터 지금까지를 지연분으로 기록한다.
+         */
+        post: operations["resume_focus_today_focus__execution_id__resume_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -1704,6 +1750,30 @@ export interface components {
             latency_ms?: number | null;
             /** Ok */
             ok: boolean;
+        };
+        /**
+         * ExecutionEventResponse
+         * @description POST /today/focus/{id}/pause·resume 응답 — 집중 세션 일시정지/재개 (#83).
+         *
+         *     pause 는 interruption_events(user_pause) 를 열고, resume 은 그 구간을 닫아
+         *     execution.pause_total_minutes 에 누적한다. execution 자체는 in_progress 유지.
+         */
+        ExecutionEventResponse: {
+            /** Actionitemid */
+            actionItemId: string;
+            /** Endedat */
+            endedAt: string | null;
+            /** Executionid */
+            executionId: string;
+            /** Pausetotalminutes */
+            pauseTotalMinutes: number;
+            /**
+             * Startedat
+             * Format: date-time
+             */
+            startedAt: string;
+            /** Status */
+            status: string;
         };
         /**
          * ExecutionStartResponse
@@ -2447,8 +2517,11 @@ export interface components {
         PreferenceProfile: {
             /** Breakpattern */
             breakPattern?: string | null;
-            /** Downscopeok */
-            downscopeOk: boolean;
+            /**
+             * Downscopeunitmin
+             * @default 10
+             */
+            downscopeUnitMin: number;
             /** Focusdurationmin */
             focusDurationMin?: number | null;
             /** Recoverytone */
@@ -2473,6 +2546,10 @@ export interface components {
         /**
          * Question
          * @description 인터뷰 질문 — 세션의 currentQuestion.
+         *
+         *     `options` = 카탈로그 고정 보기 (chip/select 의 유효 선택지, 정적 진실 소스).
+         *     `suggested_answers` = LLM 이 슬롯 맥락에 맞춰 추천한 답변 카드 — 주로 고정 보기가 없는
+         *     자유서술 슬롯(goals.list·success_image·time.fixed_blocks 등)에서 탭/참고용으로 채워진다.
          */
         Question: {
             /** Answertype */
@@ -2481,6 +2558,8 @@ export interface components {
             options: string[];
             /** Slotkey */
             slotKey: string;
+            /** Suggestedanswers */
+            suggestedAnswers?: string[];
             /** Text */
             text: string;
         };
@@ -5445,6 +5524,72 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["CheckInResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    pause_focus_today_focus__execution_id__pause_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                execution_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ExecutionEventResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    resume_focus_today_focus__execution_id__resume_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                execution_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ExecutionEventResponse"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
백엔드(`reaction-backend`) OpenAPI 를 재덤프하여 프론트 타입·래퍼·화면에 반영한 정기 동기화입니다.

## (a) 신규/변경 엔드포인트
- **`POST /today/focus/{execution_id}/pause`**, **`POST /today/focus/{execution_id}/resume`** (#83) — 이전 라운드까지 WARN(백엔드 미구현 stub)이었으나 이번에 백엔드 구현되어 **OK** 로 전환. 집중 세션 일시정지/재개(누적 `pause_total_minutes`).
- 응답 스키마 `ExecutionEventResponse` 에 `pauseTotalMinutes: integer` 필드 추가 → 수기 타입 `ExecutionEvent` 를 실제 스키마에 맞게 교정.
- `src/types/openapi.d.ts` 는 재생성(`gen:api`)으로 갱신.

## (b) 화면 실연동한 곳
- **FocusScreen (집중 모드)** — 기존에는 진입 시 항상 `start` 만 호출했고, 일시정지 시 컴포넌트가 unmount 되어 `executionId` 가 사라져 `resume` 은 호출 불가능한 상태였습니다.
  - `task.id → executionId` 를 모듈 스코프에 보관하여, 같은 카드로 재진입하면 `start` 대신 **`resume`(#83)** 을 호출하도록 pause→resume 사이클을 실연동.
  - 완료 시 보관한 `executionId` 정리(다음 세션은 새 `start`).
  - mock-and-replace 유지: 모든 호출 실패(미구현/네트워크/409 등)는 조용히 무시되어 화면 흐름이 깨지지 않습니다.

## (c) check:api 요약
```
✅ OK   66   ⚠️ WARN 1 (GET /reflection/pending — 백엔드 미구현, UI 그대로 유지)
❌ GONE 0    🆕 NEW 10 (아직 래퍼 미추가 — 이번 변경 범위 밖)
결과: PASS
```

## 검증 게이트
- `npm run check:api` → GONE 0, PASS
- `npx tsc --noEmit` → 통과
- `npm run build` → 성공

미구현(WARN)인 `GET /reflection/pending` 및 NEW 엔드포인트 10건은 이번 백엔드 변경분이 아니므로 UI/래퍼를 건드리지 않았습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018qeTCNjpcwVspNsBC9XP9b)_