### PR TITLE
refactor(timetable/goal): 블록 편집 시트·목표 카테고리 통일 + other/기타 합침

### DIFF
--- a/src/components/BlockEditSheet.tsx
+++ b/src/components/BlockEditSheet.tsx
@@ -1,0 +1,101 @@
+import React, { useState } from 'react';
+import { X, Trash } from '@phosphor-icons/react';
+import { DAYS_KO, GOAL_CATEGORY_OPTIONS, DEFAULT_GOAL_CATEGORY, categoryLabel, goalColor } from '../data';
+import { TimeDial } from './TimeDial';
+import type { Block } from '../types';
+
+// 시간표 블록 편집 바텀시트 — 온보딩 "주간 계획 생성"과 메인 "주간 캘린더"가
+// 공유한다. (예전엔 두 화면이 거의 같은 시트를 각자 복붙해 갖고 있어, 목표 카테고리
+// 표기 등이 화면마다 어긋났다.) 목표 선택지는 목표 관리(GoalsScreen)와 동일한
+// GOAL_CATEGORY_OPTIONS 를 쓰고, 값(영문)은 저장·라벨(한글)은 표시로 통일한다.
+interface BlockEditSheetProps {
+  block: Block;
+  // 지금 계획에 실제로 들어있는 카테고리 값들 — 표준 목록에 없는 사용자 자유
+  // 카테고리도 선택지에 포함시키기 위함.
+  existingCategories: string[];
+  durations: number[];
+  minuteStep?: number;
+  onSave: (b: Block) => void;
+  onDelete: (id: string) => void;
+  onClose: () => void;
+}
+
+export function BlockEditSheet({ block, existingCategories, durations, minuteStep, onSave, onDelete, onClose }: BlockEditSheetProps) {
+  const [title, setTitle] = useState(block.title);
+  const [day, setDay] = useState(block.day);
+  const [time, setTime] = useState(block.time);
+  const [dur, setDur] = useState(block.dur);
+  const [goal, setGoal] = useState(block.goal || existingCategories[0] || DEFAULT_GOAL_CATEGORY);
+
+  // 표준 카테고리 + 지금 계획의 카테고리 + 이 블록의 값 → 중복 제거한 선택지.
+  // 값(영문/자유문자열)으로 관리하고 화면엔 categoryLabel 로 한글 표기한다.
+  const categoryValues = Array.from(
+    new Set([
+      ...GOAL_CATEGORY_OPTIONS.map((o) => o.value),
+      ...existingCategories,
+      block.goal,
+    ].filter((v): v is string => !!v)),
+  );
+
+  return (
+    <div onClick={onClose} style={{ position: 'absolute', inset: 0, background: 'rgba(26,23,20,.45)', zIndex: 60, display: 'flex', alignItems: 'flex-end' }}>
+      <div onClick={(e) => e.stopPropagation()} style={{ background: 'var(--surface-raised)', width: '100%', borderRadius: '24px 24px 0 0', padding: '12px 20px 36px', boxShadow: 'var(--shadow-xl)', maxHeight: '82%', overflowY: 'auto' }}>
+        <div style={{ width: 36, height: 4, borderRadius: 9999, background: 'var(--sand-300)', margin: '0 auto 16px' }} />
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
+          <h3 style={{ fontSize: 17, fontWeight: 700, margin: 0, letterSpacing: '-0.01em' }}>블록 수정</h3>
+          <button onClick={onClose} style={{ width: 44, height: 44, borderRadius: 9999, border: 'none', background: 'var(--sand-100)', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer' }}>
+            <X size={12} color="var(--text-2)" />
+          </button>
+        </div>
+
+        <div style={{ marginBottom: 14 }}>
+          <label style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-3)', letterSpacing: '0.04em', textTransform: 'uppercase', display: 'block', marginBottom: 6 }}>제목</label>
+          <input value={title} onChange={(e) => setTitle(e.target.value)} style={{ width: '100%', height: 44, borderRadius: 12, border: '1px solid var(--sand-200)', background: 'var(--surface-ground)', padding: '0 14px', fontSize: 14, fontFamily: 'inherit', color: 'var(--text-1)', outline: 'none', boxSizing: 'border-box' }} />
+        </div>
+
+        <div style={{ marginBottom: 14 }}>
+          <label style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-3)', letterSpacing: '0.04em', textTransform: 'uppercase', display: 'block', marginBottom: 6 }}>요일</label>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', gap: 4 }}>
+            {DAYS_KO.map((d, i) => (
+              <button key={d} onClick={() => setDay(i)} style={{ height: 44, borderRadius: 10, fontFamily: 'inherit', fontSize: 13, fontWeight: 600, background: day === i ? 'var(--text-1)' : 'var(--surface-ground)', color: day === i ? '#FAF6EE' : 'var(--text-2)', border: `1px solid ${day === i ? 'var(--text-1)' : 'var(--sand-200)'}`, cursor: 'pointer', transition: 'all 120ms' }}>{d}</button>
+            ))}
+          </div>
+        </div>
+
+        <div style={{ marginBottom: 14 }}>
+          <label style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-3)', letterSpacing: '0.04em', textTransform: 'uppercase', display: 'block', marginBottom: 6 }}>시작 시간</label>
+          <TimeDial value={time} onChange={setTime} minuteStep={minuteStep} />
+        </div>
+
+        <div style={{ marginBottom: 14 }}>
+          <label style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-3)', letterSpacing: '0.04em', textTransform: 'uppercase', display: 'block', marginBottom: 6 }}>소요 시간</label>
+          <div style={{ display: 'flex', gap: 5 }}>
+            {durations.map((d) => (
+              <button key={d} onClick={() => setDur(d)} className="tnum" style={{ flex: 1, height: 44, borderRadius: 12, fontFamily: 'inherit', fontSize: 14, fontWeight: 600, background: dur === d ? 'var(--text-1)' : 'var(--surface-ground)', color: dur === d ? '#FAF6EE' : 'var(--text-2)', border: `1px solid ${dur === d ? 'var(--text-1)' : 'var(--sand-200)'}`, cursor: 'pointer', transition: 'all 120ms' }}>{d}분</button>
+            ))}
+          </div>
+        </div>
+
+        <div style={{ marginBottom: 18 }}>
+          <label style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-3)', letterSpacing: '0.04em', textTransform: 'uppercase', display: 'block', marginBottom: 6 }}>목표</label>
+          <div style={{ display: 'flex', gap: 5, flexWrap: 'wrap' }}>
+            {categoryValues.map((v) => {
+              const c = goalColor(v);
+              const sel = goal === v;
+              return (
+                <button key={v} onClick={() => setGoal(v)} style={{ height: 40, padding: '0 12px', borderRadius: 12, fontFamily: 'inherit', fontSize: 13, fontWeight: 600, background: sel ? c.bg : 'var(--surface-ground)', color: sel ? c.fg : 'var(--text-2)', border: `1.5px solid ${sel ? c.bd : 'var(--sand-200)'}`, cursor: 'pointer', transition: 'all 120ms' }}>{categoryLabel(v)}</button>
+              );
+            })}
+          </div>
+        </div>
+
+        <div style={{ display: 'flex', gap: 8 }}>
+          <button onClick={() => onDelete(block.id)} style={{ flex: 1, height: 'var(--ctrl-lg)', borderRadius: 12, border: '1px solid var(--coral-200)', background: '#FAE2D8', color: 'var(--danger)', fontWeight: 600, fontSize: 13, fontFamily: 'inherit', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6 }}>
+            <Trash size={14} /> 삭제
+          </button>
+          <button onClick={() => onSave({ ...block, title, day, time, dur, goal })} style={{ flex: 2, height: 'var(--ctrl-lg)', borderRadius: 12, border: 'none', background: 'var(--text-1)', color: '#FAF6EE', fontWeight: 700, fontSize: 14, fontFamily: 'inherit', cursor: 'pointer' }}>저장</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -35,3 +35,33 @@ export function goalColor(name: string | null | undefined): { bg: string; bd: st
 }
 
 export const DAYS_KO = ['월', '화', '수', '목', '금', '토', '일'];
