### PR TITLE
fix(demo-loop): 실패→회복→수락 executionId 실배선 + 저녁체크인 no-op 제거

### DIFF
--- a/src/app/ReActionMerged.tsx
+++ b/src/app/ReActionMerged.tsx
@@ -18,9 +18,10 @@ import { WeeklySwitch } from '../components/WeeklySwitch';
 import { EveningCheckInScreen } from '../screens/EveningCheckInScreen';
 import { WeeklyCalendarScreenV2 } from '../screens/WeeklyCalendarScreen';
 import { WeeklyReviewScreenV2 } from '../screens/WeeklyReviewScreen';
-import { BASE_TASKS, MERGED_PROPOSALS } from '../data';
+import { BASE_TASKS } from '../data';
 import { useNavigation } from '../contexts/NavigationContext';
-import type { ScreenId, TabId, Task } from '../types';
+import { reflectionApi, todayApi } from '../lib/api';
+import type { RecoveryProposal, ScreenId, TabId, Task } from '../types';
 import type { InterviewOutcome } from '../types/api';
 
 // onboarding 흐름은 백엔드 §3 state machine 을 기반으로 하되, 클라이언트에서 두 쌍을
@@ -98,6 +99,9 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
   const [interviewOutcome, setInterviewOutcome] = useState<InterviewOutcome | null>(null);
   const [activeTask, setActiveTask] = useState<Task | null>(null);
   const [failReason, setFailReason] = useState('');
+  // task.id → 실 executionId. FocusScreen(시작) 또는 markFailed(실패시 auto-start)로 채워지며,
+  // 회복 화면들(MergedRecoveryScreen/RecoveredScreen)이 이 값으로 실 API 를 호출한다(#80).
+  const [executionIds, setExecutionIds] = useState<Record<string, string>>({});
   // 이번 세션에서 수락한 복구 횟수 (백엔드 누적 집계 엔드포인트가 없어 세션 카운트로 정직하게).
   const [recoveryCount, setRecoveryCount] = useState(0);
   // 사용자가 회복 화면에서 고른 제안 — RecoveredScreen 의 before→after 카드용.
@@ -114,11 +118,30 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
       : t
     ));
 
-  const markFailed = (id: string, reason: string) => {
+  const markFailed = (id: string, reason: string, tagCode?: string) => {
     setTasks((ts) => ts.map((t) => t.id === id ? { ...t, status: 'failed', failReason: reason } : t));
     setActiveTask(tasks.find((t) => t.id === id) || null);
     setFailReason(reason);
     setScreen('recovery');
+
+    // 실패 경로는 TodayScreen 실패시트 → 여기로 직행해 FocusScreen 을 거치지 않을 수
+    // 있다 — 그런 미시작 액션은 먼저 start() 로 executionId 를 확보한다(#80 "실패 시 auto-start").
+    const existing = executionIds[id];
+    const ensureExecutionId = existing
+      ? Promise.resolve(existing)
+      : todayApi.start(id).then((e) => {
+          setExecutionIds((m) => ({ ...m, [id]: e.executionId }));
+          return e.executionId;
+        });
+
+    ensureExecutionId
+      .then((execId) =>
+        (tagCode ? reflectionApi.tagExecution(execId, { tagCodes: [tagCode] }).catch(() => {}) : Promise.resolve())
+          .then(() =>
+            todayApi.checkIn({ executionId: execId, completionStatus: 'failed' }, `check-${execId}`).catch(() => {}),
+          ),
+      )
+      .catch(() => { /* start 실패(미구현/오류) — 로컬 흐름만 유지 */ });
   };
 
   // 실제 시작 트리거 — task 를 in_progress 로 전이하고 focus 화면으로.
@@ -144,17 +167,18 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
     setScreen('recovery');
   };
 
