### PR TITLE
fix(ux): P2 잔여 — 회복완료 +1 모순, 온보딩 빈 계획 시작 가드

### DIFF
--- a/src/components/AiDraftCard.tsx
+++ b/src/components/AiDraftCard.tsx
@@ -11,6 +11,8 @@ export interface AiDraftCardProps {
   onAccept: () => void;
   onEdit: () => void;
   onReject: () => void;
+  // 수락 비활성화(예: 계획이 비어 "이대로 시작"이 말이 안 될 때). 기본 false.
+  acceptDisabled?: boolean;
   acceptLabel?: string;
   editLabel?: string;
   rejectLabel?: string;
@@ -49,6 +51,7 @@ export function AiDraftCard({
   onAccept,
   onEdit,
   onReject,
+  acceptDisabled = false,
   acceptLabel = '수락',
   editLabel = '수정',
   rejectLabel = '재생성',
@@ -186,6 +189,7 @@ export function AiDraftCard({
         <button
           onClick={onAccept}
           type="button"
+          disabled={acceptDisabled}
           style={{
             flex: 1.4,
             height: 40,
@@ -196,7 +200,8 @@ export function AiDraftCard({
             fontWeight: 700,
             fontSize: 13,
             fontFamily: 'inherit',
-            cursor: 'pointer',
+            cursor: acceptDisabled ? 'not-allowed' : 'pointer',
+            opacity: acceptDisabled ? 0.4 : 1,
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',

--- a/src/screens/RecoveredScreen.tsx
+++ b/src/screens/RecoveredScreen.tsx
@@ -137,7 +137,8 @@ export function RecoveredScreen({ recoveryCount, applied, onDone, executionId }:
         <div style={{ display: 'flex', alignItems: 'baseline', gap: 6 }}>
           <span className="tnum" style={{ fontSize: 44, fontWeight: 800, color: 'var(--brand)', letterSpacing: '-0.03em' }}>{recoveryCount}</span>
           <span style={{ fontSize: 16, color: 'var(--text-2)' }}>회</span>
-          <span style={{ marginLeft: 'auto', fontSize: 12, color: 'var(--success)', fontWeight: 700 }}>방금 +1</span>
+          {/* 실제로 이번에 회복을 수락했을 때(count>0)만 +1 — 0회일 땐 모순이라 숨긴다. */}
+          {recoveryCount > 0 && <span style={{ marginLeft: 'auto', fontSize: 12, color: 'var(--success)', fontWeight: 700 }}>방금 +1</span>}
         </div>
       </div>
 

--- a/src/screens/WeeklyPlanGenerationScreen.tsx
+++ b/src/screens/WeeklyPlanGenerationScreen.tsx
@@ -311,14 +311,21 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
           onAccept={handleContinue}
           onEdit={addBlock}
           onReject={generatePlan}
+          // 블록이 하나도 없으면 "이대로 시작"이 말이 안 되므로 막고, 아래 안내로 유도.
+          acceptDisabled={blocks.length === 0}
           acceptLabel="이대로 시작"
           editLabel="블록 추가"
           rejectLabel="재생성"
         >
           <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+            {blocks.length === 0 && (
+              <span style={{ fontSize: 11, color: 'var(--text-3)' }}>블록을 추가하면 시작할 수 있어요.</span>
+            )}
+            {blocks.length > 0 && (
             <span className="tnum" style={{ height: 'var(--ctrl-xs)', padding: '0 10px', background: 'var(--text-1)', color: '#FAF6EE', borderRadius: 9999, fontSize: 11, fontWeight: 600, display: 'inline-flex', alignItems: 'center', gap: 4 }}>
               <Clock size={11} weight="fill" /> 총 {totalH.toFixed(1)}h
             </span>
+            )}
             {Object.entries(goalCount).map(([g, mins]) => {
               const c = goalColor(g);
               return (


### PR DESCRIPTION
## 변경 사항

전체 사용자 점검 백로그의 P2 2건:

- **RecoveredScreen**: "이번 세션 회복 **0회 · 방금 +1**" 모순 수정 — 실제로 회복을 수락했을 때(`recoveryCount > 0`)만 "방금 +1" 배지 노출.
- **WeeklyPlanGenerationScreen**: 블록 0개인데 **"이대로 시작"이 눌리던 것** — 빈 계획일 때 accept 비활성화(반투명) + "블록을 추가하면 시작할 수 있어요" 안내. `AiDraftCard`에 `acceptDisabled` prop 추가.

> 참고: 백로그의 "설정 코칭 톤 선택 표시"는 **이미 구현돼 있었음**(active 시 brand 테두리 + 체크 아이콘 + 저장 토스트). 앞선 점검 때 force-nav auth 실패로 settings가 안 실려 안 보였던 것뿐이라 별도 작업 없음.

## 검증

- Playwright: 빈 계획 시 "이대로 시작" `disabled=true` 확인 + 안내 문구 렌더.
- `npx tsc --noEmit` 클린 / `check-api-contract` PASS / `npm run build` 성공.

🤖 Generated with [Claude Code](https://claude.com/claude-code)