+
+// ── Goal category ─────────────────────────────────────────────
+// 목표 카테고리의 단일 소스(값=백엔드 영문, 라벨=한글). 목표 관리(GoalsScreen)·
+// 시간표 생성(온보딩)·주간 캘린더(메인)가 전부 이걸 공유해, 'other' 가 어디선
+// "other" 어디선 "기타" 로 갈라지던 문제를 없앤다.
+export const GOAL_CATEGORY_OPTIONS: { value: string; label: string }[] = [
+  { value: 'study', label: '학습' },
+  { value: 'project', label: '프로젝트' },
+  { value: 'health', label: '건강' },
+  { value: 'routine', label: '루틴' },
+  { value: 'schedule', label: '일정' },
+  { value: 'career', label: '커리어' },
+  { value: 'relationship', label: '관계' },
+  { value: 'self_dev', label: '자기계발' },
+  { value: 'other', label: '기타' },
+];
+
+const GOAL_CATEGORY_LABEL: Record<string, string> = Object.fromEntries(
+  GOAL_CATEGORY_OPTIONS.map((c) => [c.value, c.label]),
+);
+
+// 미분류 기본 카테고리 — 한국어 리터럴 '기타' 대신 정식 값 'other' 를 쓴다.
+// (그래야 백엔드 'other' 블록과 같은 값이 되어 색·라벨이 하나로 합쳐진다.)
+export const DEFAULT_GOAL_CATEGORY = 'other';
+
+// 카테고리 값 → 한글 라벨. 알려진 값은 라벨로, 사용자 자유 문자열은 원문 그대로.
+export function categoryLabel(value: string | null | undefined): string {
+  if (!value) return GOAL_CATEGORY_LABEL[DEFAULT_GOAL_CATEGORY];
+  return GOAL_CATEGORY_LABEL[value] ?? value;
+}

--- a/src/screens/GoalsScreen.tsx
+++ b/src/screens/GoalsScreen.tsx
@@ -2,36 +2,13 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { Plus, Trash, PencilSimple, TreeStructure, Target } from '@phosphor-icons/react';
 import { ApiError, goalsApi } from '../lib/api';
 import type { ApiGoal, GoalDecomposition, GoalTier } from '../types/api';
