### PR TITLE
fix(goal-classify): 목표 분류 화면이 GET /goals 대신 인터뷰 outcome 렌더 (#75)

### DIFF
--- a/src/app/ReActionMerged.tsx
+++ b/src/app/ReActionMerged.tsx
@@ -21,6 +21,7 @@ import { WeeklyReviewScreenV2 } from '../screens/WeeklyReviewScreen';
 import { BASE_TASKS, MERGED_PROPOSALS } from '../data';
 import { useNavigation } from '../contexts/NavigationContext';
 import type { ScreenId, TabId, Task } from '../types';
+import type { InterviewOutcome } from '../types/api';
 
 // onboarding 흐름은 백엔드 §3 state machine 을 기반으로 하되, 클라이언트에서 두 쌍을
 // 묶고 coping-style 을 제거해 8단계 → 5단계로 줄였다 (recovery.tone 은 인터뷰에서 받음):
@@ -92,6 +93,9 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
   const { screen, tab, setScreen, setTab, setWeekOffset } = useNavigation();
 
   const [tasks, setTasks] = useState<Task[]>(BASE_TASKS);
+  // 방금 끝난 목표 파악 인터뷰의 outcome — 목표 분류(S03) 화면이 GET /goals
+  // (이 시점엔 항상 빈 테이블) 대신 이 값을 렌더한다(#75).
+  const [interviewOutcome, setInterviewOutcome] = useState<InterviewOutcome | null>(null);
   const [activeTask, setActiveTask] = useState<Task | null>(null);
   const [failReason, setFailReason] = useState('');
   // 이번 세션에서 수락한 복구 횟수 (백엔드 누적 집계 엔드포인트가 없어 세션 카운트로 정직하게).
@@ -185,10 +189,10 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
           <SystemIntroScreen onDone={() => setScreen('goal-intake')} />
         )}
         {screen === 'goal-intake' && (
-          <GoalIntakeScreen onDone={() => setScreen('goal-classify')} />
+          <GoalIntakeScreen onDone={() => setScreen('goal-classify')} onOutcome={setInterviewOutcome} />
         )}
         {screen === 'goal-classify' && (
-          <GoalClassificationScreen onNext={() => setScreen('setup')} />
+          <GoalClassificationScreen onNext={() => setScreen('setup')} outcome={interviewOutcome} />
         )}
         {screen === 'setup' && (
           <SetupScreen onDone={() => setScreen('weekly-plan')} />

--- a/src/screens/GoalClassificationScreen.tsx
+++ b/src/screens/GoalClassificationScreen.tsx
@@ -2,13 +2,16 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { Sparkle, Check } from '@phosphor-icons/react';
 import { INIT_GOALS, GOAL_STATUS_META } from '../data';
 import { ApiError, goalsApi } from '../lib/api';
-import type { ApiGoal, GoalsByTier } from '../types/api';
+import type { ApiGoal, GoalCandidate, GoalsByTier, InterviewOutcome } from '../types/api';
 import type { Goal, GoalStatus } from '../types';
 import { SetupProgress } from '../components/SetupProgress';
 import { AiDraftCard } from '../components/AiDraftCard';
 
 interface GoalClassificationScreenProps {
   onNext: () => void;
+  // 방금 끝난 목표 파악 인터뷰의 outcome. 이 화면(S03)은 First Plan 승인(S06) 이전
+  // 단계라 GET /goals 는 항상 빈 테이블이므로(#75), 있으면 이쪽을 우선 렌더한다.
+  outcome?: InterviewOutcome | null;
 }
 
 // 백엔드 ApiGoal → 화면용 Goal. progress·weeklyH 는 백엔드 mock 응답에 없어
@@ -25,21 +28,44 @@ function toUiGoal(api: ApiGoal): Goal {
   };
 }
 
+// 인터뷰 outcome.coreGoals → 화면용 Goal. 아직 goals 테이블에 저장되기 전(#75)이라
+// goalId 가 없다 — synthetic id(cand_N, "goal_" 로 시작 안 함)를 부여해 changeStatus 가
+// 기존 더미 데이터와 동일하게 로컬로만 처리하도록 한다(서버 저장은 First Plan 승인 때).
+function toUiGoalFromCandidate(c: GoalCandidate, idx: number): Goal {
+  return {
+    id: `cand_${idx}`,
+    name: c.title,
+    deadline: c.deadline ?? 'ongoing',
+    status: c.tentativeTier,
+    progress: 0,
+    weeklyH: 0,
+  };
+}
+
 function flatten(byTier: GoalsByTier): Goal[] {
   return [...byTier.focus, ...byTier.maintain, ...byTier.parked].map(toUiGoal);
 }
 
-export function GoalClassificationScreen({ onNext }: GoalClassificationScreenProps) {
+export function GoalClassificationScreen({ onNext, outcome }: GoalClassificationScreenProps) {
   // 초기값 비움 → 로딩 중 스켈레톤, 실패 시에만 INIT_GOALS 더미 fallback (더미 flash 방지).
   const [goals, setGoals] = useState<Goal[]>([]);
   const [selected, setSelected] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  // goalsApi.list 가 성공했는지 — true 면 goals 가 실데이터(비어있어도)라 더미로 가리지 않는다.
+  // goals 가 실데이터(비어있어도)인지 — outcome 이든 goalsApi.list 든 성공하면 true.
   const [usingReal, setUsingReal] = useState(false);
 
-  // goalsApi.list 호출. AiDraftCard 재생성 버튼에서도 같은 헬퍼 사용.
+  // outcome.coreGoals 가 있으면 그걸 쓰고(정상 경로), 없을 때만 GET /goals 로 fallback한다
+  // (예: 인터뷰를 거치지 않고 이 화면에 직접 진입한 dev/force-nav 케이스).
+  // AiDraftCard 재생성 버튼("다시 분류")에서도 같은 헬퍼를 재사용한다.
   const fetchGoals = useCallback(() => {
+    if (outcome) {
+      setUsingReal(true);
+      setGoals(outcome.coreGoals.map(toUiGoalFromCandidate));
+      setIsLoading(false);
+      setError(null);
+      return () => {};
+    }
     setIsLoading(true);
     let cancelled = false;
     goalsApi
@@ -66,7 +92,7 @@ export function GoalClassificationScreen({ onNext }: GoalClassificationScreenPro
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [outcome]);
 
   useEffect(() => {
     const cleanup = fetchGoals();

--- a/src/screens/GoalIntakeScreen.tsx
+++ b/src/screens/GoalIntakeScreen.tsx
@@ -1,12 +1,15 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Sparkle, ArrowUp, ArrowRight } from '@phosphor-icons/react';
 import { ApiError, interviewApi } from '../lib/api';
-import type { InterviewQuestion, InterviewSession, SlotCatalogEntry } from '../types/api';
+import type { InterviewOutcome, InterviewQuestion, InterviewSession, SlotCatalogEntry } from '../types/api';
 import { SetupProgress } from '../components/SetupProgress';
 import { useNavigation } from '../contexts/NavigationContext';
 
 interface GoalIntakeScreenProps {
   onDone: () => void;
+  // 인터뷰가 끝나 outcome(coreGoals 포함)을 받으면 상위로 올려준다 — 목표 분류(S03) 화면이
+  // GET /goals(이 시점엔 항상 빈 테이블, #75) 대신 이 값을 렌더한다.
+  onOutcome?: (outcome: InterviewOutcome) => void;
 }
 
 interface ChatMessage {
@@ -35,7 +38,7 @@ function omxStatus(clarity: number) {
   return { icon: '☀️', text: '완벽해요! 상황이 선명하게 파악됐어요.' };
 }
 
-export function GoalIntakeScreen({ onDone }: GoalIntakeScreenProps) {
+export function GoalIntakeScreen({ onDone, onOutcome }: GoalIntakeScreenProps) {
   // 인터뷰 세션 id 를 전역에 올려, weekly-plan(S06) 에서 /plans/generate 가 쓸 수 있게 한다.
   const { setInterviewSessionId } = useNavigation();
   const [session, setSession] = useState<InterviewSession | null>(null);
@@ -217,6 +220,7 @@ export function GoalIntakeScreen({ onDone }: GoalIntakeScreenProps) {
           endReason: next.endReason ?? 'completed',
           currentQuestion: null,
         });
+        if (next.outcome) onOutcome?.(next.outcome);
         setMessages((m) => [
           ...m,
           {
@@ -267,6 +271,7 @@ export function GoalIntakeScreen({ onDone }: GoalIntakeScreenProps) {
     try {
       const s = await interviewApi.finish(session.sessionId);
       setSession(s);
+      if (s.outcome) onOutcome?.(s.outcome);
       setMessages((m) => [...m, { id: newMsgId('ai-finish'), who: 'ai', text: '여기까지 정리해 둘게요. 언제든 이어할 수 있어요.' }]);
     } catch (err: unknown) {
       const msg = err instanceof ApiError ? `[${err.code}] ${err.message}` : '종료 처리 중 오류가 발생했어요.';

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -54,12 +54,49 @@ export interface InterviewQuestion {
 
 export type InterviewEndReason = 'early_user' | 'completed' | null;
 
+// 핵심 목표 후보 (outcome.coreGoals) — First Plan 의 goal_node 분해 입력이자,
+// 목표 분류(S03) 화면이 GET /goals 대신 렌더해야 하는 값(#75. 이 시점엔 아직
+// 어떤 목표도 goals 테이블에 저장돼있지 않다 — 저장은 First Plan 승인(S06)때).
+export interface GoalCandidate {
+  title: string;
+  category: string;
+  isHeaviest: boolean;
+  deadline?: string | null;
+  whyNow?: string | null;
+  successImage?: string | null;
+  tentativeTier: 'focus' | 'maintain' | 'parked';
+  confidence: number;
+}
+
+// 종료 턴(S03 확인 카드용) 요약 — 표현 계층일 뿐, First Plan 시드는 outcome 쪽.
+export interface InterviewSummary {
+  confirmQuestion: string;
+  goalSummary: string;
+  headline: string;
+  preferenceSummary: string;
+  timeSummary: string;
+}
+
+// Deep Interview 최종 산출물. coreGoals 외 나머지(availability/identity/preferences 등)는
+// 현재 프론트에서 직접 소비하지 않아 타입만 열어둔다.
+export interface InterviewOutcome {
+  sessionId: string;
+  endReason: 'completed' | 'turn_limit' | 'early_user' | 'abandoned';
+  ambiguityFinal: number;
+  coreGoals: GoalCandidate[];
+  unresolvedSlots?: string[];
+  [key: string]: unknown;
+}
+
 export interface InterviewSession {
   sessionId: string;
   ambiguityScore: number;
   totalTurns: number;
   endReason: InterviewEndReason;
   currentQuestion: InterviewQuestion | null;
+  // 종료 턴에만 채워진다(진행 중엔 둘 다 null/undefined) — §4.
+  outcome?: InterviewOutcome | null;
+  summary?: InterviewSummary | null;
 }
 
 export interface SlotAnswerRequest {


### PR DESCRIPTION
## 배경 (Closes #75)

딥 인터뷰(S02) 완료 후 목표 분류(S03)로 넘어가면 파악된 목표가 하나도 안 뜨고 "아직 등록된 목표가 없어요" 만 나오는 버그. 실제 구글 로그인으로 온보딩하는 신규 유저 전원에게 재현되어 온보딩이 여기서 막힘.

## 원인

S03 화면이 `GET /goals`(영속화된 Goal 테이블)를 읽는데, 이 시점엔 아직 First Plan 승인(S06, `POST /plans/{id}/approve`)이 일어나지 않아 goals 테이블이 항상 비어있다. 인터뷰가 파악한 목표는 인터뷰 종료 응답의 `outcome.coreGoals` 에만 담겨 온다(계약 §3·§4). 백엔드는 계약대로 정상 동작 — 프론트가 잘못된 소스를 읽고 있었다.

이전엔 stub 모드라 전원이 seed 데모 계정(김민수, goals 미리 심어짐)으로 로그인돼 버그가 가려져 있었다. reaction-backend#94 로 stub 을 끄면서 실제 구글 계정(빈 신규 유저)에서 드러남.

## 변경 사항

- `types/api.ts`: `InterviewSession` 에 빠져있던 `outcome`/`summary` 필드 추가, `GoalCandidate`/`InterviewSummary`/`InterviewOutcome` 타입 신설 (openapi.d.ts 실 스키마 기준).
- `GoalIntakeScreen.tsx`: 인터뷰 종료(정상 완료·"충분해요" 조기종료 모두) 시 `outcome` 을 `onOutcome` 콜백으로 상위에 전달.
- `ReActionMerged.tsx`: `interviewOutcome` state 로 끌어올려 `GoalIntakeScreen` → `GoalClassificationScreen` 에 배선.
- `GoalClassificationScreen.tsx`: `outcome.coreGoals` 가 있으면 그걸 렌더 소스로 쓰고(synthetic id `cand_N` 부여, 기존 "goal_ 접두사 없으면 로컬 전용" 재분류 로직 그대로 재사용 — First Plan 승인 전엔 서버 저장 대상이 아님), 없을 때만(dev `?force=goal-classify` 등) 기존 `GET /goals` 로 fallback.

## 검증

- `npx tsc --noEmit` 클린
- `node scripts/check-api-contract.mjs` → PASS, GONE 0
- `npm run build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)