### PR TITLE
chore(api): 백엔드 API 동기화 (routine)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2556,6 +2556,67 @@
         "title": "OnboardingStatus",
         "type": "object"
       },
+      "PolicySnapshotResponse": {
+        "description": "GET /policy-snapshot/current — 현재 활성 PolicySnapshot (#83).\n\n활성 스냅샷이 없으면 라우트가 404(POLICY_NOT_FOUND) 를 낸다 — FE 는 카운트-only\n폴백을 유지한다.",
+        "properties": {
+          "behavioralProfile": {
+            "additionalProperties": true,
+            "title": "Behavioralprofile",
+            "type": "object"
+          },
+          "executionConstraints": {
+            "additionalProperties": true,
+            "title": "Executionconstraints",
+            "type": "object"
+          },
+          "interactionStyle": {
+            "additionalProperties": true,
+            "title": "Interactionstyle",
+            "type": "object"
+          },
+          "reasonForUpdate": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reasonforupdate"
+          },
+          "recoveryPolicy": {
+            "additionalProperties": true,
+            "title": "Recoverypolicy",
+            "type": "object"
+          },
+          "source": {
+            "title": "Source",
+            "type": "string"
+          },
+          "validFrom": {
+            "format": "date-time",
+            "title": "Validfrom",
+            "type": "string"
+          },
+          "version": {
+            "title": "Version",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "version",
+          "source",
+          "behavioralProfile",
+          "executionConstraints",
+          "interactionStyle",
+          "recoveryPolicy",
+          "reasonForUpdate",
+          "validFrom"
+        ],
+        "title": "PolicySnapshotResponse",
+        "type": "object"
+      },
       "PolicyViolation": {
         "description": "정책 위반으로 제외된 노드 + 사유 (cap / 충돌 등).",
         "properties": {
@@ -2910,6 +2971,147 @@
           "cards"
         ],
         "title": "RecoveryProposalsResponse",
+        "type": "object"
+      },
+      "ReflectionBatchItem": {
+        "description": "POST /reflection/batch 항목 — 미체크 실행 1건의 최종 결과 + 선택적 실패 사유.\n\n`failure_tags`/`memo` 는 `completion_status` 가 failed/partial_done 일 때만 유효\n(그 외 값과 함께 오면 422). `memo` 는 서버가 at-rest 암호화한다.",
+        "properties": {
+          "completionStatus": {
+            "enum": [
+              "done",
+              "partial_done",
+              "failed",
+              "over_done"
+            ],
+            "title": "Completionstatus",
+            "type": "string"
+          },
+          "executionId": {
+            "title": "Executionid",
+            "type": "string"
+          },
+          "failureTags": {
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 2,
+            "title": "Failuretags",
+            "type": "array"
+          },
+          "memo": {
+            "anyOf": [
+              {
+                "maxLength": 300,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Memo"
+          }
+        },
+        "required": [
+          "executionId",
+          "completionStatus"
+        ],
+        "title": "ReflectionBatchItem",
+        "type": "object"
+      },
+      "ReflectionBatchRequest": {
+        "description": "POST /reflection/batch — [모두 완료] 일괄 처리. Idempotency-Key 필수(미들웨어).\n\n빈 배열은 no-op(200, processedCount=0). 상한 50건.",
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/ReflectionBatchItem"
+            },
+            "maxItems": 50,
+            "title": "Items",
+            "type": "array"
+          }
+        },
+        "title": "ReflectionBatchRequest",
+        "type": "object"
+      },
+      "ReflectionBatchResponse": {
+        "description": "일괄 처리 결과 요약.",
+        "properties": {
+          "needsFailureTags": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Needsfailuretags",
+            "type": "array"
+          },
+          "processedCount": {
+            "title": "Processedcount",
+            "type": "integer"
+          },
+          "taggedCount": {
+            "title": "Taggedcount",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "processedCount",
+          "taggedCount",
+          "needsFailureTags"
+        ],
+        "title": "ReflectionBatchResponse",
+        "type": "object"
+      },
+      "ReflectionPendingItem": {
+        "description": "GET /reflection/pending 응답 row — S17 저녁 회고에서 처리할 미체크 실행 (#83).\n\n최근 3일(오늘+어제+그제) 중 아직 체크인되지 않은(in_progress) 실행. 사용자가\n저녁에 소급 체크인/일괄 회고(POST /reflection/batch)할 대상이다. 아직 결과가\n정해지지 않았으므로 completion_status 는 null.",
+        "properties": {
+          "actionItemId": {
+            "title": "Actionitemid",
+            "type": "string"
+          },
+          "completionStatus": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Completionstatus"
+          },
+          "executionId": {
+            "title": "Executionid",
+            "type": "string"
+          },
+          "scheduledDate": {
+            "format": "date",
+            "title": "Scheduleddate",
+            "type": "string"
+          },
+          "scheduledTime": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scheduledtime"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "executionId",
+          "actionItemId",
+          "title",
+          "scheduledDate",
+          "scheduledTime",
+          "completionStatus"
+        ],
+        "title": "ReflectionPendingItem",
         "type": "object"
       },
       "RefreshRequest": {
@@ -6502,7 +6704,7 @@
     },
     "/policy-snapshot/current": {
       "get": {
-        "description": "현재 활성 PolicySnapshot.",
+        "description": "현재 활성 PolicySnapshot (#83) — 없으면 404 (FE 는 카운트-only 폴백 유지).",
         "operationId": "get_current_policy_policy_snapshot_current_get",
         "parameters": [
           {
@@ -6523,6 +6725,16 @@
           }
         ],
         "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PolicySnapshotResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
           "422": {
             "content": {
               "application/json": {
@@ -6532,14 +6744,6 @@
               }
             },
             "description": "Validation Error"
-          },
-          "501": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": "Successful Response"
           }
         },
         "summary": "Get Current Policy",