-  // RecoveryScreen 에서 고른 제안 id 를 받아 before→after 정보를 구성한다.
-  const acceptRecovery = (optionId: string) => {
+  // RecoveryScreen 에서 고른 실제(또는 데모) 제안 객체를 그대로 받아 before→after 를 구성한다.
+  // (예전엔 optionId 만 받아 MERGED_PROPOSALS 더미에서 재조회했었다 — 실 회복 카드의
+  // 제목/설명이 더미로 가려지던 문제 #80)
+  const acceptRecovery = (proposal: RecoveryProposal) => {
     setRecoveryCount((c) => c + 1);
-    const proposal = MERGED_PROPOSALS.find((p) => p.id === optionId);
     if (activeTask) {
       setAppliedRecovery({
         taskTitle: activeTask.title,
         failReason: failReason || activeTask.failReason || '',
-        proposalTitle: proposal?.title ?? '복구 방법 적용',
-        proposalDesc: proposal?.desc ?? '',
-        proposalTime: proposal?.time ?? '',
+        proposalTitle: proposal.title,
+        proposalDesc: proposal.desc,
+        proposalTime: proposal.time,
       });
       setTasks((ts) => ts.map((t) => t.id === activeTask.id ? { ...t, status: 'done' } : t));
     }
@@ -224,6 +248,7 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
             onBack={() => { setScreen('today'); setActiveTask(null); }}
             onPause={() => setScreen('today')}
             onComplete={handleFocusComplete}
+            onExecutionStart={(taskId, execId) => setExecutionIds((m) => ({ ...m, [taskId]: execId }))}
           />
         )}
         {screen === 'recovery' && (
@@ -232,6 +257,7 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
             failReason={failReason}
             onAccept={acceptRecovery}
             onDismiss={() => setScreen('today')}
+            executionId={activeTask ? executionIds[activeTask.id] : undefined}
           />
         )}
         {screen === 'recovered' && (
@@ -239,6 +265,7 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
             recoveryCount={recoveryCount}
             applied={appliedRecovery}
             onDone={() => { setTab('today'); setScreen('today'); setAppliedRecovery(null); }}
+            executionId={activeTask ? executionIds[activeTask.id] : undefined}
           />
         )}
         {screen === 'evening' && (

--- a/src/screens/EveningCheckInScreen.tsx
+++ b/src/screens/EveningCheckInScreen.tsx
@@ -1,6 +1,5 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { CheckCircle } from '@phosphor-icons/react';
-import { reflectionApi } from '../lib/api';
 import { DemoNotice } from '../components/DemoNotice';
 
 interface EveningCheckInScreenProps {
@@ -19,15 +18,9 @@ export function EveningCheckInScreen({ onDone }: EveningCheckInScreenProps) {
   const [step, setStep] = useState(0);
   const [energy, setEnergy] = useState<number | null>(null);
 
-  // 최종 step 진입 시 /reflection/batch 일괄 처리 호출 시도(best-effort).
-  // 이 엔드포인트는 아직 백엔드 미구현(404)이라 실패는 조용히 무시하고 화면 흐름은 유지.
-  // 이 화면은 에너지 1종만 수집하고 executionId·completionStatus 가 없어
-  // /today/check-ins 로는 깔끔히 매핑되지 않으므로 정직 배너를 유지한다.
-  useEffect(() => {
-    if (step !== 2) return;
-    const idempotencyKey = `evening-${Date.now()}`;
-    reflectionApi.batch({ items: [] }, idempotencyKey).catch(() => { /* 미구현(404) ok */ });
-  }, [step]);
+  // /reflection/batch 는 백엔드 501 이고, 이 화면은 애초에 executionId·completionStatus
+  // 없이 에너지 1종만 모아 그 계약에도 안 맞는다 — 빈 items 로 찌르는 no-op 호출은
+  // 제거하고, 데모 범위에서 명시적으로 제외한다(#82). 서버 저장 없이 로컬로만 흐름 유지.
 
   if (step === 2) {
     const selectedEnergy = energyOptions.find((e) => e.v === energy);

--- a/src/screens/FocusScreen.tsx
+++ b/src/screens/FocusScreen.tsx
@@ -14,9 +14,12 @@ interface FocusScreenProps {
   onPause: () => void;
   onComplete: () => void;
   onBack: () => void;
+  // 실 executionId 확보 시 컨트롤러로 리프트 — 실패→회복→수락 화면들이 이 값으로
+  // reflectionApi.tagExecution/recoveryApi.generateProposals 등을 실호출한다(#80).
+  onExecutionStart?: (taskId: string, executionId: string) => void;
 }
 
-export function FocusScreen({ task, elapsedMin, totalMin, onComplete, onBack }: FocusScreenProps) {
+export function FocusScreen({ task, elapsedMin, totalMin, onComplete, onBack, onExecutionStart }: FocusScreenProps) {
   // mock-and-replace: 백엔드 /today/* 일부 미구현. 시작/일시정지/완료를 시도하되 실패는 조용히.
   const executionIdRef = useRef<string | null>(null);
 
@@ -38,7 +41,11 @@ export function FocusScreen({ task, elapsedMin, totalMin, onComplete, onBack }: 
     if (!task) return;
     let cancelled = false;
     todayApi.start(task.id).then(
-      (e) => { if (!cancelled) executionIdRef.current = e.executionId; },
+      (e) => {
+        if (cancelled) return;
+        executionIdRef.current = e.executionId;
+        onExecutionStart?.(task.id, e.executionId);
+      },
       () => { /* 미구현 — 그냥 진행 */ },
     );
     return () => { cancelled = true; };

--- a/src/screens/RecoveryScreen.tsx
+++ b/src/screens/RecoveryScreen.tsx
@@ -41,7 +41,9 @@ function cardToProposal(c: RecoveryCard): RecoveryProposal {
 interface MergedRecoveryScreenProps {
   task: Task | null;
   failReason?: string;
-  onAccept: (optionId: string) => void;
+  // 선택된 실제 제안 객체를 그대로 올려준다 — 컨트롤러가 더미(MERGED_PROPOSALS)에서
+  // id 로 재조회하지 않고, 실제(또는 데모) 카드 내용을 그대로 써야 정직하다(#80).
+  onAccept: (proposal: RecoveryProposal) => void;
   onDismiss: () => void;
   // 시작/실패한 실제 실행의 executionId. 데모 task 엔 없으므로 optional.
   // 있으면 백엔드 LLM 회복 제안(POST /recovery/proposals/generate)과 연동한다.
@@ -102,7 +104,8 @@ export function MergedRecoveryScreen({ task, failReason, onAccept, onDismiss, ex
         .catch(() => { /* 오류 ok — 흐름 유지 */ });
     }
     setAccepted(true);
-    setTimeout(() => onAccept(sel), 1400);
+    const chosen = proposals.find((p) => p.id === sel);
+    if (chosen) setTimeout(() => onAccept(chosen), 1400);
   };
 
   if (accepted) {

--- a/src/screens/TodayScreen.tsx
+++ b/src/screens/TodayScreen.tsx
@@ -60,7 +60,8 @@ interface MergedTodayScreenProps {
   onOpen: (id: string) => void;
   onMarkDone: (id: string) => void;
   onPartial: (id: string, pct: number) => void;
-  onFail: (id: string, reason: string) => void;
+  // reason 은 표시용 labelKo, tagCode 는 reflectionApi.tagExecution 저장용(#80).
+  onFail: (id: string, reason: string, tagCode?: string) => void;
   onOpenRecovery: () => void;
   onEvening: () => void;
   // /today/agenda 실데이터 로드 성공 시 부모의 tasks 를 이 목록으로 교체한다.
@@ -211,13 +212,17 @@ export function MergedTodayScreen({ tasks, onOpen, onMarkDone, onPartial, onFail
   // hero 카드가 가리키는 task — row 클릭으로 promote 만, 실제 시작 X.
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [failReason, setFailReason] = useState('');
+  const [failTagCode, setFailTagCode] = useState<string | undefined>(undefined);
   const [toast, setToast] = useState<string | null>(null);
-  // 실패 사유 목록 — 백엔드 실패 태그 카탈로그(#17)가 오면 그 labelKo 로, 없으면 더미.
-  const [failReasons, setFailReasons] = useState<string[]>(FAIL_REASONS);
+  // 실패 사유 목록 — 백엔드 실패 태그 카탈로그(#17)가 오면 그 tagCode/labelKo 로, 없으면 더미.
+  // tagCode 를 같이 들고 있어야 reflectionApi.tagExecution 저장 호출에 실 코드를 실어보낸다(#80).
+  const [failReasons, setFailReasons] = useState<{ code: string; labelKo: string }[]>(
+    FAIL_REASONS.map((label) => ({ code: label, labelKo: label })),
+  );
   useEffect(() => {
     let cancelled = false;
     reflectionApi.failureTags().then(
-      (tags) => { if (!cancelled && tags.length) setFailReasons(tags.map((t) => t.labelKo)); },
+      (tags) => { if (!cancelled && tags.length) setFailReasons(tags.map((t) => ({ code: t.tagCode, labelKo: t.labelKo }))); },
       () => { /* 미구현/오류 — 더미 그대로 */ },
     );
     return () => { cancelled = true; };
@@ -306,9 +311,10 @@ export function MergedTodayScreen({ tasks, onOpen, onMarkDone, onPartial, onFail
 
   const submitFail = () => {
     if (!failReason || !failSheet) return;
-    onFail(failSheet, failReason);
+    onFail(failSheet, failReason, failTagCode);
     setFailSheet(null);
     setFailReason('');
+    setFailTagCode(undefined);
   };
 
   // Focus on Now — 색 팔레트 통일. 모든 카드 동일 베이지 배경. 상태는 ring +
@@ -377,7 +383,7 @@ export function MergedTodayScreen({ tasks, onOpen, onMarkDone, onPartial, onFail
               total={tasks.length}
               onComplete={() => heroTask && (onMarkDone(heroTask.id), showToast('완료!'))}
               onPartial={() => heroTask && setPartialSheet(heroTask.id)}
-              onFail={() => heroTask && (setFailSheet(heroTask.id), setFailReason(''))}
+              onFail={() => heroTask && (setFailSheet(heroTask.id), setFailReason(''), setFailTagCode(undefined))}
               onStart={(id) => onOpen(id)}
             />
 
@@ -482,7 +488,7 @@ export function MergedTodayScreen({ tasks, onOpen, onMarkDone, onPartial, onFail
             <p style={{ fontSize: 12, color: 'var(--text-3)', marginBottom: 14 }}>이유를 기록하면 더 잘 맞는 복구안을 제안해드려요.</p>
             <div style={{ display: 'flex', flexDirection: 'column', gap: 6, marginBottom: 14 }}>
               {failReasons.map((r) => (
-                <button key={r} onClick={() => setFailReason(r)} style={{ padding: '12px 14px', borderRadius: 12, textAlign: 'left', background: failReason === r ? 'var(--text-1)' : 'var(--surface-raised)', color: failReason === r ? '#FAF6EE' : 'var(--text-1)', border: `1px solid ${failReason === r ? 'var(--text-1)' : 'var(--sand-200)'}`, fontSize: 14, fontWeight: 500, cursor: 'pointer', fontFamily: 'inherit', transition: 'all 160ms' }}>{r}</button>
+                <button key={r.code} onClick={() => { setFailReason(r.labelKo); setFailTagCode(r.code); }} style={{ padding: '12px 14px', borderRadius: 12, textAlign: 'left', background: failReason === r.labelKo ? 'var(--text-1)' : 'var(--surface-raised)', color: failReason === r.labelKo ? '#FAF6EE' : 'var(--text-1)', border: `1px solid ${failReason === r.labelKo ? 'var(--text-1)' : 'var(--sand-200)'}`, fontSize: 14, fontWeight: 500, cursor: 'pointer', fontFamily: 'inherit', transition: 'all 160ms' }}>{r.labelKo}</button>
               ))}
             </div>
             <button onClick={submitFail} disabled={!failReason} style={{ width: '100%', height: 44, borderRadius: 12, border: 'none', background: 'var(--text-1)', color: '#FAF6EE', fontWeight: 700, fontSize: 14, fontFamily: 'inherit', cursor: 'pointer', opacity: failReason ? 1 : 0.35 }}>기록하고 복구안 보기</button>


### PR DESCRIPTION
## 배경 (Closes #80, Closes #82)

MVP 데모 5-hop 중 로그인·Today(hop1·2)는 실배선이나, 실패→회복→수락(hop3·4·5)은 여전히 로컬 mock 이었다. 백엔드(`reflection.py:89`, `recovery.py:146,250`)는 전부 구현돼 있어 프론트가 executionId 만 흘려보내면 살아난다(#80).

## 원인

`FocusScreen` 이 확보한 실 executionId 가 컨트롤러 `ReActionMerged` 로 올라가지 못해, 컨트롤러가 `MergedRecoveryScreen`/`RecoveredScreen` 에 executionId 를 전달하지 못하고 → `tagExecution`/`generateProposals`/`decide`/`replan` 호출이 전부 `if(executionId)` 가드에 걸려 skip. 게다가 실패 경로는 `FocusScreen` 을 거치지 않고 `TodayScreen` 실패시트 → `markFailed` 로 직행해 executionId 를 얻을 기회 자체가 없었다.

## 변경 사항

- `FocusScreen.tsx`: 확보한 executionId 를 `onExecutionStart(taskId, executionId)` 로 컨트롤러에 리프트.
- `ReActionMerged.tsx`: `task.id → executionId` 맵(`executionIds`) 보유. `markFailed` 는 미시작 액션이면 `todayApi.start()` 로 먼저 확보(실패 시 auto-start) 후 `reflectionApi.tagExecution`(실 태그코드) + `todayApi.checkIn(failed)` 실호출. `MergedRecoveryScreen`/`RecoveredScreen` 에 해당 executionId 전달.
- `TodayScreen.tsx`: 실패 사유 칩이 표시용 labelKo 뿐 아니라 저장용 tagCode 도 같이 들고 있도록 수정(`reflectionApi.failureTags()` 응답 매핑 포함).
- `RecoveryScreen.tsx`: 수락 시 `optionId` 대신 선택된 실제 제안 객체를 그대로 올려, 컨트롤러가 `MERGED_PROPOSALS` 더미에서 재조회하던 로컬 합성 제거.
- `EveningCheckInScreen.tsx`: `reflectionApi.batch({items: []})` 는 항상 빈 배열만 보내는 데다 백엔드 `/reflection/batch` 가 501 이라 순수 no-op 이었다(#82). 백엔드 구현이 선행돼야 해 이번 주 데모 범위에서 제외 — 호출 자체를 제거하고 기존 정직 배너(DemoNotice)만 유지.

## DoD 확인

- 시드 계정 실패→회복→수락 루프가 executionId 를 통해 백엔드까지 관통(`start`→`checkIn(failed)`+`tagExecution`→`generateProposals`→`decide`→재진입 시 agenda refetch 로 새 ActionItem 반영).
- 저녁 체크인이 조용한 no-op 으로 남지 않음(명시적 제외 + 정직 배너).

## 검증

- `npx tsc --noEmit` 클린
- `node scripts/check-api-contract.mjs` → PASS, GONE 0
- `npm run build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)