### PR TITLE
fix(weekly-plan): /plans/generate 409(동시 생성) 회복탄력 처리

### DIFF
--- a/src/screens/WeeklyPlanGenerationScreen.tsx
+++ b/src/screens/WeeklyPlanGenerationScreen.tsx
@@ -5,7 +5,7 @@ import { SetupProgress } from '../components/SetupProgress';
 import { AiDraftCard } from '../components/AiDraftCard';
 import { DemoNotice } from '../components/DemoNotice';
 import { BlockEditSheet } from '../components/BlockEditSheet';
-import { plansApi } from '../lib/api';
+import { ApiError, plansApi } from '../lib/api';
 import { useNavigation } from '../contexts/NavigationContext';
 import type { Block } from '../types';
 import type { FirstPlanGenerateRequest, ScheduledBlockPreview } from '../types/api';
@@ -46,6 +46,9 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
   // 라이브 호출을 실제로 시도했으나 실패했는지 — 배너 문구를 정직하게 맞추는 용도.
   const [genFailed, setGenFailed] = useState(false);
   const planIdRef = React.useRef<string | null>(null);
+  // 생성이 이미 진행 중인지 — 자기 자신 중복 발사(effect 재실행/재생성 버튼)로 백엔드
+  // planning advisory lock 에 겹쳐 409 AGENT_CONCURRENT_ACCESS 가 나는 걸 막는다.
+  const inFlightRef = React.useRef(false);
 
   // 온보딩 인터뷰(S02)의 sessionId 를 GoalIntakeScreen 이 NavigationContext 에 올려둔다.
   // sessionId 는 메모리 보관이라 새로고침/재진입 시 사라질 수 있는데(#91), 백엔드
@@ -59,20 +62,41 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
 
   // /plans/generate 실연동 — useCallback 으로 빼서 진입 시 + AiDraftCard 재생성에서 재사용.
   const generatePlan = React.useCallback(() => {
+    if (inFlightRef.current) return; // 이미 생성 중이면 무시 (중복 발사 방지)
+    inFlightRef.current = true;
     setGenerating(true);
     setGenFailed(false);
     const minDelay = new Promise<void>((r) => setTimeout(r, 1400));
-    const fetchPlan: Promise<void> = plansApi.generate(generateInput).then(
-      (plan) => {
-        planIdRef.current = plan.planId;
-        // 200 응답 = 연동 성공. 블록이 0개여도 '예시'가 아니라 '아직 계획 없음'인
-        // 실데이터다 — 더미로 가리지 않고 그대로 반영한다.
-        setBlocks((plan.blocks ?? []).map(previewToBlock));
-        setUsingRealPlan(true);
-      },
-      () => { setGenFailed(true); /* 네트워크/422(완료 인터뷰 없음) — 빈 상태 유지 + 정직 배너 */ },
-    );
-    Promise.all([minDelay, fetchPlan]).finally(() => setGenerating(false));
+
+    // 409 AGENT_CONCURRENT_ACCESS: 같은 유저의 다른 /plans/generate 가 아직 LLM 실행 중이라
+    // planning advisory lock(5s 대기 후 409)을 못 잡은 경우 — 하드 실패로 보지 말고 짧게
+    // 기다렸다 재시도한다(앞 생성이 끝나면 lock 이 풀림). 그 외 오류·재시도 소진 시 genFailed.
+    const attempt = async (): Promise<void> => {
+      for (let i = 0; i < 3; i++) {
+        try {
+          const plan = await plansApi.generate(generateInput);
+          planIdRef.current = plan.planId;
+          // 200 응답 = 연동 성공. 블록이 0개여도 '예시'가 아니라 '아직 계획 없음'인
+          // 실데이터다 — 더미로 가리지 않고 그대로 반영한다.
+          setBlocks((plan.blocks ?? []).map(previewToBlock));
+          setUsingRealPlan(true);
+          return;
+        } catch (err) {
+          const concurrent = err instanceof ApiError && err.status === 409;
+          if (concurrent && i < 2) {
+            await new Promise((r) => setTimeout(r, 3500));
+            continue;
+          }
+          setGenFailed(true); // 네트워크/422(완료 인터뷰 없음)/재시도 소진 — 빈 상태 + 정직 배너
+          return;
+        }
+      }
+    };
+
+    Promise.all([minDelay, attempt()]).finally(() => {
+      inFlightRef.current = false;
+      setGenerating(false);
+    });
   }, [interviewSessionId]);
 
   // 자동 생성은 '유효 입력(interviewSessionId)'별로 딱 한 번만 호출한다.


### PR DESCRIPTION
## 배경

주간 계획 생성에서 간헐적 **409**가 계속 뜬다는 제보. **백엔드 조사 결과 백엔드는 정상 동작**입니다.

`POST /plans/generate`(`api/routes/planning.py:279`)는 First-Plan 생성 전체를 유저 단위 **advisory lock**으로 감쌉니다:

```python
async with user_agent_lock(session, user.id, "planning"):
    # decompose(LLM) → schedule(룰) → review(LLM)  ← LLM 2회, 1~8s 동안 lock 점유
```

- 락은 `pg_advisory_xact_lock` + `lock_timeout 5s`(`orchestrator/_common.py`). 5초 내 미획득 시 **409 `AGENT_CONCURRENT_ACCESS`**.
- 즉 같은 유저의 `/generate`가 겹치고 앞 요청 LLM 실행이 5초를 넘기면 뒤 요청이 409. 백엔드 주석에도 "순간 겹침은 5s 대기로 흡수, 진짜 장기 점유만 409" — **설계대로**(ADR-0005 §7.6), 백엔드 버그 아님.

**겹치는 경로:** 공유 데모 계정(`?demo=stub`) 다중 탭/디바이스 동시 생성, 생성 중 화면 재진입(백엔드는 앞 생성을 계속 붙듦), effect 재발사 엣지.

## FE 회복탄력 처리 (백엔드는 못 고치므로)

- **in-flight 가드**(`inFlightRef`): 화면 자체의 중복 발사를 막아 self-겹침 제거.
- **409면 하드 실패 배너 대신 3.5s 뒤 재시도(최대 2회)** — 앞 생성이 끝나면 lock 이 풀려 성공. `422`(완료 인터뷰 없음)·기타 오류·재시도 소진 시에만 `genFailed` 배너.

ADR-0005 도 "409 + 사용자 재시도 안내"를 의도하므로 이 처리가 계약에 부합합니다.

## 검증

- `npx tsc --noEmit` 클린 / `check-api-contract` PASS / `npm run build` 성공.
- 재시도 루프 시뮬: 409×2→성공(3콜), 409×3→실패, 422→즉시실패(1콜), 성공→1콜.

🤖 Generated with [Claude Code](https://claude.com/claude-code)