@@ -6778,7 +6982,7 @@
     },
     "/reflection/batch": {
       "post": {
-        "description": "오늘+어제+그제 미체크 카드 일괄 처리. Idempotency-Key 헤더 필수.",
+        "description": "저녁 회고 일괄 처리 (S17) — 오늘+어제+그제 미체크 카드를 한 번에 종결.\n\n각 항목 = 미체크(in_progress) 실행 1건의 최종 결과(4칩) + 선택적 실패 사유(0~2개).\ncheck-in(`POST /today/check-ins`)과 동일한 전이(execution 종결 + 블록 finished\n+ action_item.status)를 재현하고, failed/partial_done 항목엔 실패 사유를 함께 기록한다.\n**전량 사전 검증 후 한 트랜잭션으로 적용** — 하나라도 무효면 전체 롤백(부분 적용 없음).\nIdempotency-Key 는 미들웨어가 강제([모두 완료] 중복 탭 방지). 빈 배열은 no-op.",
         "operationId": "batch_reflect_reflection_batch_post",
         "parameters": [
           {
@@ -6798,7 +7002,27 @@
             }
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReflectionBatchRequest"
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReflectionBatchResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
           "422": {
             "content": {
               "application/json": {
@@ -6808,14 +7032,6 @@
               }
             },
             "description": "Validation Error"
-          },
-          "501": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": "Successful Response"
           }
         },
         "summary": "Batch Reflect",
@@ -6942,6 +7158,60 @@
           }
         },
         "summary": "Tag Failure Reasons",
+        "tags": [
+          "reflection"
+        ]
+      }
+    },
+    "/reflection/pending": {
+      "get": {
+        "description": "S17 저녁 회고 — 최근 3일(오늘+어제+그제) 미체크(in_progress) 실행 목록 (#83).\n\n시작만 하고 체크인하지 않은 실행을 소급 회고(POST /reflection/batch)하도록 모은다.\n아직 결과 미정이라 completionStatus 는 null.",
+        "operationId": "list_pending_reflections_reflection_pending_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/ReflectionPendingItem"
+                  },
+                  "title": "Response List Pending Reflections Reflection Pending Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Pending Reflections",
         "tags": [
           "reflection"
         ]

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -48,6 +48,7 @@ import type {
   RecoveryGenerateRequest,
   RecoveryProposalsResponse,
   ReflectionBatchRequest,
+  ReflectionBatchResponse,
   ReflectionPendingItem,
   ReplanApproveResponse,
   ReplanDiff,
@@ -429,13 +430,14 @@ export const reviewsApi = {
     }),
 };
 
