### PR TITLE
feat(focus): S13 — 중단 버튼 + sleep 복원 타이머 + over_done (#7)

### DIFF
--- a/src/screens/FocusScreen.tsx
+++ b/src/screens/FocusScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useRef } from 'react';
-import { CaretLeft, Pause, Play, Check } from '@phosphor-icons/react';
+import { CaretLeft, Pause, Play, Check, X } from '@phosphor-icons/react';
 import { Chip } from '../components/Chip';
 import { ReButton } from '../components/ReButton';
 import { todayApi } from '../lib/api';
@@ -23,18 +23,70 @@ export function FocusScreen({ task, elapsedMin, totalMin, onComplete, onBack, on
   // mock-and-replace: 백엔드 /today/* 일부 미구현. 시작/일시정지/완료를 시도하되 실패는 조용히.
   const executionIdRef = useRef<string | null>(null);
 
-  // 열품타식 라이브 타이머 — 진입 시각부터 1초 단위로 카운트업. running 토글로 일시정지/재개.
+  // 타이머 — 순수 setInterval 카운트업은 백그라운드/슬립 시 throttle 되어 시간이 어긋난다.
+  // 대신 "시작 시각(startAt)" 타임스탬프에서 매번 재계산하고, visibilitychange·새로고침
+  // (sessionStorage) 에도 경과를 복원한다(S13 브라우저 sleep 대응).
+  const storeKey = task ? `reaction.focus.${task.id}` : '';
+  const startAtRef = useRef(0);            // epoch ms
+  const pausedMsRef = useRef(0);           // 누적 일시정지 시간(ms)
+  const pauseAtRef = useRef<number | null>(null); // 현재 정지 시작 시각(정지 중일 때만)
   const [elapsedSec, setElapsedSec] = React.useState(Math.max(0, Math.round(elapsedMin * 60)));
   const [running, setRunning] = React.useState(true);
-  const [startLabel] = React.useState(() =>
-    new Date().toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit', hour12: false }),
-  );
+  const [startLabel, setStartLabel] = React.useState('');
 
+  const recompute = React.useCallback(() => {
+    if (!startAtRef.current) return;
+    const now = Date.now();
+    const extra = pauseAtRef.current ? now - pauseAtRef.current : 0;
+    setElapsedSec(Math.max(0, Math.round((now - startAtRef.current - pausedMsRef.current - extra) / 1000)));
+  }, []);
+
+  const persist = () => {
+    if (!storeKey) return;
+    try {
+      sessionStorage.setItem(storeKey, JSON.stringify({ startAt: startAtRef.current, pausedMs: pausedMsRef.current, pauseAt: pauseAtRef.current, running }));
+    } catch { /* ignore */ }
+  };
+
+  // 최초 마운트 — sessionStorage 에 진행 중 세션이 있으면 복원, 없으면 새로 시작.
+  React.useEffect(() => {
+    if (!task) return;
+    let restored = false;
+    try {
+      const saved = sessionStorage.getItem(storeKey);
+      if (saved) {
+        const o = JSON.parse(saved);
+        startAtRef.current = o.startAt;
+        pausedMsRef.current = o.pausedMs ?? 0;
+        pauseAtRef.current = o.pauseAt ?? null;
+        setRunning(o.running ?? true);
+        restored = true;
+      }
+    } catch { /* ignore */ }
+    if (!restored) {
+      startAtRef.current = Date.now();
+      pausedMsRef.current = 0;
+      pauseAtRef.current = null;
+      persist();
+    }
+    setStartLabel(new Date(startAtRef.current).toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit', hour12: false }));
+    recompute();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [task?.id]);
+
+  // 매 초 재계산(타임스탬프 기준). 정지 중엔 멈춘다.
   React.useEffect(() => {
     if (!running) return;
-    const id = setInterval(() => setElapsedSec((s) => s + 1), 1000);
+    const id = setInterval(recompute, 1000);
     return () => clearInterval(id);
-  }, [running]);
+  }, [running, recompute]);
+
+  // 백그라운드 복귀 시 재계산(슬립 드리프트 보정).
+  React.useEffect(() => {
+    const onVis = () => { if (document.visibilityState === 'visible') recompute(); };
+    document.addEventListener('visibilitychange', onVis);
+    return () => document.removeEventListener('visibilitychange', onVis);
+  }, [recompute]);
 
   // 첫 진입 시 시작 호출 (executionId 확보 시도)
   React.useEffect(() => {
@@ -62,27 +114,41 @@ export function FocusScreen({ task, elapsedMin, totalMin, onComplete, onBack, on
     );
   }
 
-  // 일시정지/재개 — 로컬 타이머 토글 + 백엔드 pause/resume(미구현이면 조용히).
+  // 일시정지/재개 — 정지 시간 누적 + 백엔드 pause/resume(미구현이면 조용히).
   const toggleRun = () => {
     const next = !running;
+    if (next) {
+      if (pauseAtRef.current) { pausedMsRef.current += Date.now() - pauseAtRef.current; pauseAtRef.current = null; }
+    } else {
+      pauseAtRef.current = Date.now();
+    }
     setRunning(next);
+    persist();
+    recompute();
     if (executionIdRef.current) {
       (next ? todayApi.resume : todayApi.pause)(executionIdRef.current).catch(() => {});
     }
   };
 
+  const clearSession = () => { if (storeKey) { try { sessionStorage.removeItem(storeKey); } catch { /* ignore */ } } };
+
   const handleComplete = () => {
+    clearSession();
     if (executionIdRef.current) {
-      // 소요 시간(actualDurationMinutes)은 백엔드가 start 시각 기준으로 계산한다.
+      // 목표 시간 초과면 over_done, 아니면 done (소요 시간은 백엔드가 start 시각 기준 계산).
+      const status: 'done' | 'over_done' = elapsedSec > totalMin * 60 ? 'over_done' : 'done';
       todayApi
         .checkIn(
-          { executionId: executionIdRef.current, completionStatus: 'done' },
+          { executionId: executionIdRef.current, completionStatus: status },
           `check-${executionIdRef.current}`,
         )
         .catch(() => {});
     }
     onComplete();
   };
+
+  // 중단 — 기록 없이 오늘로 복귀(세션 정리). 나중에 다시 시작할 수 있다.
+  const handleAbort = () => { clearSession(); onBack(); };
 
   const totalSec = Math.max(1, totalMin * 60);
   const pct = Math.min(elapsedSec / totalSec, 1);
@@ -123,12 +189,15 @@ export function FocusScreen({ task, elapsedMin, totalMin, onComplete, onBack, on
         </svg>
       </div>
 
-      <div style={{ display: 'flex', gap: 10 }}>
+      <div style={{ display: 'flex', gap: 8 }}>
         <ReButton variant="ghost" size="lg" full onClick={toggleRun}>
-          {running ? <><Pause size={18} /> 잠깐 멈춤</> : <><Play size={18} weight="fill" /> 이어서</>}
+          {running ? <><Pause size={16} /> 멈춤</> : <><Play size={16} weight="fill" /> 이어서</>}
+        </ReButton>
+        <ReButton variant="ghost" size="lg" full onClick={handleAbort}>
+          <X size={16} /> 중단
         </ReButton>
         <ReButton variant="primary" size="lg" full onClick={handleComplete}>
-          <Check size={18} /> 완료
+          <Check size={16} /> 완료
         </ReButton>
       </div>
     </div>


### PR DESCRIPTION
## 배경 (Refs #7 S13)

에픽 검증에서 나온 갭: Focus에 중단 버튼이 없고(2버튼), 타이머가 순수 setInterval이라 백그라운드/슬립 시 시간이 어긋나며, `over_done` 상태가 도달 불가였다.

## 변경 사항

- **3버튼**: `멈춤`(일시정지) / `중단`(기록 없이 오늘 복귀, 세션 정리) / `완료`.
- **sleep 대응 타이머**: 시작 타임스탬프(`startAt`)에서 매번 재계산 → 백그라운드 throttle에도 정확. `visibilitychange`로 복귀 시 보정, `sessionStorage`로 새로고침에도 경과 복원. 일시정지 시간은 `pausedMs`로 누적.
- **over_done**: 완료 시 목표 시간 초과면 `completionStatus:'over_done'`, 아니면 `'done'`(기존엔 항상 `done`이라 over_done 도달 불가였음).

## 검증 (Playwright, todo→focus 플로우)

3버튼 + 타이머 렌더 확인. `tsc`/`check-api-contract`(PASS)/`build` 클린.

> 참고: #7 의 S11 Action Detail 모달·S12 Focus Entry 미니 화면은 새 화면이라 별도 범위로 남김. `device_type`/`companion_present` 는 백엔드 요청 스키마에 필드가 없어 보류.

Refs #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)