### PR TITLE
feat(time-picker): 시작 시간 칩 나열 → iOS 휠(다이얼) 선택기

### DIFF
--- a/src/components/TimeDial.tsx
+++ b/src/components/TimeDial.tsx
@@ -1,0 +1,161 @@
+import React, { useEffect, useRef } from 'react';
+
+// iOS 스타일 휠(다이얼) 시간 선택기.
+// 기존엔 09:00~22:00 시간 칩 수십 개가 flex-wrap 으로 쫙 깔려 있어 시각적으로
+// 답답했다 — 시/분 두 개의 스크롤 휠로 바꿔 한 번에 몇 칸만 보이게 한다.
+
+const ITEM_H = 34;   // 한 칸 높이(px)
+const VISIBLE = 5;   // 동시에 보이는 칸 수(홀수 → 가운데가 선택 위치)
+const PAD = ((VISIBLE - 1) / 2) * ITEM_H; // 첫/마지막 항목도 가운데로 올 수 있게 위아래 여백
+
+function pad2(n: number): string {
+  return String(n).padStart(2, '0');
+}
+
+function WheelColumn({
+  values,
+  selectedIndex,
+  onSelect,
+  ariaLabel,
+}: {
+  values: number[];
+  selectedIndex: number;
+  onSelect: (index: number) => void;
+  ariaLabel: string;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+  const settleRef = useRef<number | null>(null);
+  const mountedRef = useRef(false);
+
+  // 선택 인덱스가 바뀌면 해당 위치로 스크롤을 맞춘다. 최초엔 즉시, 이후(클릭 등)엔 부드럽게.
+  // 사용자가 직접 스크롤해 settle 된 경우엔 이미 위치가 맞아 no-op 이 되어 서로 안 싸운다.
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const target = selectedIndex * ITEM_H;
+    if (Math.abs(el.scrollTop - target) < 2) return;
+    el.scrollTo({ top: target, behavior: mountedRef.current ? 'smooth' : 'auto' });
+  }, [selectedIndex]);
+
+  useEffect(() => { mountedRef.current = true; }, []);
+
+  const handleScroll = () => {
+    const el = ref.current;
+    if (!el) return;
+    if (settleRef.current) window.clearTimeout(settleRef.current);
+    // 스크롤이 멈춘 뒤(≈100ms) 가운데에 온 칸을 선택으로 확정한다.
+    settleRef.current = window.setTimeout(() => {
+      const idx = Math.round(el.scrollTop / ITEM_H);
+      const clamped = Math.max(0, Math.min(values.length - 1, idx));
+      if (clamped !== selectedIndex) onSelect(clamped);
+    }, 100);
+  };
+
+  return (
+    <div
+      ref={ref}
+      className="rx-wheel"
+      role="listbox"
+      aria-label={ariaLabel}
+      onScroll={handleScroll}
+      style={{
+        flex: 1,
+        height: ITEM_H * VISIBLE,
+        overflowY: 'auto',
+        scrollSnapType: 'y mandatory',
+        position: 'relative',
+        zIndex: 1,
+        WebkitOverflowScrolling: 'touch',
+      }}
+    >
+      <div style={{ height: PAD }} aria-hidden />
+      {values.map((v, i) => {
+        const sel = i === selectedIndex;
+        return (
+          <div
+            key={v}
+            role="option"
+            aria-selected={sel}
+            onClick={() => onSelect(i)}
+            style={{
+              height: ITEM_H,
+              scrollSnapAlign: 'center',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontFamily: 'var(--font-mono)',
+              fontVariantNumeric: 'tabular-nums',
+              fontSize: sel ? 19 : 15,
+              fontWeight: sel ? 700 : 500,
+              color: sel ? 'var(--text-1)' : 'var(--text-3)',
+              opacity: sel ? 1 : 0.45,
+              cursor: 'pointer',
+              transition: 'font-size 120ms, opacity 120ms, color 120ms',
+            }}
+          >
+            {pad2(v)}
+          </div>
+        );
+      })}
+      <div style={{ height: PAD }} aria-hidden />
+    </div>
+  );
+}
+
+interface TimeDialProps {
+  value: string; // "HH:MM"
+  onChange: (value: string) => void;
+  minuteStep?: number;
+  minHour?: number;
+  maxHour?: number;
+}
+
+export function TimeDial({ value, onChange, minuteStep = 5, minHour = 0, maxHour = 23 }: TimeDialProps) {
+  const [h, m] = value.split(':').map(Number);
+  const hours = Array.from({ length: maxHour - minHour + 1 }, (_, i) => minHour + i);
+  const minutes = Array.from({ length: Math.ceil(60 / minuteStep) }, (_, i) => i * minuteStep);
+
+  const hourIndex = Math.max(0, hours.indexOf(Number.isFinite(h) ? h : minHour));
+  // 초기 분이 스텝에 안 맞을 수 있어(예: 21:30, step 5) 가장 가까운 스텝으로 스냅.
+  const minuteIndex = Math.max(
+    0,
+    Math.min(minutes.length - 1, Math.round((Number.isFinite(m) ? m : 0) / minuteStep)),
+  );
+
+  const emit = (hi: number, mi: number) => onChange(`${pad2(hours[hi])}:${pad2(minutes[mi])}`);
+
+  return (
+    <div
+      style={{
+        position: 'relative',
+        display: 'flex',
+        alignItems: 'stretch',
+        background: 'var(--surface-ground)',
+        border: '1px solid var(--sand-200)',
+        borderRadius: 14,
+        overflow: 'hidden',
+      }}
+    >
+      {/* 가운데 선택 밴드 — 항목 텍스트 뒤에 깔리는 강조 띠. */}
+      <div
+        aria-hidden
+        style={{
+          position: 'absolute',
+          left: 8,
+          right: 8,
+          top: '50%',
+          transform: 'translateY(-50%)',
+          height: ITEM_H,
+          borderRadius: 10,
+          background: 'var(--brand-soft)',
+          border: '1px solid var(--coral-200)',
+          pointerEvents: 'none',
+          zIndex: 0,
+        }}
+      />
+      <WheelColumn values={hours} selectedIndex={hourIndex} onSelect={(i) => emit(i, minuteIndex)} ariaLabel="시" />
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', width: 10, fontWeight: 700, fontSize: 17, color: 'var(--text-2)', zIndex: 1 }}>:</div>
+      <WheelColumn values={minutes} selectedIndex={minuteIndex} onSelect={(i) => emit(hourIndex, i)} ariaLabel="분" />
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -329,3 +329,12 @@ body {
 .animate-load-bar {
   animation: load 1.3s ease-out forwards;
 }
+
+/* 휠(다이얼) 시간 선택기 컬럼 — 스크롤바 숨김 (iOS 피커 느낌). */
+.rx-wheel {
+  scrollbar-width: none;          /* Firefox */
+  -ms-overflow-style: none;       /* 구형 Edge */
+}
+.rx-wheel::-webkit-scrollbar {
+  display: none;                  /* Chrome/Safari */
+}

--- a/src/screens/WeeklyCalendarScreen.tsx
+++ b/src/screens/WeeklyCalendarScreen.tsx
@@ -4,6 +4,7 @@ import { DAYS_KO, goalColor } from '../data';
 import { ApiError, plansApi } from '../lib/api';
 import { DemoNotice } from '../components/DemoNotice';
 import { Segmented } from '../components/Segmented';
+import { TimeDial } from '../components/TimeDial';
 import { useNavigation } from '../contexts/NavigationContext';
 import type { Block } from '../types';
 import type { WeeklyPlanResponse, BlockEditRequest } from '../types/api';
@@ -45,16 +46,6 @@ function BlockEditSheet({ block, existingGoals, onSave, onDelete, onClose }: { b
   const [dur, setDur] = useState(block.dur);
   const [goal, setGoal] = useState(block.goal || existingGoals[0] || '기타');
 
-  // 15분 단위 옵션 — S15 DoD '15분 snap'.
-  const HOURS = (() => {
-    const arr: string[] = [];
-    for (let h = 7; h <= 22; h++) {
-      for (const m of [0, 15, 30, 45]) {
-        arr.push(`${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`);
-      }
-    }
-    return arr;
-  })();
   const DURS = [15, 30, 45, 60, 90, 120];
   // 목표 선택지는 하드코딩된 이름 대신 지금 계획에 실제로 있는 카테고리에서 뽑는다(#85).
   const GOALS = Array.from(new Set([...existingGoals, block.goal].filter((g): g is string => !!g)));
@@ -86,11 +77,8 @@ function BlockEditSheet({ block, existingGoals, onSave, onDelete, onClose }: { b
 
         <div style={{ marginBottom: 14 }}>
           <label style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-3)', letterSpacing: '0.04em', textTransform: 'uppercase', display: 'block', marginBottom: 6 }}>시작 시간</label>
-          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 5 }}>
-            {HOURS.map((h) => (
-              <button key={h} onClick={() => setTime(h)} className="tnum" style={{ height: 38, padding: '0 12px', borderRadius: 9999, fontFamily: 'inherit', fontSize: 12, fontWeight: 600, background: time === h ? 'var(--brand)' : 'var(--surface-ground)', color: time === h ? '#FFFCF6' : 'var(--text-2)', border: `1px solid ${time === h ? 'var(--brand)' : 'var(--sand-200)'}`, cursor: 'pointer', transition: 'all 120ms' }}>{h}</button>
-            ))}
-          </div>
+          {/* 15분 snap 드래그(S15)와 별개로, 시트 편집은 다이얼로 자유롭게 고른다. */}
+          <TimeDial value={time} onChange={setTime} minuteStep={15} />
         </div>
 
         <div style={{ marginBottom: 14 }}>

--- a/src/screens/WeeklyPlanGenerationScreen.tsx
+++ b/src/screens/WeeklyPlanGenerationScreen.tsx
@@ -4,6 +4,7 @@ import { DAYS_KO, goalColor } from '../data';
 import { SetupProgress } from '../components/SetupProgress';
 import { AiDraftCard } from '../components/AiDraftCard';
 import { DemoNotice } from '../components/DemoNotice';
+import { TimeDial } from '../components/TimeDial';
 import { plansApi } from '../lib/api';
 import { useNavigation } from '../contexts/NavigationContext';
 import type { Block } from '../types';
@@ -39,7 +40,6 @@ function BlockEditSheet({ block, existingGoals, onSave, onDelete, onClose }: { b
   const [dur, setDur] = useState(block.dur);
   const [goal, setGoal] = useState(block.goal || existingGoals[0] || '기타');
 
-  const HOURS = ['09:00','10:00','11:00','13:00','14:00','15:00','16:00','17:00','18:00','19:00','20:00','21:00','21:30','22:00'];
   const DURS = [30, 45, 60, 90, 120];
   // 목표 선택지는 하드코딩된 이름 대신 지금 계획에 실제로 있는 카테고리에서 뽑는다(#85).
   // 편집 중인 블록 자신의 goal 은 목록에 없어도 항상 포함시켜 선택 해제되지 않게 한다.
@@ -72,11 +72,7 @@ function BlockEditSheet({ block, existingGoals, onSave, onDelete, onClose }: { b
 
         <div style={{ marginBottom: 14 }}>
           <label style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-3)', letterSpacing: '0.04em', textTransform: 'uppercase', display: 'block', marginBottom: 6 }}>시작 시간</label>
-          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 5 }}>
-            {HOURS.map((h) => (
-              <button key={h} onClick={() => setTime(h)} className="tnum" style={{ height: 38, padding: '0 12px', borderRadius: 9999, fontFamily: 'inherit', fontSize: 12, fontWeight: 600, background: time === h ? 'var(--brand)' : 'var(--surface-ground)', color: time === h ? '#FFFCF6' : 'var(--text-2)', border: `1px solid ${time === h ? 'var(--brand)' : 'var(--sand-200)'}`, cursor: 'pointer', transition: 'all 120ms' }}>{h}</button>
-            ))}
-          </div>
+          <TimeDial value={time} onChange={setTime} />
         </div>
 
         <div style={{ marginBottom: 14 }}>


### PR DESCRIPTION
## 배경

블록 편집 시트의 "시작 시간"이 시간 칩을 `flex-wrap`으로 쫙 깔아놔서 시각적으로 답답했다("환공포증"). 특히 주간 캘린더는 07~22시를 15분 단위로 나열해 칩이 **64개**나 됐다.

## 변경 사항

- **`src/components/TimeDial.tsx` 신설**: `scroll-snap` 기반 iOS 휠 선택기. 시/분 두 컬럼을 굴려서 고르고, 스크롤이 멈추면 가운데 칸을 선택으로 확정한다(칸 직접 클릭도 지원). 가운데 선택 밴드로 현재 값 강조. `minuteStep`/`minHour`/`maxHour` props로 조정 가능.
- **`index.css`**: 휠 컬럼 스크롤바 숨김 유틸(`.rx-wheel`) 추가.
- **`WeeklyPlanGenerationScreen`**: 시간 칩 14개 → `TimeDial`(5분 단위).
- **`WeeklyCalendarScreen`**: 시간 칩 64개 → `TimeDial`(15분 단위). 드래그 15분 snap(S15)은 그대로 유지되며, 시트 편집만 다이얼로 자유롭게 고른다.

## 검증

- Playwright로 두 시트를 모두 열어 휠 렌더 + 스크롤 시 값 변경(시 14→18) 정상 동작 확인, 콘솔 에러 없음.
- `npx tsc --noEmit` 클린
- `node scripts/check-api-contract.mjs` → PASS, GONE 0
- `npm run build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)