-import { GOAL_STATUS_META } from '../data';
+import { GOAL_STATUS_META, GOAL_CATEGORY_OPTIONS, categoryLabel } from '../data';
 import { ReButton } from '../components/ReButton';
 import { AiDraftCard } from '../components/AiDraftCard';
 
 // Focus ≤ 3 / Maintain ≤ 5. Parked 는 한도 자유 (백엔드 _TIER_LIMITS 와 동일).
 const TIER_LIMIT: Record<GoalTier, number | null> = { focus: 3, maintain: 5, parked: null };
 const TIER_ORDER: GoalTier[] = ['focus', 'maintain', 'parked'];
-
-const CATEGORY_OPTIONS: { value: string; label: string }[] = [
-  { value: 'study', label: '학습' },
-  { value: 'project', label: '프로젝트' },
-  { value: 'health', label: '건강' },
-  { value: 'routine', label: '루틴' },
-  { value: 'schedule', label: '일정' },
-  { value: 'career', label: '커리어' },
-  { value: 'relationship', label: '관계' },
-  { value: 'self_dev', label: '자기계발' },
-  { value: 'other', label: '기타' },
-];
-const CATEGORY_LABEL: Record<string, string> = Object.fromEntries(
-  CATEGORY_OPTIONS.map((c) => [c.value, c.label]),
-);
-
-// 백엔드가 비어있을 때 시연용 더미. id 에 goal_ 접두사가 없으므로 mutation 은 로컬에만 반영.
-const DEMO_GOALS: ApiGoal[] = [
-  { goalId: 'demo-1', title: '토익 700+ 달성', category: 'study', goalTier: 'focus', priorityLevel: 1, deadline: '2026-12-07', estimatedMinutes: 1920, status: 'active' },
-  { goalId: 'demo-2', title: '캡스톤 프로젝트', category: 'project', goalTier: 'focus', priorityLevel: 2, deadline: '2026-06-20', estimatedMinutes: 2400, status: 'active' },
-  { goalId: 'demo-3', title: '학교 수업 출석·과제', category: 'schedule', goalTier: 'maintain', priorityLevel: 3, deadline: null, estimatedMinutes: 960, status: 'active' },
-  { goalId: 'demo-4', title: '헬스장 운동 루틴', category: 'health', goalTier: 'parked', priorityLevel: 4, deadline: null, estimatedMinutes: 0, status: 'active' },
-];
 
 const isReal = (id: string) => id.startsWith('goal_');
 
