### PR TITLE
fix(dates): 주차 계산의 toISOString(UTC) → 로컬 날짜로

### DIFF
--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -1,0 +1,10 @@
+// 로컬(KST) 기준 YYYY-MM-DD 문자열.
+//
+// ⚠️ new Date() 는 로컬 시각인데 .toISOString() 은 UTC 로 변환하므로, KST(=UTC+9)
+// 00:00~08:59 에는 날짜가 하루 밀린다. 그 결과 "그 주 월요일"이 "전날(일요일)"로
+// 전송돼 주간 계획/리뷰/습관 조회가 한 주씩 어긋난다(#92). 주차·날짜 계산에는
+// 절대 toISOString().slice(0,10) 을 쓰지 말고 이 헬퍼를 쓸 것.
+export function localDateStr(d: Date): string {
+  const p = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`;
+}

--- a/src/screens/MorningBriefScreen.tsx
+++ b/src/screens/MorningBriefScreen.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { ArrowCounterClockwise, ArrowRight, Sparkle } from '@phosphor-icons/react';
 import { useNavigation } from '../contexts/NavigationContext';
 import { goalsApi, reviewsApi, todayApi } from '../lib/api';
+import { localDateStr } from '../lib/dates';
 import type { AgendaCard } from '../types/api';
 
 interface MorningBriefScreenProps {
@@ -33,7 +34,7 @@ function thisMonday(): string {
   const diff = day === 0 ? -6 : 1 - day;
   const d = new Date(now);
   d.setDate(now.getDate() + diff);
-  return d.toISOString().slice(0, 10);
+  return localDateStr(d);
 }
 
 // /today/agenda 의 AgendaCard → 브리프 블록. AgendaCard 에는 예약시각·이월 필드가 없다.

--- a/src/screens/TodayScreen.tsx
+++ b/src/screens/TodayScreen.tsx
@@ -11,6 +11,7 @@ import type { AgendaCard } from '../types/api';
 import { FAIL_REASONS } from '../data';
 import { useNavigation } from '../contexts/NavigationContext';
 import { habitsApi, reflectionApi, todayApi } from '../lib/api';
+import { localDateStr } from '../lib/dates';
 import { DemoNotice } from '../components/DemoNotice';
 import { Gear, Target, DotsThreeVertical } from '@phosphor-icons/react';
 
@@ -139,7 +140,7 @@ function thisMonday(): string {
   const diff = day === 0 ? -6 : 1 - day;
   const d = new Date(now);
   d.setDate(now.getDate() + diff);
-  return d.toISOString().slice(0, 10);
+  return localDateStr(d);
 }
 
 // 백엔드 AgendaCard.status(string) → 화면 Task.status. 'pending' 은 'todo' 로,

--- a/src/screens/WeeklyCalendarScreen.tsx
+++ b/src/screens/WeeklyCalendarScreen.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { Plus } from '@phosphor-icons/react';
 import { DAYS_KO, DEFAULT_GOAL_CATEGORY, goalColor } from '../data';
 import { ApiError, plansApi } from '../lib/api';
+import { localDateStr } from '../lib/dates';
 import { DemoNotice } from '../components/DemoNotice';
 import { Segmented } from '../components/Segmented';
 import { BlockEditSheet } from '../components/BlockEditSheet';
@@ -59,7 +60,7 @@ export function WeeklyCalendarScreenV2() {
     const d = new Date();
     const today = (d.getDay() + 6) % 7;
     d.setDate(d.getDate() - today + weekOffset * 7);
-    return d.toISOString().slice(0, 10);
+    return localDateStr(d);
   })();
 
 

--- a/src/screens/WeeklyReviewScreen.tsx
+++ b/src/screens/WeeklyReviewScreen.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Sparkle, ArrowRight } from '@phosphor-icons/react';
 import { reviewsApi } from '../lib/api';
+import { localDateStr } from '../lib/dates';
 import { DemoNotice } from '../components/DemoNotice';
 import { useNavigation } from '../contexts/NavigationContext';
 import type { WeeklyReviewResponse } from '../types/api';
@@ -12,7 +13,7 @@ function thisMonday(): string {
   const diff = day === 0 ? -6 : 1 - day;
   const d = new Date(now);
   d.setDate(now.getDate() + diff);
-  return d.toISOString().slice(0, 10);
+  return localDateStr(d);
 }
 
 // YYYY-MM-DD → "M.D" (주차 라벨용).
@@ -114,7 +115,7 @@ export function WeeklyReviewScreenV2() {
     const sunday = (() => {
       const d = new Date(`${monday}T00:00:00`);
       d.setDate(d.getDate() + 6);
-      return d.toISOString().slice(0, 10);
+      return localDateStr(d);
     })();
     return `${formatMD(monday)} – ${formatMD(sunday)}`;
   })();


### PR DESCRIPTION
## 배경 (Closes #92)

**00:00~09:00 KST 사이에만** 주간 계획/리뷰의 주차가 통째로 한 주씩 어긋나던 P0 버그. "이번 주" 탭이 텅 비고, "다음 주" 탭에 이번 주 시간표가 표시됨. 오전 9시가 지나면 저절로 정상 → 심야 데모에서 치명적.

## 원인

`new Date()`(로컬 KST)로 그 주 월요일을 계산한 뒤 `.toISOString()`(UTC 변환)으로 문자열화. KST=UTC+9라 00:00~08:59 KST는 UTC로 전날 → "월요일"이 "일요일"로 전송되고, 백엔드가 계약대로 "그 주 월요일"로 정규화하며 한 주 전체가 뒤로 밀림. (백엔드는 정상 동작)

## 변경 사항

- `src/lib/dates.ts` 신설: `localDateStr(d)` — 로컬 연/월/일로 `YYYY-MM-DD` 조립(UTC 변환 없음).
- 같은 패턴 **5곳** 교체:
  - `WeeklyCalendarScreen.tsx` `weekStartStr` (주범, `/plans/weekly`)
  - `WeeklyReviewScreen.tsx` `thisMonday()` + 주차 라벨 sunday 계산
  - `TodayScreen.tsx` 습관 주차 (`/habit-instances?weekStart=`)
  - `MorningBriefScreen.tsx` 주간 진행률

## 검증

- `TZ=Asia/Seoul`, 2026-07-06 01:22 KST 기준: 버그 로직 → `2026-07-05`(일, 한 주 밀림), 수정 로직 → `2026-07-06`(월, 정상).
- `npx tsc --noEmit` 클린 / `check-api-contract` PASS / `npm run build` 성공.

🤖 Generated with [Claude Code](https://claude.com/claude-code)