### PR TITLE
fix(plan): S06 aiSource/warnings 배선 + generate Idempotency-Key (#6·#12 갭)

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -439,8 +439,9 @@ export const todayApi = {
 
 // ── Plans (S06·S14·S15·S16) — generate/get/approve 는 백엔드 #18 구현됨 ──
 export const plansApi = {
-  generate: (body: FirstPlanGenerateRequest = {}) =>
-    request<FirstPlanResponse>('/plans/generate', { method: 'POST', body }),
+  // Idempotency-Key 동봉 시 같은 키 재요청은 동일 planId 를 돌려준다(재시도 안전, #6).
+  generate: (body: FirstPlanGenerateRequest = {}, idempotencyKey?: string) =>
+    request<FirstPlanResponse>('/plans/generate', { method: 'POST', body, idempotencyKey }),
 
   get: (planId: string) => request<FirstPlanResponse>(`/plans/${planId}`),
 

--- a/src/screens/WeeklyPlanGenerationScreen.tsx
+++ b/src/screens/WeeklyPlanGenerationScreen.tsx
@@ -127,6 +127,10 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
   const [usingRealPlan, setUsingRealPlan] = useState(false);
   // 라이브 호출을 실제로 시도했으나 실패했는지 — 배너 문구를 정직하게 맞추는 용도.
   const [genFailed, setGenFailed] = useState(false);
+  // 응답의 aiSource — 'rule' 이면 AiDraftCard 가 "오프라인 모드(룰 기반)" 안내를 띄운다(#12).
+  const [planAiSource, setPlanAiSource] = useState<'llm' | 'rule'>('llm');
+  // 응답의 warnings[] — 스케줄러가 남긴 경고(예: 슬롯 부족) 헤더 표시(#6).
+  const [warnings, setWarnings] = useState<string[]>([]);
   const planIdRef = React.useRef<string | null>(null);
   // 생성이 이미 진행 중인지 — 자기 자신 중복 발사(effect 재실행/재생성 버튼)로 백엔드
   // planning advisory lock 에 겹쳐 409 AGENT_CONCURRENT_ACCESS 가 나는 걸 막는다.
@@ -165,6 +169,10 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
     setGenerating(true);
     setGenFailed(false);
     const minDelay = new Promise<void>((r) => setTimeout(r, 1400));
+    // Idempotency-Key — 이 한 번의 생성(3회 재시도 포함)에 같은 키를 써서, 409 재시도 시
+    // 백엔드가 LLM 을 다시 돌리지 않고 같은 planId 를 돌려주게 한다(#6). 재생성 버튼은
+    // 새 generatePlan 호출이라 새 키가 생겨 새 plan 이 나온다.
+    const key = crypto.randomUUID();
 
     // 409 AGENT_CONCURRENT_ACCESS: 같은 유저의 다른 /plans/generate 가 아직 LLM 실행 중이라
     // planning advisory lock(5s 대기 후 409)을 못 잡은 경우 — 하드 실패로 보지 말고 짧게
@@ -172,11 +180,13 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
     const attempt = async (): Promise<void> => {
       for (let i = 0; i < 3; i++) {
         try {
-          const plan = await plansApi.generate(generateInput);
+          const plan = await plansApi.generate(generateInput, key);
           planIdRef.current = plan.planId;
           // 200 응답 = 연동 성공. 블록이 0개여도 '예시'가 아니라 '아직 계획 없음'인
           // 실데이터다 — 더미로 가리지 않고 그대로 반영한다.
           setBlocks((plan.blocks ?? []).map(previewToBlock));
+          setPlanAiSource(plan.aiSource === 'rule' ? 'rule' : 'llm');
+          setWarnings(plan.warnings ?? []);
           setUsingRealPlan(true);
           return;
         } catch (err) {
@@ -301,6 +311,14 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
             아직 계획 블록이 없어요. 아래 "블록 추가"로 채워보세요.
           </div>
         )}
+        {/* 스케줄러 경고(warnings[]) — 슬롯 부족 등 (#6) */}
+        {warnings.length > 0 && (
+          <div style={{ padding: '8px 12px', borderRadius: 12, background: '#FBEEDA', border: '1px solid #F2D29A', fontSize: 11, color: 'var(--warning)', lineHeight: 1.5 }}>
+            {warnings.map((w, i) => (
+              <div key={i}>· {w}</div>
+            ))}
+          </div>
+        )}
       </div>
 
       {/* Day headers — 주간 캘린더(WeeklyCalendarScreen)와 동일하게 요일 아래 날짜 숫자 +
@@ -372,7 +390,7 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
       <div style={{ flexShrink: 0, padding: '10px 14px', paddingBottom: 'max(14px, env(safe-area-inset-bottom, 14px))', background: 'var(--surface-ground)' }}>
         <AiDraftCard
           isDraft={true}
-          aiSource="llm"
+          aiSource={planAiSource}
           onAccept={handleContinue}
           onEdit={addBlock}
           onReject={generatePlan}


### PR DESCRIPTION
## 배경

에픽 검증(#6·#12)에서 나온 DoD 갭 메우기 ① — S06 관련 값싼 완결:

- #12: AiDraftCard 소비처가 `aiSource="llm"` 하드코딩이라 rule-fallback 안내가 실데이터로 안 뜸.
- #6: `warnings[]` 헤더 미표시, `POST /plans/generate` Idempotency-Key 미전송(DoD 필수).

## 변경 사항

- **aiSource 배선**: 응답 `plan.aiSource` 를 상태로 받아 AiDraftCard 에 전달(하드코딩 제거). 백엔드가 `aiSource:"rule"` 을 주면 카드가 **"오프라인 모드(룰 기반)로 자동 분배됨"** 안내를 실제로 띄운다. (`llmRunId` 는 `FirstPlanResponse` 에 없어 미배선.)
- **warnings 헤더**: 응답 `warnings[]`(슬롯 부족 등 스케줄러 경고)를 헤더에 표시.
- **Idempotency-Key**: `plansApi.generate(body, idempotencyKey)` 로 확장 + 한 번의 생성(3회 재시도 포함)에 같은 키(`crypto.randomUUID()`) 사용 → 409 재시도 시 백엔드가 LLM 재실행 없이 **같은 planId** 반환(#98 재시도와 시너지). 재생성 버튼은 새 키.

## 검증 (Playwright, mock)

- `aiSource:"rule"` → "오프라인 모드" 안내 노출 ✓
- `warnings` 노출 ✓
- 요청에 `Idempotency-Key` 헤더 전송 확인 ✓
- `npx tsc --noEmit` 클린 / `check-api-contract` PASS / `npm run build` 성공.

Refs #6, #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)