### PR TITLE
fix(ux): 앱 전체 사용자 점검 P0 6건 (거짓정보/중복배너/백지/자정스크롤)

### DIFF
--- a/src/app/ReActionMerged.tsx
+++ b/src/app/ReActionMerged.tsx
@@ -242,7 +242,9 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
             onAgendaLoaded={setTasks}
           />
         )}
-        {screen === 'focus' && activeTask && (
+        {screen === 'focus' && (
+          // activeTask 가 없어도(완료/상태 race) 백지 대신 FocusScreen 내부의
+          // "시작할 카드가 없어요" 안내가 뜨도록 항상 렌더한다(task=null 허용).
           <FocusScreen
             task={activeTask}
             elapsedMin={0} totalMin={45}

--- a/src/screens/TodayScreen.tsx
+++ b/src/screens/TodayScreen.tsx
@@ -232,8 +232,6 @@ export function MergedTodayScreen({ tasks, onOpen, onMarkDone, onPartial, onFail
   const [habits, setHabits] = useState<Habit[]>([]);
   const [addingHabit, setAddingHabit] = useState(false);
   const [newHabitName, setNewHabitName] = useState('');
-  // /habits 가 성공했는지 — true 면 습관 목록이 실데이터(비어있어도)라 더미로 가리지 않는다.
-  const [usingRealHabits, setUsingRealHabits] = useState(false);
   // 초기 습관 로드 중 — 더미/실데이터 겹침 대신 스켈레톤.
   const [habitsLoading, setHabitsLoading] = useState(true);
 
@@ -243,7 +241,6 @@ export function MergedTodayScreen({ tasks, onOpen, onMarkDone, onPartial, onFail
       .then(([apiHabits, instances]) => {
         if (cancelled) return;
         // fetch 성공 = 연동됨. 비어있어도 실데이터로 처리 — 더미 습관으로 가리지 않는다.
-        setUsingRealHabits(true);
         const mapped: Habit[] = apiHabits.map((h) => {
           const inst = instances.find((i) => i.habitId === h.habitId);
           return {
@@ -258,11 +255,8 @@ export function MergedTodayScreen({ tasks, onOpen, onMarkDone, onPartial, onFail
       })
       .catch(() => {
         if (cancelled) return;
-        // 백엔드 미동작 — 더미로 fallback (로딩이 끝난 뒤에만 표시되어 flash 없음).
-        setHabits([
-          { id: 'h1', instanceId: null, name: '피트니스 센터 헬스장 가기', targetDays: 3, doneDays: 2 },
-          { id: 'h2', instanceId: null, name: '마음 챙김 명상', targetDays: 3, doneDays: 0 },
-        ]);
+        // 실패 시 더미로 가리지 않고 빈 목록 — 아래 empty-state 안내가 대신 뜬다.
+        setHabits([]);
       })
       .finally(() => { if (!cancelled) setHabitsLoading(false); });
     return () => { cancelled = true; };
@@ -308,7 +302,8 @@ export function MergedTodayScreen({ tasks, onOpen, onMarkDone, onPartial, onFail
   const showToast = (msg: string) => { setToast(msg); setTimeout(() => setToast(null), 2200); };
   const partialTasks = tasks.filter((t) => t.status === 'partial_done' || t.status === 'recovery_pending');
   const doneTasks = tasks.filter((t) => t.status === 'done');
-  const allDone = doneTasks.length === tasks.length;
+  // 일정이 0개면 "모두 완료"가 아니다(0===0 이라도) — 없는 걸 다 했다고 하지 않는다.
+  const allDone = tasks.length > 0 && doneTasks.length === tasks.length;
 
   const submitFail = () => {
     if (!failReason || !failSheet) return;
@@ -361,27 +356,22 @@ export function MergedTodayScreen({ tasks, onOpen, onMarkDone, onPartial, onFail
           </div>
         </div>
 
-        {/* 첫 agenda fetch 가 끝나기 전엔 더미→실데이터 깜빡임을 막기 위해 스켈레톤만 노출.
-            배너·hero·task row 는 모두 fetch 결과에 의존하므로 함께 가린다. */}
+        {/* 첫 agenda fetch 가 끝나기 전엔 스켈레톤. 비었으면 배너 하나만(에러 or 안내),
+            일정이 있으면 hero + row. 예전엔 배너 2개 + 빈 hero 가 겹쳐 3중으로 떴다. */}
         {agendaLoading ? (
           <AgendaSkeleton />
+        ) : tasks.length === 0 ? (
+          !usingRealAgenda ? (
+            <DemoNotice storageKey="today-agenda">
+              오늘 일정을 서버에서 불러오지 못했어요. 네트워크 상태를 확인하고 다시 시도해 주세요.
+            </DemoNotice>
+          ) : (
+            <div style={{ padding: '10px 12px', borderRadius: 12, background: 'var(--surface-raised)', border: '1px dashed var(--sand-200)', fontSize: 12, color: 'var(--text-2)', lineHeight: 1.5 }}>
+              오늘 등록된 일정이 없어요. 주간 계획에서 일정을 추가하면 여기에 표시돼요.
+            </div>
+          )
         ) : (
           <>
-            {!usingRealAgenda ? (
-              <DemoNotice storageKey="today-agenda">
-                오늘 일정을 서버에서 불러오지 못했어요.
-              </DemoNotice>
-            ) : tasks.length === 0 ? (
-              <div style={{ padding: '10px 12px', borderRadius: 12, background: 'var(--surface-raised)', border: '1px dashed var(--sand-200)', fontSize: 12, color: 'var(--text-2)', lineHeight: 1.5 }}>
-                오늘 등록된 일정이 없어요. 주간 계획에서 일정을 추가하면 여기에 표시돼요.
-              </div>
-            ) : null}
-            {!usingRealAgenda && tasks.length === 0 && (
-              <div style={{ padding: '10px 12px', borderRadius: 12, background: 'var(--surface-raised)', border: '1px dashed var(--sand-200)', fontSize: 12, color: 'var(--text-2)', lineHeight: 1.5 }}>
-                표시할 일정이 없어요. 네트워크 상태를 확인하고 다시 시도해 주세요.
-              </div>
-            )}
-
             {/* Hero — 지금 할 일. row 에서 promote 한 카드 또는 진행 중 카드. */}
             <HeroTaskCard
               task={heroTask}
@@ -424,7 +414,7 @@ export function MergedTodayScreen({ tasks, onOpen, onMarkDone, onPartial, onFail
             {habitsLoading && [0, 1].map((i) => (
               <div key={`hsk${i}`} style={{ height: 52, borderRadius: 14, background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', opacity: 0.6 }} aria-hidden="true" />
             ))}
-            {!habitsLoading && usingRealHabits && habits.length === 0 && !addingHabit && (
+            {!habitsLoading && habits.length === 0 && !addingHabit && (
               <div style={{ padding: '12px 14px', borderRadius: 12, background: 'var(--surface-raised)', border: '1px dashed var(--sand-200)', fontSize: 12, color: 'var(--text-2)', lineHeight: 1.5 }}>
                 아직 추적 중인 습관이 없어요. 위 <b>+ 습관 추가</b>로 만들어보세요.
               </div>

--- a/src/screens/WeeklyCalendarScreen.tsx
+++ b/src/screens/WeeklyCalendarScreen.tsx
@@ -143,6 +143,16 @@ export function WeeklyCalendarScreenV2() {
   const toY = (m: number) => (m - START_H * 60) * HOUR_PX / 60;
   const hours = Array.from({ length: END_H - START_H }, (_, i) => START_H + i);
 
+  // 그리드가 0시(자정)부터라 그냥 두면 새벽 빈 칸부터 보인다 — 로드 후 유용한
+  // 시간대로 스크롤을 맞춘다: 이번 주면 현재 시각, 아니면 오전 8시(6~20시로 클램프).
+  useEffect(() => {
+    if (planLoading) return;
+    const el = gridRef.current;
+    if (!el) return;
+    const targetH = isThisWeek ? Math.min(Math.max(_now.getHours(), 6), 20) : 8;
+    el.scrollTop = Math.max(0, toY(targetH * 60) - 8);
+  }, [planLoading, isThisWeek, weekStartStr]);
+
   const blockStyle = (b: BlockWithStatus) => {
     if (b.status === 'done')   return { bg: '#E5EFE3', bd: '#b4dfc8', fg: 'var(--success)' };
     if (b.status === 'failed') return { bg: '#FAE2D8', bd: 'var(--coral-200)', fg: 'var(--danger)' };
@@ -353,7 +363,7 @@ export function WeeklyCalendarScreenV2() {
             </DemoNotice>
           </div>
         )}
-        {!planLoading && blocks.length === 0 && (
+        {!planLoading && usingRealPlan && blocks.length === 0 && (
           <div style={{ marginBottom: 8, padding: '10px 12px', borderRadius: 12, background: 'var(--surface-raised)', border: '1px dashed var(--sand-200)', fontSize: 12, color: 'var(--text-2)', lineHeight: 1.5 }}>
             이번 주에 등록된 계획이 없어요. 온보딩에서 주간 계획을 생성하거나, 우측 하단 + 버튼으로 추가해보세요.
           </div>

--- a/src/screens/WeeklyPlanGenerationScreen.tsx
+++ b/src/screens/WeeklyPlanGenerationScreen.tsx
@@ -105,6 +105,17 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
   const toY = (m: number) => (m - START_H * 60) * HOUR_PX / 60;
   const hours = Array.from({ length: END_H - START_H }, (_, i) => START_H + i);
 
+  // 그리드가 0시(자정)부터라 그냥 두면 새벽 빈 칸부터 보인다 — 생성이 끝나면
+  // 가장 이른 블록(없으면 오전 8시) 근처로 스크롤을 맞춘다.
+  const gridRef = React.useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (generating) return;
+    const el = gridRef.current;
+    if (!el) return;
+    const earliest = blocks.length ? Math.min(...blocks.map((b) => parseMin(b.time))) : 8 * 60;
+    el.scrollTop = Math.max(0, toY(Math.max(earliest, 6 * 60)) - 8);
+  }, [generating, blocks.length]);
+
   // 이번 주 월요일부터 7일치 일자 숫자 — 주간 캘린더와 동일하게 요일 아래 날짜를 보여준다.
   const TODAY = (new Date().getDay() + 6) % 7;
   const dayNumbers = (() => {
@@ -186,7 +197,7 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
       </div>
 
       {/* Calendar grid */}
-      <div style={{ flex: 1, overflowY: 'auto' }}>
+      <div ref={gridRef} style={{ flex: 1, overflowY: 'auto' }}>
         <div style={{ display: 'flex', minWidth: TIME_W + COL_W * 7 }}>
           <div style={{ width: TIME_W, flexShrink: 0, background: 'var(--surface-ground)' }}>
             {hours.map((h) => (


### PR DESCRIPTION
## 배경

실사용 관점으로 온보딩~메인 16개 화면을 전부 구동해 점검한 결과 나온 명백한 결함(대부분 최근 목업 제거·24h 변경의 회귀 + 거짓정보) 정리. 우선순위는 `(심각도×빈도 + 정직성위반) / 공수`로 산정한 P0 6건.

## 변경 사항

1. **Today 습관 더미 잔존** → 실패 시 빈 목록 + "아직 추적 중인 습관이 없어요" 안내 (피트니스/명상 가짜 제거).
2. **Today "오늘 모두 완료했어요" 거짓 표시** — 일정 0개인데 `0===0`이라 뜨던 것. `allDone`을 `tasks.length > 0` 조건 추가로 수정.
3. **Today 빈 상태 배너 3중 중첩**(DemoNotice + 두번째 배너 + 빈 hero 카드) → 비었으면 배너 하나(에러 or 안내), 일정 있으면 hero+row로 정리.
4. **캘린더 24h 자정 시작 dead-space** — 그리드가 0시부터라 새벽 빈 칸부터 보이던 것 → 로드 후 자동 스크롤(주간 캘린더=현재 시각으로, 온보딩=가장 이른 블록/오전 8시로).
5. **캘린더 빈 상태 배너 2중 중첩** → 연동 성공 & 빈 경우에만 "계획 없음" 안내(에러 배너와 상호배타).
6. **Focus 진입 시 백지** — `activeTask` 없으면 아무것도 안 그려 뒤로가기만 가능하던 것 → 항상 렌더해 내부 "시작할 카드가 없어요" 가드가 뜨도록(부모 `&& activeTask` 제거, `task=null` 허용).

부수: 죽은 상태 `usingRealHabits` 제거.

## 검증

- Playwright로 `today`/`weekly`/`weekly-plan`/`focus` 재점검: 단일 안내, 자동 스크롤(now-line 상단 노출), 습관 정직 empty, Focus 가드 확인. 콘솔 에러 0.
- `npx tsc --noEmit` 클린 / `check-api-contract` PASS / `npm run build` 성공.

## 남은 백로그 (P1/P2, 별도 논의)
- P1: 원시 에러코드 `[AUTH_INVALID_TOKEN]` 노출(6파일·18곳) → 친화 문구 매핑, 설정 "코칭 톤" 선택 표시.
- P2: 회복완료 "0회·방금+1" 모순, 온보딩 빈 계획으로 "이대로 시작" 가드.

🤖 Generated with [Claude Code](https://claude.com/claude-code)