### PR TITLE
fix(onboarding): 계획 승인 반복 가드 + approve Idempotency-Key (#115)

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -445,8 +445,8 @@ export const plansApi = {
 
   get: (planId: string) => request<FirstPlanResponse>(`/plans/${planId}`),
 
-  approve: (planId: string) =>
-    request<FirstPlanApproveResponse>(`/plans/${planId}/approve`, { method: 'POST', body: {} }),
+  approve: (planId: string, idempotencyKey?: string) =>
+    request<FirstPlanApproveResponse>(`/plans/${planId}/approve`, { method: 'POST', body: {}, idempotencyKey }),
 
   // 주간 보기/블록 수정 — 백엔드 #21 구현됨.
   weekly: (weekStart: string) =>

--- a/src/screens/WeeklyPlanGenerationScreen.tsx
+++ b/src/screens/WeeklyPlanGenerationScreen.tsx
@@ -218,12 +218,19 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
     generatePlan();
   }, [interviewSessionId, generatePlan]);
 
-  // "이대로 시작" 클릭 시 plan approve 시도 (mock-and-replace)
+  // "이대로 시작" 클릭 시 plan approve. 더블클릭/재진입 반복 승인을 막고(#115),
+  // 같은 planId 엔 같은 Idempotency-Key 를 써서 서버가 1회로 처리하게 한다.
+  const approvingRef = React.useRef(false);
+  const [approving, setApproving] = useState(false);
   const handleContinue = () => {
-    if (planIdRef.current) {
-      plansApi.approve(planIdRef.current).catch(() => { /* 501 ok */ });
-    }
-    onContinue();
+    if (approvingRef.current) return; // 승인 진행 중 중복 클릭 무시
+    if (!planIdRef.current) { onContinue(); return; }
+    approvingRef.current = true;
+    setApproving(true);
+    plansApi
+      .approve(planIdRef.current, `approve-${planIdRef.current}`)
+      .catch(() => { /* 501/오류 ok — 온보딩 흐름은 이어간다 */ })
+      .finally(() => { onContinue(); });
   };
 
   // 자정부터 자정까지 24시간 전체를 스크롤로 훑을 수 있어야 한다 — 실제 주간
@@ -395,8 +402,8 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
           onEdit={addBlock}
           onReject={generatePlan}
           // 블록이 하나도 없으면 "이대로 시작"이 말이 안 되므로 막고, 아래 안내로 유도.
-          acceptDisabled={blocks.length === 0}
-          acceptLabel="이대로 시작"
+          acceptDisabled={blocks.length === 0 || approving}
+          acceptLabel={approving ? '시작하는 중…' : '이대로 시작'}
           editLabel="블록 추가"
           rejectLabel="재생성"
         >


### PR DESCRIPTION
## 배경 (Closes #115)

주간 캘린더에 같은 블록이 겹겹이 쌓이는 문제의 FE 기여분. 백엔드가 "승인=교체"로 누적 자체는 막았지만, FE도 불필요한 반복 승인/생성을 줄인다.

## 변경 사항

- **승인 반복 가드**: "이대로 시작"(approve) 더블클릭/재진입 반복 승인 방지 — `approvingRef` in-flight 가드 + 승인 중 accept 버튼 비활성화("시작하는 중…"). 완료 후 `onContinue`.
- **approve Idempotency-Key**: `plansApi.approve(planId, key)`로 확장, 같은 `planId`엔 같은 키(`approve-<planId>`) → 서버가 1회로 처리(미들웨어 이미 존재).
- **재생성 연타**: 이미 #98의 `inFlightRef` + 생성 중 로딩뷰가 버튼을 대체해 차단됨(추가 조치 불필요).

## 검증 (Playwright, mock)

"이대로 시작" 더블클릭에도 **approve 1회만 호출** + **Idempotency-Key(`approve-<planId>`) 전송** 확인. `tsc`/`check-api-contract`(PASS)/`build` 클린.

> 참고: 새로고침 재진입 시 자동 생성은 `autoGenKeyRef`+`inFlightRef`로 1회 가드. 매 마운트 새 draft가 생기지만 draft는 72h 만료·미승인이라 캘린더에 누적되지 않음(누적은 approve 경로였고 위에서 가드).

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)