### PR TITLE
chore(api): 백엔드 API 동기화 (routine)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -108,8 +108,8 @@
             "type": "string"
           },
           "estimatedMinutes": {
-            "exclusiveMinimum": 0.0,
             "maximum": 60.0,
+            "minimum": 1.0,
             "title": "Estimatedminutes",
             "type": "integer"
           },
@@ -792,6 +792,54 @@
           "ok"
         ],
         "title": "DbStatus",
+        "type": "object"
+      },
+      "ExecutionEventResponse": {
+        "description": "POST /today/focus/{id}/pause·resume 응답 — 집중 세션 일시정지/재개 (#83).\n\npause 는 interruption_events(user_pause) 를 열고, resume 은 그 구간을 닫아\nexecution.pause_total_minutes 에 누적한다. execution 자체는 in_progress 유지.",
+        "properties": {
+          "actionItemId": {
+            "title": "Actionitemid",
+            "type": "string"
+          },
+          "endedAt": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Endedat"
+          },
+          "executionId": {
+            "title": "Executionid",
+            "type": "string"
+          },
+          "pauseTotalMinutes": {
+            "title": "Pausetotalminutes",
+            "type": "integer"
+          },
+          "startedAt": {
+            "format": "date-time",
+            "title": "Startedat",
+            "type": "string"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "executionId",
+          "actionItemId",
+          "startedAt",
+          "endedAt",
+          "status",
+          "pauseTotalMinutes"
+        ],
+        "title": "ExecutionEventResponse",
         "type": "object"
       },
       "ExecutionStartResponse": {
@@ -2541,9 +2589,11 @@
             ],
             "title": "Breakpattern"
           },