@@ -42,8 +19,11 @@ interface EditDraft {
 }
 
 export function GoalsScreen() {
-  const [goals, setGoals] = useState<ApiGoal[]>(DEMO_GOALS);
+  // 초기값 비움 → 로딩 중 스켈레톤, 실패 시엔 빈 목록 + 에러(더미로 가리지 않는다).
+  const [goals, setGoals] = useState<ApiGoal[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  // goals 가 실데이터(비어있어도)인지 — list() 성공 시 true.
+  const [usingReal, setUsingReal] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [editId, setEditId] = useState<string | null>(null);
@@ -68,16 +48,16 @@ export function GoalsScreen() {
       .list()
       .then((res) => {
         if (cancelled) return;
-        const flat = [...res.focus, ...res.maintain, ...res.parked];
-        // 백엔드가 비어있으면 더미 유지 — 시연 흐름을 끊지 않는다.
-        if (flat.length > 0) setGoals(flat);
+        // 200 응답 = 연동 성공. 비어있어도 실데이터(빈 목표)로 처리한다.
+        setUsingReal(true);
+        setGoals([...res.focus, ...res.maintain, ...res.parked]);
       })
       .catch((err: unknown) => {
         if (cancelled) return;
         setError(
           err instanceof ApiError
             ? `[${err.code}] ${err.message}`
-            : '목표를 불러오지 못했어요. 더미 데이터로 진행합니다.',
+            : '목표를 불러오지 못했어요.',
         );
       })
       .finally(() => {
@@ -247,8 +227,22 @@ export function GoalsScreen() {
           </div>
         )}
 
+        {/* 첫 로드 중엔 스켈레톤, 연동 성공했는데 목표가 없으면 빈 상태 안내. */}
+        {isLoading && (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }} aria-hidden="true">
+            {[0, 1, 2].map((i) => (
+              <div key={i} style={{ height: 72, borderRadius: 14, border: '1px solid var(--sand-200)', background: 'var(--surface-raised)', opacity: 0.6 }} />
+            ))}
+          </div>
+        )}
+        {!isLoading && usingReal && goals.length === 0 && (
+          <div style={{ padding: '14px 16px', borderRadius: 14, background: 'var(--surface-raised)', border: '1px dashed var(--sand-200)', fontSize: 12, color: 'var(--text-2)', lineHeight: 1.5 }}>
+            아직 등록된 목표가 없어요. 아래 <b>+ 목표 추가</b>로 만들어보세요.
+          </div>
+        )}
+
         {/* tier 별 그룹 */}
-        {TIER_ORDER.map((tier) => {
+        {!isLoading && TIER_ORDER.map((tier) => {
           const items = goals.filter((g) => g.goalTier === tier);
           if (items.length === 0) return null;
           const m = GOAL_STATUS_META[tier];
@@ -267,7 +261,7 @@ export function GoalsScreen() {
                       <div style={{ flex: 1, minWidth: 0 }}>
                         <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 5, flexWrap: 'wrap' }}>
                           <span style={{ height: 'var(--ctrl-xs)', padding: '0 8px', borderRadius: 9999, background: m.bg, border: `1px solid ${m.border}`, fontSize: 10, fontWeight: 700, color: m.color, fontFamily: 'var(--font-mono)', display: 'inline-flex', alignItems: 'center' }}>{m.label}</span>
-                          <span style={{ height: 'var(--ctrl-xs)', padding: '0 7px', background: 'var(--sand-100)', border: '1px solid var(--sand-200)', borderRadius: 9999, fontSize: 10, color: 'var(--text-2)', display: 'inline-flex', alignItems: 'center' }}>{CATEGORY_LABEL[g.category] ?? g.category}</span>
+                          <span style={{ height: 'var(--ctrl-xs)', padding: '0 7px', background: 'var(--sand-100)', border: '1px solid var(--sand-200)', borderRadius: 9999, fontSize: 10, color: 'var(--text-2)', display: 'inline-flex', alignItems: 'center' }}>{categoryLabel(g.category)}</span>
                         </div>
                         <div style={{ fontWeight: 700, fontSize: 14, color: 'var(--text-1)', letterSpacing: '-0.01em' }}>{g.title}</div>
                         <div style={{ display: 'flex', gap: 5, flexWrap: 'wrap', marginTop: 4 }}>
@@ -358,7 +352,7 @@ export function GoalsScreen() {
             <input value={addTitle} onChange={(e) => setAddTitle(e.target.value)} placeholder="예: 정보처리기사 필기" style={inputStyle} />
             <div style={{ display: 'flex', gap: 6 }}>
               <select value={addCategory} onChange={(e) => setAddCategory(e.target.value)} style={{ ...inputStyle, flex: 1 }}>
-                {CATEGORY_OPTIONS.map((c) => <option key={c.value} value={c.value}>{c.label}</option>)}
+                {GOAL_CATEGORY_OPTIONS.map((c) => <option key={c.value} value={c.value}>{c.label}</option>)}
               </select>
               <input value={addDeadline} onChange={(e) => setAddDeadline(e.target.value)} placeholder="마감 YYYY-MM-DD" style={{ ...inputStyle, flex: 1 }} />
             </div>

--- a/src/screens/WeeklyCalendarScreen.tsx
+++ b/src/screens/WeeklyCalendarScreen.tsx
@@ -1,13 +1,16 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Plus, X, Trash } from '@phosphor-icons/react';
-import { DAYS_KO, goalColor } from '../data';
+import { Plus } from '@phosphor-icons/react';
+import { DAYS_KO, DEFAULT_GOAL_CATEGORY, goalColor } from '../data';
 import { ApiError, plansApi } from '../lib/api';
 import { DemoNotice } from '../components/DemoNotice';
 import { Segmented } from '../components/Segmented';
-import { TimeDial } from '../components/TimeDial';
+import { BlockEditSheet } from '../components/BlockEditSheet';
 import { useNavigation } from '../contexts/NavigationContext';
 import type { Block } from '../types';
 import type { WeeklyPlanResponse, BlockEditRequest } from '../types/api';
+
+// 소요 시간 프리셋(15분 옵션 포함) — 공유 BlockEditSheet 에 넘긴다.
+const DURATIONS = [15, 30, 45, 60, 90, 120];
 
 // 백엔드 WeeklyPlanResponse(days[].blocks[] = WeeklyBlock) → 화면 BlockWithStatus[].
 function weeklyToBlocks(res: WeeklyPlanResponse): (Block & { status: 'pending' | 'done' | 'failed' })[] {
@@ -23,7 +26,8 @@ function weeklyToBlocks(res: WeeklyPlanResponse): (Block & { status: 'pending' |
         time: `${String(s.getHours()).padStart(2, '0')}:${String(s.getMinutes()).padStart(2, '0')}`,
         dur: Math.max(15, Math.round((e.getTime() - s.getTime()) / 60000)),
         title: b.title,
-        goal: b.category,
+        // 카테고리 미지정이면 정식 값 'other' 로 정규화해 '기타' 로 합쳐지게 한다.
+        goal: b.category || DEFAULT_GOAL_CATEGORY,
         fixed: b.source === 'fixed',
         status,
       });
@@ -39,80 +43,6 @@ const POLICY_NIGHT_START = 23 * 60;
 // 정책 위반 시뮬: 6시 이전 시작 차단.
 const POLICY_MORNING_START = 6 * 60;
 
-function BlockEditSheet({ block, existingGoals, onSave, onDelete, onClose }: { block: Block; existingGoals: string[]; onSave: (b: Block) => void; onDelete: (id: string) => void; onClose: () => void }) {
-  const [title, setTitle] = useState(block.title);
-  const [day, setDay] = useState(block.day);
-  const [time, setTime] = useState(block.time);
-  const [dur, setDur] = useState(block.dur);
-  const [goal, setGoal] = useState(block.goal || existingGoals[0] || '기타');
-
-  const DURS = [15, 30, 45, 60, 90, 120];
-  // 목표 선택지는 하드코딩된 이름 대신 지금 계획에 실제로 있는 카테고리에서 뽑는다(#85).
-  const GOALS = Array.from(new Set([...existingGoals, block.goal].filter((g): g is string => !!g)));
-
-  return (
-    <div onClick={onClose} style={{ position: 'absolute', inset: 0, background: 'rgba(26,23,20,.45)', zIndex: 60, display: 'flex', alignItems: 'flex-end' }}>
-      <div onClick={(e) => e.stopPropagation()} style={{ background: 'var(--surface-raised)', width: '100%', borderRadius: '24px 24px 0 0', padding: '12px 20px 36px', boxShadow: 'var(--shadow-xl)', maxHeight: '82%', overflowY: 'auto' }}>
-        <div style={{ width: 36, height: 4, borderRadius: 9999, background: 'var(--sand-300)', margin: '0 auto 16px' }} />
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
-          <h3 style={{ fontSize: 17, fontWeight: 700, margin: 0, letterSpacing: '-0.01em' }}>블록 수정</h3>
-          <button onClick={onClose} style={{ width: 44, height: 44, borderRadius: 9999, border: 'none', background: 'var(--sand-100)', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer' }}>
-            <X size={12} color="var(--text-2)" />
-          </button>
-        </div>
-
-        <div style={{ marginBottom: 14 }}>
-          <label style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-3)', letterSpacing: '0.04em', textTransform: 'uppercase', display: 'block', marginBottom: 6 }}>제목</label>
-          <input value={title} onChange={(e) => setTitle(e.target.value)} style={{ width: '100%', height: 44, borderRadius: 12, border: '1px solid var(--sand-200)', background: 'var(--surface-ground)', padding: '0 14px', fontSize: 14, fontFamily: 'inherit', color: 'var(--text-1)', outline: 'none', boxSizing: 'border-box' }} />
-        </div>
-
-        <div style={{ marginBottom: 14 }}>
-          <label style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-3)', letterSpacing: '0.04em', textTransform: 'uppercase', display: 'block', marginBottom: 6 }}>요일</label>
-          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', gap: 4 }}>
-            {DAYS_KO.map((d, i) => (
-              <button key={d} onClick={() => setDay(i)} style={{ height: 44, borderRadius: 10, fontFamily: 'inherit', fontSize: 13, fontWeight: 600, background: day === i ? 'var(--text-1)' : 'var(--surface-ground)', color: day === i ? '#FAF6EE' : 'var(--text-2)', border: `1px solid ${day === i ? 'var(--text-1)' : 'var(--sand-200)'}`, cursor: 'pointer', transition: 'all 120ms' }}>{d}</button>
-            ))}
-          </div>
-        </div>
-
-        <div style={{ marginBottom: 14 }}>
-          <label style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-3)', letterSpacing: '0.04em', textTransform: 'uppercase', display: 'block', marginBottom: 6 }}>시작 시간</label>
-          {/* 15분 snap 드래그(S15)와 별개로, 시트 편집은 다이얼로 자유롭게 고른다. */}
-          <TimeDial value={time} onChange={setTime} minuteStep={15} />
-        </div>
-
-        <div style={{ marginBottom: 14 }}>
-          <label style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-3)', letterSpacing: '0.04em', textTransform: 'uppercase', display: 'block', marginBottom: 6 }}>소요 시간</label>
-          <div style={{ display: 'flex', gap: 5 }}>
-            {DURS.map((d) => (
-              <button key={d} onClick={() => setDur(d)} className="tnum" style={{ flex: 1, height: 44, borderRadius: 12, fontFamily: 'inherit', fontSize: 14, fontWeight: 600, background: dur === d ? 'var(--text-1)' : 'var(--surface-ground)', color: dur === d ? '#FAF6EE' : 'var(--text-2)', border: `1px solid ${dur === d ? 'var(--text-1)' : 'var(--sand-200)'}`, cursor: 'pointer', transition: 'all 120ms' }}>{d}분</button>
-            ))}
-          </div>
-        </div>
-
-        <div style={{ marginBottom: 18 }}>
-          <label style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-3)', letterSpacing: '0.04em', textTransform: 'uppercase', display: 'block', marginBottom: 6 }}>목표</label>
-          <div style={{ display: 'flex', gap: 5 }}>
-            {GOALS.map((g) => {
-              const c = goalColor(g);
-              const isSel = goal === g;
-              return (
-                <button key={g} onClick={() => setGoal(g)} style={{ flex: 1, height: 44, borderRadius: 12, fontFamily: 'inherit', fontSize: 13, fontWeight: 600, background: isSel ? c.bg : 'var(--surface-ground)', color: isSel ? c.fg : 'var(--text-2)', border: `1.5px solid ${isSel ? c.bd : 'var(--sand-200)'}`, cursor: 'pointer', transition: 'all 120ms' }}>{g}</button>
-              );
-            })}
-          </div>
-        </div>
-
-        <div style={{ display: 'flex', gap: 8 }}>
-          <button onClick={() => onDelete(block.id)} style={{ flex: 1, height: 'var(--ctrl-lg)', borderRadius: 12, border: '1px solid var(--coral-200)', background: '#FAE2D8', color: 'var(--danger)', fontWeight: 600, fontSize: 13, fontFamily: 'inherit', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6 }}>
-            <Trash size={14} /> 삭제
-          </button>
-          <button onClick={() => onSave({ ...block, title, day, time, dur, goal })} style={{ flex: 2, height: 'var(--ctrl-lg)', borderRadius: 12, border: 'none', background: 'var(--text-1)', color: '#FAF6EE', fontWeight: 700, fontSize: 14, fontFamily: 'inherit', cursor: 'pointer' }}>저장</button>
-        </div>
-      </div>
-    </div>
-  );
-}
 
 type BlockWithStatus = Block & { status: string };
 
@@ -390,8 +320,8 @@ export function WeeklyCalendarScreenV2() {
   };
   const addBlock = () => {
     const id = 'new-' + Date.now();
-    // 기본 목표는 하드코딩된 이름 대신 지금 계획에 있는 첫 카테고리를 재사용(#85).
-    const defaultGoal = blocks.find((b) => b.goal)?.goal ?? '기타';
+    // 기본 목표는 지금 계획의 첫 카테고리, 없으면 정식 기본값 'other'(→ '기타').
+    const defaultGoal = blocks.find((b) => b.goal)?.goal ?? DEFAULT_GOAL_CATEGORY;
     const newBlock: BlockWithStatus = { id, day: TODAY, time: '14:00', dur: 60, title: '새 블록', goal: defaultGoal, status: 'pending' };
     setBlocks((bs) => [...bs, newBlock]);
     setEditing(newBlock);
@@ -563,7 +493,9 @@ export function WeeklyCalendarScreenV2() {
       {editing && (
         <BlockEditSheet
           block={editing}
-          existingGoals={Array.from(new Set(blocks.map((b) => b.goal).filter((g): g is string => !!g)))}
+          existingCategories={Array.from(new Set(blocks.map((b) => b.goal).filter((g): g is string => !!g)))}
+          durations={DURATIONS}
+          minuteStep={15}
           onSave={handleSave}
           onDelete={handleDelete}
           onClose={() => setEditing(null)}

--- a/src/screens/WeeklyPlanGenerationScreen.tsx
+++ b/src/screens/WeeklyPlanGenerationScreen.tsx
@@ -1,14 +1,17 @@
 import React, { useState, useEffect } from 'react';
-import { Clock, X, Trash } from '@phosphor-icons/react';
-import { DAYS_KO, goalColor } from '../data';
+import { Clock } from '@phosphor-icons/react';
+import { DAYS_KO, DEFAULT_GOAL_CATEGORY, categoryLabel, goalColor } from '../data';
 import { SetupProgress } from '../components/SetupProgress';
 import { AiDraftCard } from '../components/AiDraftCard';
 import { DemoNotice } from '../components/DemoNotice';
-import { TimeDial } from '../components/TimeDial';
+import { BlockEditSheet } from '../components/BlockEditSheet';
 import { plansApi } from '../lib/api';
 import { useNavigation } from '../contexts/NavigationContext';
 import type { Block } from '../types';
 import type { FirstPlanGenerateRequest, ScheduledBlockPreview } from '../types/api';
+
+// 소요 시간 프리셋 — 온보딩(생성)과 메인 캘린더가 공유하는 블록 편집 시트에 넘긴다.
+const DURATIONS = [30, 45, 60, 90, 120];
 
 // 백엔드 ScheduledBlockPreview(start/end KST ISO) → 화면 Block(day/time/dur).
 function previewToBlock(b: ScheduledBlockPreview, i: number): Block {
@@ -23,7 +26,8 @@ function previewToBlock(b: ScheduledBlockPreview, i: number): Block {
     time,
     title: b.title,
     dur,
-    goal: b.category,
+    // 카테고리 미지정이면 정식 값 'other' 로 정규화해 '기타' 로 합쳐지게 한다.
+    goal: b.category || DEFAULT_GOAL_CATEGORY,
     fixed: b.origin === 'fixed',
     type: b.origin,
   };
@@ -31,81 +35,6 @@ function previewToBlock(b: ScheduledBlockPreview, i: number): Block {
 
 interface WeeklyPlanGenerationScreenProps {
   onContinue: () => void;
-}
-
-function BlockEditSheet({ block, existingGoals, onSave, onDelete, onClose }: { block: Block; existingGoals: string[]; onSave: (b: Block) => void; onDelete: (id: string) => void; onClose: () => void }) {
-  const [title, setTitle] = useState(block.title);
-  const [day, setDay] = useState(block.day);
-  const [time, setTime] = useState(block.time);
-  const [dur, setDur] = useState(block.dur);
-  const [goal, setGoal] = useState(block.goal || existingGoals[0] || '기타');
-
-  const DURS = [30, 45, 60, 90, 120];
-  // 목표 선택지는 하드코딩된 이름 대신 지금 계획에 실제로 있는 카테고리에서 뽑는다(#85).
-  // 편집 중인 블록 자신의 goal 은 목록에 없어도 항상 포함시켜 선택 해제되지 않게 한다.
-  const GOALS = Array.from(new Set([...existingGoals, block.goal].filter((g): g is string => !!g)));
-
-  return (
-    <div onClick={onClose} style={{ position: 'absolute', inset: 0, background: 'rgba(26,23,20,.45)', zIndex: 60, display: 'flex', alignItems: 'flex-end' }}>
-      <div onClick={(e) => e.stopPropagation()} style={{ background: 'var(--surface-raised)', width: '100%', borderRadius: '24px 24px 0 0', padding: '12px 20px 36px', boxShadow: 'var(--shadow-xl)', maxHeight: '82%', overflowY: 'auto' }}>
-        <div style={{ width: 36, height: 4, borderRadius: 9999, background: 'var(--sand-300)', margin: '0 auto 16px' }} />
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
-          <h3 style={{ fontSize: 17, fontWeight: 700, margin: 0, letterSpacing: '-0.01em' }}>블록 수정</h3>
-          <button onClick={onClose} style={{ width: 44, height: 44, borderRadius: 9999, border: 'none', background: 'var(--sand-100)', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer' }}>
-            <X size={12} color="var(--text-2)" />
-          </button>
-        </div>
-
-        <div style={{ marginBottom: 14 }}>
-          <label style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-3)', letterSpacing: '0.04em', textTransform: 'uppercase', display: 'block', marginBottom: 6 }}>제목</label>
-          <input value={title} onChange={(e) => setTitle(e.target.value)} style={{ width: '100%', height: 44, borderRadius: 12, border: '1px solid var(--sand-200)', background: 'var(--surface-ground)', padding: '0 14px', fontSize: 14, fontFamily: 'inherit', color: 'var(--text-1)', outline: 'none', boxSizing: 'border-box' }} />
-        </div>
-
-        <div style={{ marginBottom: 14 }}>
-          <label style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-3)', letterSpacing: '0.04em', textTransform: 'uppercase', display: 'block', marginBottom: 6 }}>요일</label>
-          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', gap: 4 }}>
-            {DAYS_KO.map((d, i) => (
-              <button key={d} onClick={() => setDay(i)} style={{ height: 44, borderRadius: 10, fontFamily: 'inherit', fontSize: 13, fontWeight: 600, background: day === i ? 'var(--text-1)' : 'var(--surface-ground)', color: day === i ? '#FAF6EE' : 'var(--text-2)', border: `1px solid ${day === i ? 'var(--text-1)' : 'var(--sand-200)'}`, cursor: 'pointer', transition: 'all 120ms' }}>{d}</button>
-            ))}
-          </div>
-        </div>
-
-        <div style={{ marginBottom: 14 }}>
-          <label style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-3)', letterSpacing: '0.04em', textTransform: 'uppercase', display: 'block', marginBottom: 6 }}>시작 시간</label>
-          <TimeDial value={time} onChange={setTime} />
-        </div>
-
-        <div style={{ marginBottom: 14 }}>
-          <label style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-3)', letterSpacing: '0.04em', textTransform: 'uppercase', display: 'block', marginBottom: 6 }}>소요 시간</label>
-          <div style={{ display: 'flex', gap: 5 }}>
-            {DURS.map((d) => (
-              <button key={d} onClick={() => setDur(d)} className="tnum" style={{ flex: 1, height: 44, borderRadius: 12, fontFamily: 'inherit', fontSize: 14, fontWeight: 600, background: dur === d ? 'var(--text-1)' : 'var(--surface-ground)', color: dur === d ? '#FAF6EE' : 'var(--text-2)', border: `1px solid ${dur === d ? 'var(--text-1)' : 'var(--sand-200)'}`, cursor: 'pointer', transition: 'all 120ms' }}>{d}분</button>
-            ))}
-          </div>
-        </div>
-
-        <div style={{ marginBottom: 18 }}>
-          <label style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-3)', letterSpacing: '0.04em', textTransform: 'uppercase', display: 'block', marginBottom: 6 }}>목표</label>
-          <div style={{ display: 'flex', gap: 5 }}>
-            {GOALS.map((g) => {
-              const c = goalColor(g);
-              const sel = goal === g;
-              return (
-                <button key={g} onClick={() => setGoal(g)} style={{ flex: 1, height: 44, borderRadius: 12, fontFamily: 'inherit', fontSize: 13, fontWeight: 600, background: sel ? c.bg : 'var(--surface-ground)', color: sel ? c.fg : 'var(--text-2)', border: `1.5px solid ${sel ? c.bd : 'var(--sand-200)'}`, cursor: 'pointer', transition: 'all 120ms' }}>{g}</button>
-              );
-            })}
-          </div>
-        </div>
-
-        <div style={{ display: 'flex', gap: 8 }}>
-          <button onClick={() => onDelete(block.id)} style={{ flex: 1, height: 'var(--ctrl-lg)', borderRadius: 12, border: '1px solid var(--coral-200)', background: '#FAE2D8', color: 'var(--danger)', fontWeight: 600, fontSize: 13, fontFamily: 'inherit', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6 }}>
-            <Trash size={14} /> 삭제
-          </button>
-          <button onClick={() => onSave({ ...block, title, day, time, dur, goal })} style={{ flex: 2, height: 'var(--ctrl-lg)', borderRadius: 12, border: 'none', background: 'var(--text-1)', color: '#FAF6EE', fontWeight: 700, fontSize: 14, fontFamily: 'inherit', cursor: 'pointer' }}>저장</button>
-        </div>
-      </div>
-    </div>
-  );
 }
 
 export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationScreenProps) {
@@ -200,8 +129,8 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
   const handleDelete = (id: string) => { setBlocks((bs) => bs.filter((b) => b.id !== id)); setEditing(null); };
   const addBlock = () => {
     const id = 'new-' + Date.now();
-    // 기본 목표는 하드코딩된 이름 대신 지금 계획에 있는 첫 카테고리를 재사용(#85).
-    const defaultGoal = blocks.find((b) => b.goal)?.goal ?? '기타';
+    // 기본 목표는 지금 계획의 첫 카테고리, 없으면 정식 기본값 'other'(→ '기타').
+    const defaultGoal = blocks.find((b) => b.goal)?.goal ?? DEFAULT_GOAL_CATEGORY;
     const newBlock: Block = { id, day: 0, time: '14:00', dur: 60, title: '새 블록', goal: defaultGoal };
     setBlocks((bs) => [...bs, newBlock]);
     setEditing(newBlock);
@@ -318,7 +247,7 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
               return (
                 <span key={g} style={{ height: 'var(--ctrl-xs)', padding: '0 10px', background: c.bg, border: `1px solid ${c.bd}`, color: c.fg, borderRadius: 9999, fontSize: 11, fontWeight: 600, display: 'inline-flex', alignItems: 'center', gap: 4 }}>
                   <span style={{ width: 6, height: 6, borderRadius: 9999, background: c.fg }} />
-                  {g} <span className="tnum">{(mins / 60).toFixed(1)}h</span>
+                  {categoryLabel(g)} <span className="tnum">{(mins / 60).toFixed(1)}h</span>
                 </span>
               );
             })}
@@ -329,7 +258,8 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
       {editing && (
         <BlockEditSheet
           block={editing}
-          existingGoals={Array.from(new Set(blocks.map((b) => b.goal).filter((g): g is string => !!g)))}
+          existingCategories={Array.from(new Set(blocks.map((b) => b.goal).filter((g): g is string => !!g)))}
+          durations={DURATIONS}
           onSave={handleSave}
           onDelete={handleDelete}
           onClose={() => setEditing(null)}


### PR DESCRIPTION
## 배경

사용자 요청 2가지:
1. 시간표 생성/조회/수정을 **목표 설정 쪽과 메인에서 통일**되게.
2. 목표 카테고리에서 **"other"와 "기타"가 둘로 갈라지는** 문제 확인/수정.

## 원인

- 온보딩 "주간 계획 생성"(`WeeklyPlanGenerationScreen`)과 메인 "주간 캘린더"(`WeeklyCalendarScreen`)가 거의 **동일한 블록 편집 시트를 각자 복붙**해 갖고 있었다(각자 로컬 `BlockEditSheet`).
- 두 시간표 화면은 백엔드 카테고리 값(영문 `'other'`)을 **라벨 매핑 없이 그대로** 칩에 렌더 → 화면에 문자 그대로 "other"로 표시. 게다가 카테고리 없는 블록은 한국어 리터럴 `'기타'`를 **값**으로 넣어, 같은 "미분류"가 `'other'`/`'기타'` 두 문자열 → 두 칩, 두 색으로 갈라졌다.
- 정식 카테고리 맵(`value:'other' → label:'기타'`)은 `GoalsScreen`에만 있었고 시간표 화면은 안 씀.

## 변경 사항

**통일 (#1)**
- `src/components/BlockEditSheet.tsx` 신설 — 블록 편집 시트를 공유 컴포넌트로 추출. 두 시간표 화면이 이걸 import(소요시간 프리셋·분 단위만 props로 주입). 로컬 복붙본 삭제(−196줄).
- 블록 편집 시트의 목표 선택지 = 목표 관리와 **동일한 카테고리 목록**.

**other/기타 합침 (#2)**
- `src/data/index.ts`에 카테고리 단일 소스 신설: `GOAL_CATEGORY_OPTIONS`(값=영문, 라벨=한글), `categoryLabel()`(알려진 값→한글, 자유문자열→원문), `DEFAULT_GOAL_CATEGORY='other'`.
- 두 시간표 화면: 미분류 블록을 `'other'`로 정규화(→ "기타"), 칩/요약은 `categoryLabel`로 표시, 색은 `goalColor(값)`로 일관 → `'other'`와 예전 `'기타'`가 하나로 합쳐짐.
- `GoalsScreen`: 로컬 `CATEGORY_OPTIONS`/`CATEGORY_LABEL` 중복 제거하고 공유본 사용.

**부수**
- `GoalsScreen`에 남아있던 `DEMO_GOALS` 더미 제거 → 로딩 스켈레톤 + 실패 시 빈 상태/에러로 정직화(앞선 목업 제거 방침과 동일).

## 검증

- Playwright: 블록 편집 시트의 목표 칩이 목표 관리와 같은 한글 카테고리 목록(학습·프로젝트·건강·루틴·일정·커리어·관계·자기계발·기타)으로 뜨는 것 확인, 콘솔 에러 없음.
- `categoryLabel` 합침 로직 단위 확인: `'other'`·빈값 → "기타", 커스텀 문자열 → 원문 유지.
- `npx tsc --noEmit` 클린 / `check-api-contract` PASS, GONE 0 / `npm run build` 성공(번들 감소).

🤖 Generated with [Claude Code](https://claude.com/claude-code)