-// ── Reflection (S17·S18) — failure-tags 는 백엔드 #17 구현됨 ────
+// ── Reflection (S17·S18) — failure-tags(#17)·pending(#83)·batch 모두 백엔드 구현됨 ──
 export const reflectionApi = {
-  // /reflection/pending·batch 는 아직 백엔드 미구현(추정 contract).
+  // 최근 3일 미체크(in_progress) 실행 목록 — 저녁 소급 회고 대상 (#83).
   pending: () => request<ReflectionPendingItem[]>('/reflection/pending'),
 
+  // [모두 완료] 일괄 처리. 빈 items 는 no-op(200, processedCount=0), 상한 50건.
   batch: (body: ReflectionBatchRequest, idempotencyKey: string) =>
-    request<void>('/reflection/batch', { method: 'POST', body, idempotencyKey }),
+    request<ReflectionBatchResponse>('/reflection/batch', { method: 'POST', body, idempotencyKey }),
 
   // 실패 태그 마스터 카탈로그 (#17)
   failureTags: () => request<FailureTagMaster[]>('/reflection/failure-tags'),

--- a/src/screens/EveningCheckInScreen.tsx
+++ b/src/screens/EveningCheckInScreen.tsx
@@ -1,9 +1,28 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { CheckCircle } from '@phosphor-icons/react';
 import { DemoNotice } from '../components/DemoNotice';
+import { reflectionApi } from '../lib/api';
+import type { ReflectionPendingItem } from '../types/api';
 
 interface EveningCheckInScreenProps {
   onDone: () => void;
+}
+
+// 백엔드 미동작/오류 시 보여줄 더미 — 화면이 비어 깨지지 않도록 fallback.
+const FALLBACK_PENDING: ReflectionPendingItem[] = [
+  { executionId: 'demo-1', actionItemId: 'demo-a1', title: 'GROUP BY / HAVING 실습', scheduledDate: '2026-07-07', scheduledTime: '21:00', completionStatus: null },
+  { executionId: 'demo-2', actionItemId: 'demo-a2', title: '알고리즘 문제 2개', scheduledDate: '2026-07-06', scheduledTime: '14:00', completionStatus: null },
+];
+
+// YYYY-MM-DD → 오늘/어제/그제 상대 라벨 (최근 3일 회고 대상이라 그 범위만 다룬다).
+function relDayLabel(dateStr: string): string {
+  const today = new Date();
+  const d = new Date(`${dateStr}T00:00:00`);
+  const diff = Math.round((today.setHours(0, 0, 0, 0) - d.setHours(0, 0, 0, 0)) / 86400000);
+  if (diff <= 0) return '오늘';
+  if (diff === 1) return '어제';
+  if (diff === 2) return '그제';
+  return dateStr.slice(5);
 }
 
 const energyOptions = [
@@ -18,9 +37,27 @@ export function EveningCheckInScreen({ onDone }: EveningCheckInScreenProps) {
   const [step, setStep] = useState(0);
   const [energy, setEnergy] = useState<number | null>(null);
 
-  // /reflection/batch 는 백엔드 501 이고, 이 화면은 애초에 executionId·completionStatus
-  // 없이 에너지 1종만 모아 그 계약에도 안 맞는다 — 빈 items 로 찌르는 no-op 호출은
-  // 제거하고, 데모 범위에서 명시적으로 제외한다(#82). 서버 저장 없이 로컬로만 흐름 유지.
+  // GET /reflection/pending (#83) 은 백엔드 구현됨 — 최근 3일 미체크(in_progress) 실행을
+  // 실데이터로 보여준다. 실패/미동작 시에만 더미로 fallback 하고 DemoNotice 를 띄운다.
+  // /reflection/batch 저장은 이 화면이 에너지 1종만 모아 계약(executionId·completionStatus)에
+  // 안 맞아 아직 로컬 흐름만 유지한다(#82).
+  const [pending, setPending] = useState<ReflectionPendingItem[]>(FALLBACK_PENDING);
+  const [usingRealPending, setUsingRealPending] = useState(false);
+  const [pendingLoading, setPendingLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    reflectionApi.pending().then(
+      (items) => {
+        if (cancelled) return;
+        // fetch 성공 = 연동됨. 비어있어도 실데이터로 처리 — 더미로 가리지 않는다.
+        setUsingRealPending(true);
+        setPending(items);
+      },
+      () => { /* 네트워크/미동작 — 더미 그대로, usingRealPending=false */ },
+    ).finally(() => { if (!cancelled) setPendingLoading(false); });
+    return () => { cancelled = true; };
+  }, []);
 
   if (step === 2) {
     const selectedEnergy = energyOptions.find((e) => e.v === energy);
@@ -36,7 +73,7 @@ export function EveningCheckInScreen({ onDone }: EveningCheckInScreenProps) {
         </div>
         <div style={{ width: '100%' }}>
           <DemoNotice storageKey="evening-batch">
-            저녁 회고 일괄 저장 기능은 아직 서버에서 준비 중이에요. 입력은 임시 저장돼요.
+            이 데모에서는 에너지 기록이 임시 저장돼요. 실행별 소급 회고(일괄 저장)는 곧 연결됩니다.
           </DemoNotice>
         </div>
         <button onClick={onDone} style={{ width: '100%', height: 44, borderRadius: 12, border: 'none', background: 'var(--text-1)', color: '#FAF6EE', fontWeight: 700, fontSize: 14, fontFamily: 'inherit', cursor: 'pointer' }}>주간 계획 보기 →</button>
@@ -82,6 +119,39 @@ export function EveningCheckInScreen({ onDone }: EveningCheckInScreenProps) {
       <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--text-3)', fontFamily: 'var(--font-mono)' }}>저녁 체크인 · 1/2</div>
       <h2 style={{ fontSize: 22, fontWeight: 700, letterSpacing: '-0.02em', margin: '0 0 4px' }}>오늘 하루 어땠나요?</h2>
       <p style={{ fontSize: 13, color: 'var(--text-2)' }}>에너지 상태를 기록하면 내일 계획에 반영해요.</p>
+
+      {/* 최근 3일 미체크(in_progress) 실행 — GET /reflection/pending 실연동 (#83) */}
+      {!(usingRealPending && pending.length === 0) && (
+        <div style={{ background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', borderRadius: 14, padding: 14, display: 'flex', flexDirection: 'column', gap: 10 }}>
+          <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between' }}>
+            <div style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-3)' }}>아직 체크인하지 않은 실행</div>
+            {!pendingLoading && (
+              <span className="tnum" style={{ fontSize: 11, fontFamily: 'var(--font-mono)', color: 'var(--text-3)' }}>{pending.length}건</span>
+            )}
+          </div>
+          {pendingLoading ? (
+            <div style={{ fontSize: 12, color: 'var(--text-3)' }}>불러오는 중…</div>
+          ) : (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+              {pending.map((p) => (
+                <div key={p.executionId} style={{ display: 'flex', gap: 10, alignItems: 'center' }}>
+                  <span style={{ height: 'var(--ctrl-xs)', minWidth: 34, padding: '0 7px', background: 'var(--sand-100)', border: '1px solid var(--sand-200)', borderRadius: 9999, fontSize: 10, color: 'var(--text-2)', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>{relDayLabel(p.scheduledDate)}</span>
+                  <div style={{ flex: 1, fontSize: 13, fontWeight: 500, color: 'var(--text-1)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{p.title}</div>
+                  {p.scheduledTime && (
+                    <div className="tnum" style={{ fontSize: 10, fontFamily: 'var(--font-mono)', color: 'var(--text-3)', flexShrink: 0 }}>{p.scheduledTime.slice(0, 5)}</div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+          {!pendingLoading && !usingRealPending && (
+            <DemoNotice storageKey="evening-pending">
+              미체크 실행 목록은 아직 불러오지 못했어요. 예시 데이터를 보여드리고 있어요.
+            </DemoNotice>
+          )}
+        </div>
+      )}
+
       <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
         {energyOptions.map((e) => (
           <button key={e.v} onClick={() => setEnergy(e.v)} style={{ padding: '14px 16px', borderRadius: 12, textAlign: 'left', background: energy === e.v ? 'var(--text-1)' : 'var(--surface-raised)', color: energy === e.v ? '#FAF6EE' : 'var(--text-1)', border: `1px solid ${energy === e.v ? 'var(--text-1)' : 'var(--sand-200)'}`, fontSize: 14, fontWeight: 500, cursor: 'pointer', fontFamily: 'inherit', transition: 'all 160ms', display: 'flex', alignItems: 'center', gap: 12 }}>

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -425,22 +425,37 @@ export interface FailureTagResponse {
   hasMemo: boolean;
 }
 
+// GET /reflection/pending (#83) — 최근 3일 미체크(in_progress) 실행 row.
+// 아직 결과 미정이라 completionStatus 는 null.
 export interface ReflectionPendingItem {
   executionId: string;
   actionItemId: string;
   title: string;
-  scheduledDate: string; // YYYY-MM-DD
+  scheduledDate: string; // YYYY-MM-DD (date)
   scheduledTime: string | null;
   completionStatus: CompletionStatus | null;
 }
 
+// POST /reflection/batch 항목 — 미체크 실행 1건의 최종 결과 + 선택적 실패 사유.
+// failureTags/memo 는 completionStatus 가 failed/partial_done 일 때만 유효(그 외면 422).
+// memo 는 서버가 at-rest 암호화한다. failureTags 최대 2개, memo 최대 300자.
+export interface ReflectionBatchItem {
+  executionId: string;
+  completionStatus: CompletionStatus;
+  failureTags?: FailureTagCode[]; // 최대 2
+  memo?: string | null; // 최대 300자, 서버 암호화
+}
+
+// POST /reflection/batch — [모두 완료] 일괄 처리. Idempotency-Key 필수. 상한 50건.
 export interface ReflectionBatchRequest {
-  items: Array<{
-    executionId: string;
-    completionStatus: CompletionStatus;
-    failureTags?: FailureTagCode[];
-    memoEncrypted?: string;
-  }>;
+  items: ReflectionBatchItem[];
+}
+
+// POST /reflection/batch 응답 — 일괄 처리 결과 요약.
+export interface ReflectionBatchResponse {
+  processedCount: number;
+  taggedCount: number;
+  needsFailureTags: string[]; // 추가 실패태그 입력이 필요한 executionId 목록
 }
 
 // ── Recovery / Replan (S19·S20) ───────────────────────────────

--- a/src/types/openapi.d.ts
+++ b/src/types/openapi.d.ts
@@ -847,7 +847,7 @@ export interface paths {
         };
         /**
          * Get Current Policy
-         * @description 현재 활성 PolicySnapshot.
+         * @description 현재 활성 PolicySnapshot (#83) — 없으면 404 (FE 는 카운트-only 폴백 유지).
          */
         get: operations["get_current_policy_policy_snapshot_current_get"];
         put?: never;
@@ -942,7 +942,13 @@ export interface paths {
         put?: never;
         /**
          * Batch Reflect
-         * @description 오늘+어제+그제 미체크 카드 일괄 처리. Idempotency-Key 헤더 필수.
+         * @description 저녁 회고 일괄 처리 (S17) — 오늘+어제+그제 미체크 카드를 한 번에 종결.
+         *
+         *     각 항목 = 미체크(in_progress) 실행 1건의 최종 결과(4칩) + 선택적 실패 사유(0~2개).
+         *     check-in(`POST /today/check-ins`)과 동일한 전이(execution 종결 + 블록 finished
+         *     + action_item.status)를 재현하고, failed/partial_done 항목엔 실패 사유를 함께 기록한다.
+         *     **전량 사전 검증 후 한 트랜잭션으로 적용** — 하나라도 무효면 전체 롤백(부분 적용 없음).
+         *     Idempotency-Key 는 미들웨어가 강제([모두 완료] 중복 탭 방지). 빈 배열은 no-op.
          */
         post: operations["batch_reflect_reflection_batch_post"];
         delete?: never;
@@ -987,6 +993,29 @@ export interface paths {
          *     이 태그가 Recovery 룰 엔진(§12)의 `primary_trigger_tags` 매칭 입력이 된다.
          */
         post: operations["tag_failure_reasons_reflection_failure_tags__execution_id__post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/reflection/pending": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Pending Reflections
+         * @description S17 저녁 회고 — 최근 3일(오늘+어제+그제) 미체크(in_progress) 실행 목록 (#83).
+         *
+         *     시작만 하고 체크인하지 않은 실행을 소급 회고(POST /reflection/batch)하도록 모은다.
+         *     아직 결과 미정이라 completionStatus 는 null.
+         */
+        get: operations["list_pending_reflections_reflection_pending_get"];
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -2499,6 +2528,42 @@ export interface components {
             suggestedNextScreen: string;
         };
         /**
+         * PolicySnapshotResponse
+         * @description GET /policy-snapshot/current — 현재 활성 PolicySnapshot (#83).
+         *
+         *     활성 스냅샷이 없으면 라우트가 404(POLICY_NOT_FOUND) 를 낸다 — FE 는 카운트-only
+         *     폴백을 유지한다.
+         */
+        PolicySnapshotResponse: {
+            /** Behavioralprofile */
+            behavioralProfile: {
+                [key: string]: unknown;
+            };
+            /** Executionconstraints */
+            executionConstraints: {
+                [key: string]: unknown;
+            };
+            /** Interactionstyle */
+            interactionStyle: {
+                [key: string]: unknown;
+            };
+            /** Reasonforupdate */
+            reasonForUpdate: string | null;
+            /** Recoverypolicy */
+            recoveryPolicy: {
+                [key: string]: unknown;
+            };
+            /** Source */
+            source: string;
+            /**
+             * Validfrom
+             * Format: date-time
+             */
+            validFrom: string;
+            /** Version */
+            version: number;
+        };
+        /**
          * PolicyViolation
          * @description 정책 위반으로 제외된 노드 + 사유 (cap / 충돌 등).
          */
@@ -2657,6 +2722,73 @@ export interface components {
              * @default true
              */
             isDraft: boolean;
+        };
+        /**
+         * ReflectionBatchItem
+         * @description POST /reflection/batch 항목 — 미체크 실행 1건의 최종 결과 + 선택적 실패 사유.
+         *
+         *     `failure_tags`/`memo` 는 `completion_status` 가 failed/partial_done 일 때만 유효
+         *     (그 외 값과 함께 오면 422). `memo` 는 서버가 at-rest 암호화한다.
+         */
+        ReflectionBatchItem: {
+            /**
+             * Completionstatus
+             * @enum {string}
+             */
+            completionStatus: "done" | "partial_done" | "failed" | "over_done";
+            /** Executionid */
+            executionId: string;
+            /** Failuretags */
+            failureTags?: string[];
+            /** Memo */
+            memo?: string | null;
+        };
+        /**
+         * ReflectionBatchRequest
+         * @description POST /reflection/batch — [모두 완료] 일괄 처리. Idempotency-Key 필수(미들웨어).
+         *
+         *     빈 배열은 no-op(200, processedCount=0). 상한 50건.
+         */
+        ReflectionBatchRequest: {
+            /** Items */
+            items?: components["schemas"]["ReflectionBatchItem"][];
+        };
+        /**
+         * ReflectionBatchResponse
+         * @description 일괄 처리 결과 요약.
+         */
+        ReflectionBatchResponse: {
+            /** Needsfailuretags */
+            needsFailureTags: string[];
+            /** Processedcount */
+            processedCount: number;
+            /** Taggedcount */
+            taggedCount: number;
+        };
+        /**
+         * ReflectionPendingItem
+         * @description GET /reflection/pending 응답 row — S17 저녁 회고에서 처리할 미체크 실행 (#83).
+         *
+         *     최근 3일(오늘+어제+그제) 중 아직 체크인되지 않은(in_progress) 실행. 사용자가
+         *     저녁에 소급 체크인/일괄 회고(POST /reflection/batch)할 대상이다. 아직 결과가
+         *     정해지지 않았으므로 completion_status 는 null.
+         */
+        ReflectionPendingItem: {
+            /** Actionitemid */
+            actionItemId: string;
+            /** Completionstatus */
+            completionStatus: string | null;
+            /** Executionid */
+            executionId: string;
+            /**
+             * Scheduleddate
+             * Format: date
+             */
+            scheduledDate: string;
+            /** Scheduledtime */
+            scheduledTime: string | null;
+            /** Title */
+            title: string;
         };
         /**
          * RefreshRequest
@@ -4686,6 +4818,15 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PolicySnapshotResponse"];
+                };
+            };
             /** @description Validation Error */
             422: {
                 headers: {
@@ -4693,15 +4834,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-            /** @description Successful Response */
-            501: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
                 };
             };
         };
@@ -4851,8 +4983,21 @@ export interface operations {
             path?: never;
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ReflectionBatchRequest"];
+            };
+        };
         responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ReflectionBatchResponse"];
+                };
+            };
             /** @description Validation Error */
             422: {
                 headers: {
@@ -4860,15 +5005,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-            /** @description Successful Response */
-            501: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
                 };
             };
         };
@@ -4928,6 +5064,37 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["FailureTagResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_pending_reflections_reflection_pending_get: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ReflectionPendingItem"][];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
백엔드(reaction-backend) OpenAPI 재덤프 기반 정기 동기화입니다.

## (a) 신규/변경 엔드포인트
- **신규 `GET /reflection/pending` (#83)** — 최근 3일(오늘·어제·그제) 미체크(in_progress) 실행 목록. 이전엔 백엔드 미구현(WARN)이었으나 이제 구현됨(OK).
- **`POST /reflection/batch` 스키마 확정** — 이전 프론트 추정 타입이 실제 스키마와 달라 교정:
  - `ReflectionBatchItem.memoEncrypted` → `memo` (서버가 at-rest 암호화, 최대 300자)
  - `failureTags` 최대 2개 명시
  - 응답 `void` → `ReflectionBatchResponse`(`processedCount`/`taggedCount`/`needsFailureTags`) 추가
- `openapi.json` 재덤프 + `src/types/openapi.d.ts` 재생성.

## (b) 화면 실연동
- **EveningCheckInScreen (S17 저녁 체크인)** — 1단계에 "아직 체크인하지 않은 실행" 패널을 추가하고 `reflectionApi.pending()` 실데이터로 연동했습니다.
  - mock-and-replace 패턴 유지: 응답 성공 시 실데이터(빈 목록 포함)로 표시, 네트워크/미동작 시 더미로 fallback 하여 화면이 깨지지 않습니다.
  - 실데이터가 들어오면 `DemoNotice`를 숨기고, fallback 일 때만 표시합니다.
  - 완료 단계 안내 문구도 batch 구현 상태에 맞게 정정("서버 준비 중" → "데모에서 임시 저장").
- 참고: `/reflection/batch` 저장 자체는 이 화면이 에너지 1종만 수집해 계약(executionId·completionStatus)과 맞지 않아 로컬 흐름만 유지했습니다.

## (c) check:api 요약
```
✅ OK   72  (백엔드 구현됨, 메서드 일치)
⚠️  WARN 0
❌ GONE 0
🆕 NEW  6  (approve-insert, sync-preview, PATCH /habits/{}, /health, /inbox, /policy-snapshot/current)
결과: PASS
```

## 검증 게이트
- `npm run check:api` — GONE 0 ✅
- `npx tsc --noEmit` — 통과 ✅
- `npm run build` — 통과 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NTGLmCFXrcdA5c4x5KyDpo

---
_Generated by [Claude Code](https://claude.ai/code/session_01NTGLmCFXrcdA5c4x5KyDpo)_