-          "downscopeOk": {
-            "title": "Downscopeok",
-            "type": "boolean"
+          "downscopeUnitMin": {
+            "default": 10,
+            "minimum": 1.0,
+            "title": "Downscopeunitmin",
+            "type": "integer"
           },
           "focusDurationMin": {
             "anyOf": [
@@ -2578,8 +2628,7 @@
         },
         "required": [
           "recoveryTone",
-          "restOk",
-          "downscopeOk"
+          "restOk"
         ],
         "title": "PreferenceProfile",
         "type": "object"
@@ -2608,7 +2657,7 @@
         "type": "object"
       },
       "Question": {
-        "description": "인터뷰 질문 — 세션의 currentQuestion.",
+        "description": "인터뷰 질문 — 세션의 currentQuestion.\n\n`options` = 카탈로그 고정 보기 (chip/select 의 유효 선택지, 정적 진실 소스).\n`suggested_answers` = LLM 이 슬롯 맥락에 맞춰 추천한 답변 카드 — 주로 고정 보기가 없는\n자유서술 슬롯(goals.list·success_image·time.fixed_blocks 등)에서 탭/참고용으로 채워진다.",
         "properties": {
           "answerType": {
             "title": "Answertype",
@@ -2624,6 +2673,13 @@
           "slotKey": {
             "title": "Slotkey",
             "type": "string"
+          },
+          "suggestedAnswers": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Suggestedanswers",
+            "type": "array"
           },
           "text": {
             "title": "Text",
@@ -5515,7 +5571,7 @@
     },
     "/interview/sessions": {
       "post": {
-        "description": "딥 인터뷰 세션 시작 — FSM 이 고른 첫 필수 슬롯 질문 1개 생성.\n\n단일 활성 세션 enforce: 이미 진행 중(end_reason IS NULL)인 세션이 있으면 409.\n동시성 lock(ADR-0005 §7.6) 안에서 검사+생성해 다중 디바이스 race 를 막는다.",
+        "description": "딥 인터뷰 세션 시작 — FSM 이 고른 첫 필수 슬롯 질문 1개 생성.\n\n재시작 승리(restart-wins): 진행 중(end_reason IS NULL) 세션이 있으면 `abandoned` 로\n닫고 새로 시작한다 — 항상 201. FE 가 sessionId 를 잃어도(새로고침·localStorage 유실)\n재시작만으로 복구된다. 이어하기는 기존 `next-question` 재개 경로 그대로.\n동시성 lock(ADR-0005 §7.6) 안에서 검사+생성해 다중 디바이스 race 를 막는다.",
         "operationId": "start_session_interview_sessions_post",
         "parameters": [
           {
@@ -7922,6 +7978,124 @@
           }
         },
         "summary": "Quick Check In",
+        "tags": [
+          "today"
+        ]
+      }
+    },
+    "/today/focus/{execution_id}/pause": {
+      "post": {
+        "description": "[⏸] 집중 세션 일시정지 (#83) — user_pause interruption 을 연다.\n\nexecution 은 in_progress 유지. 이미 정지 중이면 409. 재개 시 누적 시간이 반영된다.",
+        "operationId": "pause_focus_today_focus__execution_id__pause_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "execution_id",
+            "required": true,
+            "schema": {
+              "title": "Execution Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExecutionEventResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Pause Focus",
+        "tags": [
+          "today"
+        ]
+      }
+    },
+    "/today/focus/{execution_id}/resume": {
+      "post": {
+        "description": "[▶ 계속] 집중 세션 재개 (#83) — 열린 정지 구간을 닫고 pause_total_minutes 누적.\n\n정지 중이 아니면 409. 정지 시작(created_at)부터 지금까지를 지연분으로 기록한다.",
+        "operationId": "resume_focus_today_focus__execution_id__resume_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "execution_id",
+            "required": true,
+            "schema": {
+              "title": "Execution Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExecutionEventResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Resume Focus",
         "tags": [
           "today"
         ]

--- a/src/app/ReActionMerged.tsx
+++ b/src/app/ReActionMerged.tsx
@@ -98,6 +98,8 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
   const [recoveryCount, setRecoveryCount] = useState(0);
   // 사용자가 회복 화면에서 고른 제안 — RecoveredScreen 의 before→after 카드용.
   const [appliedRecovery, setAppliedRecovery] = useState<AppliedRecovery | null>(null);
+  // Focus 에서 일시정지한 execution — 같은 task 로 재진입하면 resume 한다 (backend #83).
+  const [pausedExec, setPausedExec] = useState<{ taskId: string; executionId: string } | null>(null);
 
   const showTabs = !hideTabs && TAB_SCREENS.includes(screen);
 
@@ -170,6 +172,7 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
     if (activeTask) markDone(activeTask.id);
     setScreen('today');
     setActiveTask(null);
+    setPausedExec(null);
   };
 
   return (
@@ -214,8 +217,10 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
           <FocusScreen
             task={activeTask}
             elapsedMin={18} totalMin={45}
-            onBack={() => { setScreen('today'); setActiveTask(null); }}
+            resumeExecutionId={pausedExec?.taskId === activeTask.id ? pausedExec.executionId : null}
+            onBack={() => { setScreen('today'); setActiveTask(null); setPausedExec(null); }}
             onPause={() => setScreen('today')}
+            onPaused={(executionId) => setPausedExec({ taskId: activeTask.id, executionId })}
             onComplete={handleFocusComplete}
           />
         )}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -298,7 +298,7 @@ export const habitsApi = {
 };
 
 // ── Today / Execution (S10-S13) ───────────────────────────────
-// start·check-ins 는 백엔드 #13 구현됨. agenda/action 상세·pause/resume 은 미구현.
+// agenda·action 상세·start·check-ins 는 백엔드 #13, focus pause/resume 은 #83 구현됨.
 export const todayApi = {
   agenda: () => request<TodayAgenda>('/today/agenda'),
 

--- a/src/screens/FocusScreen.tsx
+++ b/src/screens/FocusScreen.tsx
@@ -10,26 +10,35 @@ interface FocusScreenProps {
   task: Task | null;
   elapsedMin: number;
   totalMin: number;
+  // 일시정지 후 재진입이면 이 execution 을 resume 한다 (없으면 새로 start).
+  resumeExecutionId?: string | null;
   onPause: () => void;
+  // 일시정지 시 확보한 executionId 를 부모로 올려 재진입 때 resume 하도록 한다.
+  onPaused?: (executionId: string) => void;
   onComplete: () => void;
   onBack: () => void;
 }
 
-export function FocusScreen({ task, elapsedMin, totalMin, onPause, onComplete, onBack }: FocusScreenProps) {
-  // mock-and-replace: 백엔드 /today/* 가 501. 시작/일시정지/완료를 mock 으로 시도하되
-  // 실패는 조용히 — 화면 흐름(onPause/onComplete) 은 그대로 진행.
+export function FocusScreen({ task, elapsedMin, totalMin, resumeExecutionId, onPause, onPaused, onComplete, onBack }: FocusScreenProps) {
+  // 백엔드 /today/* 실연동: start(#13)·pause/resume(#83)·check-in(#13) 을 시도하되
+  // 실패는 조용히 — 화면 흐름(onPause/onComplete) 은 그대로 진행(fallback).
   const executionIdRef = useRef<string | null>(null);
 
-  // 첫 진입 시 시작 호출 (executionId 확보 시도)
+  // 첫 진입 시: 재진입(resumeExecutionId)이면 resume, 아니면 새 세션 start.
   React.useEffect(() => {
     if (!task) return;
     let cancelled = false;
-    todayApi.start(task.id).then(
-      (e) => { if (!cancelled) executionIdRef.current = e.executionId; },
-      () => { /* 501 — 그냥 진행 */ },
-    );
+    if (resumeExecutionId) {
+      executionIdRef.current = resumeExecutionId;
+      todayApi.resume(resumeExecutionId).catch(() => { /* 실패해도 진행 */ });
+    } else {
+      todayApi.start(task.id).then(
+        (e) => { if (!cancelled) executionIdRef.current = e.executionId; },
+        () => { /* 미구현/실패 — 그냥 진행 */ },
+      );
+    }
     return () => { cancelled = true; };
-  }, [task?.id]);
+  }, [task?.id, resumeExecutionId]);
 
   // task 없이 잘못 마운트된 경우 — 빈 흰 화면 대신 명확한 안내 + 뒤로가기.
   if (!task) {
@@ -45,6 +54,7 @@ export function FocusScreen({ task, elapsedMin, totalMin, onPause, onComplete, o
   const handlePause = () => {
     if (executionIdRef.current) {
       todayApi.pause(executionIdRef.current).catch(() => {});
+      onPaused?.(executionIdRef.current);
     }
     onPause();
   };

--- a/src/screens/GoalIntakeScreen.tsx
+++ b/src/screens/GoalIntakeScreen.tsx
@@ -207,6 +207,10 @@ export function GoalIntakeScreen({ onDone }: GoalIntakeScreenProps) {
     (currentQuestion.answerType === 'chip' || currentQuestion.answerType === 'select') &&
     currentQuestion.options.length > 0;
 
+  // 자유서술 슬롯: 고정 보기가 없을 때만 LLM 추천 답변(suggestedAnswers)을 참고 카드로 노출.
+  // 탭하면 입력창을 채워 사용자가 수정 후 보낼 수 있게 한다 (auto-submit 아님, 참고용).
+  const suggestions = (!showQuickReplies && currentQuestion?.suggestedAnswers) || [];
+
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100%', background: 'var(--surface-ground)' }}>
       {/* Header */}
@@ -318,7 +322,34 @@ export function GoalIntakeScreen({ onDone }: GoalIntakeScreenProps) {
                 ))}
               </div>
             )}
-            <div style={{ display: 'flex', gap: 8, marginTop: showQuickReplies ? 4 : 0 }}>
+            {suggestions.length > 0 && (
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+                {suggestions.map((s, i) => (
+                  <button
+                    key={i}
+                    onClick={() => setInputText(s)}
+                    disabled={isTyping}
+                    style={{
+                      padding: '7px 11px',
+                      borderRadius: 9999,
+                      border: '1.5px dashed var(--sand-200)',
+                      background: 'transparent',
+                      color: 'var(--text-2)',
+                      fontSize: 12,
+                      textAlign: 'left',
+                      cursor: isTyping ? 'wait' : 'pointer',
+                      lineHeight: 1.4,
+                      fontFamily: 'inherit',
+                      wordBreak: 'keep-all',
+                      opacity: isTyping ? 0.6 : 1,
+                    }}
+                  >
+                    {s}
+                  </button>
+                ))}
+              </div>
+            )}
+            <div style={{ display: 'flex', gap: 8, marginTop: showQuickReplies || suggestions.length > 0 ? 4 : 0 }}>
               <input
                 value={inputText}
                 onChange={(e) => setInputText(e.target.value)}

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -47,6 +47,9 @@ export interface InterviewQuestion {
   text: string;
   answerType: SlotAnswerType;
   options: string[];
+  // LLM 이 슬롯 맥락에 맞춰 추천한 답변 카드. 주로 고정 보기(options)가 없는 자유서술
+  // 슬롯(goals.list·success_image·time.fixed_blocks 등)에서 탭/참고용으로 채워진다.
+  suggestedAnswers?: string[];
 }
 
 export type InterviewEndReason = 'early_user' | 'completed' | null;
@@ -280,13 +283,16 @@ export interface TodayAgenda {
 
 export type CompletionStatus = 'done' | 'partial_done' | 'failed' | 'over_done';
 
-// /today/focus/{executionId}/pause·resume 는 아직 contract 추정(미구현).
+// POST /today/focus/{executionId}/pause·resume 응답 (ExecutionEventResponse, backend #83).
+// pause 는 interruption_events 를 열고, resume 은 그 구간을 닫아 pauseTotalMinutes 에 누적한다.
+// execution 자체는 in_progress 유지.
 export interface ExecutionEvent {
   executionId: string;
   actionItemId: string;
   startedAt: string; // KST ISO
   endedAt: string | null;
   status: CompletionStatus | 'started' | string;
+  pauseTotalMinutes: number;
 }
 
 // POST /today/actions/{actionId}/start (#13)

--- a/src/types/openapi.d.ts
+++ b/src/types/openapi.d.ts
@@ -535,7 +535,9 @@ export interface paths {
          * Start Session
          * @description 딥 인터뷰 세션 시작 — FSM 이 고른 첫 필수 슬롯 질문 1개 생성.
          *
-         *     단일 활성 세션 enforce: 이미 진행 중(end_reason IS NULL)인 세션이 있으면 409.
+         *     재시작 승리(restart-wins): 진행 중(end_reason IS NULL) 세션이 있으면 `abandoned` 로
+         *     닫고 새로 시작한다 — 항상 201. FE 가 sessionId 를 잃어도(새로고침·localStorage 유실)
+         *     재시작만으로 복구된다. 이어하기는 기존 `next-question` 재개 경로 그대로.
          *     동시성 lock(ADR-0005 §7.6) 안에서 검사+생성해 다중 디바이스 race 를 막는다.
          */
         post: operations["start_session_interview_sessions_post"];
@@ -1346,6 +1348,50 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/today/focus/{execution_id}/pause": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Pause Focus
+         * @description [⏸] 집중 세션 일시정지 (#83) — user_pause interruption 을 연다.
+         *
+         *     execution 은 in_progress 유지. 이미 정지 중이면 409. 재개 시 누적 시간이 반영된다.
+         */
+        post: operations["pause_focus_today_focus__execution_id__pause_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/today/focus/{execution_id}/resume": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Resume Focus
+         * @description [▶ 계속] 집중 세션 재개 (#83) — 열린 정지 구간을 닫고 pause_total_minutes 누적.
+         *
+         *     정지 중이 아니면 409. 정지 시작(created_at)부터 지금까지를 지연분으로 기록한다.
+         */
+        post: operations["resume_focus_today_focus__execution_id__resume_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -1704,6 +1750,30 @@ export interface components {
             latency_ms?: number | null;
             /** Ok */
             ok: boolean;
+        };
+        /**
+         * ExecutionEventResponse
+         * @description POST /today/focus/{id}/pause·resume 응답 — 집중 세션 일시정지/재개 (#83).
+         *
+         *     pause 는 interruption_events(user_pause) 를 열고, resume 은 그 구간을 닫아
+         *     execution.pause_total_minutes 에 누적한다. execution 자체는 in_progress 유지.
+         */
+        ExecutionEventResponse: {
+            /** Actionitemid */
+            actionItemId: string;
+            /** Endedat */
+            endedAt: string | null;
+            /** Executionid */
+            executionId: string;
+            /** Pausetotalminutes */
+            pauseTotalMinutes: number;
+            /**
+             * Startedat
+             * Format: date-time
+             */
+            startedAt: string;
+            /** Status */
+            status: string;
         };
         /**
          * ExecutionStartResponse
@@ -2447,8 +2517,11 @@ export interface components {
         PreferenceProfile: {
             /** Breakpattern */
             breakPattern?: string | null;
-            /** Downscopeok */
-            downscopeOk: boolean;
+            /**
+             * Downscopeunitmin
+             * @default 10
+             */
+            downscopeUnitMin: number;
             /** Focusdurationmin */
             focusDurationMin?: number | null;
             /** Recoverytone */
@@ -2473,6 +2546,10 @@ export interface components {
         /**
          * Question
          * @description 인터뷰 질문 — 세션의 currentQuestion.
+         *
+         *     `options` = 카탈로그 고정 보기 (chip/select 의 유효 선택지, 정적 진실 소스).
+         *     `suggested_answers` = LLM 이 슬롯 맥락에 맞춰 추천한 답변 카드 — 주로 고정 보기가 없는
+         *     자유서술 슬롯(goals.list·success_image·time.fixed_blocks 등)에서 탭/참고용으로 채워진다.
          */
         Question: {
             /** Answertype */
@@ -2481,6 +2558,8 @@ export interface components {
             options: string[];
             /** Slotkey */
             slotKey: string;
+            /** Suggestedanswers */
+            suggestedAnswers?: string[];
             /** Text */
             text: string;
         };
@@ -5445,6 +5524,72 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["CheckInResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    pause_focus_today_focus__execution_id__pause_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                execution_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ExecutionEventResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    resume_focus_today_focus__execution_id__resume_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                execution_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ExecutionEventResponse"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
백엔드(`reaction-backend`) OpenAPI 를 재덤프해 신규 엔드포인트/스키마를 프론트 타입·화면에 반영한 자동 동기화 PR 입니다.

## (a) 신규/변경 엔드포인트·스키마
- **신규 엔드포인트**: `POST /today/focus/{execution_id}/pause`, `POST /today/focus/{execution_id}/resume` — 집중 세션 일시정지/재개 (backend #83)
- **신규 스키마**: `ExecutionEventResponse` (pause/resume 응답, `pauseTotalMinutes` 포함)
- **변경 스키마**:
  - `PreferenceProfile`: `downscopeOk` → `downscopeUnitMin` (프론트 수기 타입/화면 미사용 → 재생성만 반영)
  - `Question`: `suggestedAnswers` 필드 추가
- 제거된 엔드포인트 없음 (GONE 0)

## (b) 화면 실연동한 곳
- **FocusScreen (집중 모드)**: focus **resume** 실연동. 일시정지 후 같은 카드로 재진입하면 `todayApi.resume()` 를 호출하도록 `executionId` 를 부모(`ReActionMerged`)로 lift. 기존 mock-and-replace 패턴 유지 — 백엔드 호출 실패 시 조용히 무시하고 화면 흐름은 그대로 진행(데모 안 깨짐).
- **GoalIntakeScreen (목표 파악 인터뷰)**: 자유서술 슬롯(고정 보기 없음)에서 LLM 추천 답변 `suggestedAnswers` 를 참고 카드(점선 chip)로 노출. 탭하면 입력창을 채워 사용자가 수정 후 전송 (auto-submit 아님, 참고용). 백엔드가 값을 안 주면 표시 안 됨 → graceful degradation.
- 수기 타입 교정: `ExecutionEvent` 에 `pauseTotalMinutes` 추가·주석 갱신, `InterviewQuestion` 에 `suggestedAnswers` 추가, `api.ts` 의 today 엔드포인트 주석(미구현→#83 구현됨) 갱신.

## (c) check:api 요약
```
✅ OK   66  (백엔드 구현됨, 메서드 일치)
⚠️  WARN 1  (/reflection/pending — 아직 백엔드 미구현)
❌ GONE 0
🆕 NEW  10
결과: PASS
```

## 검증 게이트
- `npm run check:api` → GONE 0, PASS
- `npx tsc --noEmit` → 통과
- `npm run build` → 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J6dYVzPGSMYLA6jWzvLKyZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01J6dYVzPGSMYLA6jWzvLKyZ)_