### PR TITLE
fix(weekly): 블록 편집(목표·제목) 저장 PATCH 배선 (#121)

### DIFF
--- a/src/screens/WeeklyCalendarScreen.tsx
+++ b/src/screens/WeeklyCalendarScreen.tsx
@@ -339,10 +339,52 @@ export function WeeklyCalendarScreenV2() {
     targetEl.addEventListener('pointercancel', onUp);
   };
 
-  const handleSave = (updated: Block) => {
+  const handleSave = async (updated: Block) => {
+    const prev = blocks.find((b) => b.id === updated.id);
+    // 옵티미스틱 로컬 반영.
     setBlocks((bs) => bs.map((b) => b.id === updated.id ? { ...b, ...updated } : b));
     setEditing(null);
-    showToast('블록 수정됨');
+
+    // 서버에 아직 없는 새 블록(new-*)이거나 planId 없으면 로컬 저장만(임시).
+    if (!planIdRef.current || updated.id.startsWith('new-')) {
+      showToast('블록 수정됨 (임시 저장)');
+      return;
+    }
+
+    // day/time/dur → startAt/endAt (commitMove 와 동일 변환).
+    const min = parseMin(updated.time);
+    const startAt = new Date(_monday);
+    startAt.setDate(startAt.getDate() + updated.day);
+    startAt.setHours(Math.floor(min / 60), min % 60, 0, 0);
+    const endAt = new Date(startAt.getTime() + updated.dur * 60000);
+    try {
+      const body: BlockEditRequest = {
+        startAt: startAt.toISOString(),
+        endAt: endAt.toISOString(),
+        category: updated.goal, // 정식 카테고리 값(미지원값은 서버가 other 로 정규화)
+        title: updated.title,
+      };
+      const res = await plansApi.updateBlock(planIdRef.current, updated.id, body);
+      // 응답으로 목표 연결/카테고리 갱신 → 색·라벨 반영(#109).
+      setBlocks((bs) => bs.map((b) => b.id === updated.id
+        ? { ...b, goal: res.category ?? b.goal, goalId: res.goalId ?? b.goalId, title: res.title ?? b.title }
+        : b));
+      showToast('블록 수정됨');
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 422) {
+        const msg =
+          err.code === 'PLAN_BLOCK_CONFLICT'
+            ? '이 시간에 다른 블록과 겹쳐요'
+            : err.code === 'POLICY_VIOLATION'
+              ? '이 시간대는 야간 차단 정책이 있어요'
+              : err.message;
+        showToast(msg, 'error');
+        if (prev) setBlocks((bs) => bs.map((b) => (b.id === updated.id ? prev : b))); // revert
+        return;
+      }
+      // 404 등 백엔드 미구현 — 임시 저장으로 간주.
+      showToast('블록 수정됨 (임시 저장)');
+    }
   };
   const handleDelete = (id: string) => {
     setBlocks((bs) => bs.filter((b) => b.id !== id));

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -642,12 +642,17 @@ export interface WeeklyPlanResponse {
 export interface BlockEditRequest {
   startAt: string; // KST ISO
   endAt?: string | null;
+  category?: string | null; // 목표 카테고리(GOAL_CATEGORY_OPTIONS 값). 미지원값은 서버가 'other' 로 정규화.
+  title?: string | null;
 }
 export interface BlockEditResponse {
   blockId: string;
   startAt: string;
   endAt: string | null;
   blockStatus?: string;
+  category?: string | null;
+  title?: string | null;
+  goalId?: string | null;
 }
 
 // ── Reviews (S21·S22) — GET /reviews/weekly (#21 구현됨) ───────


### PR DESCRIPTION
## 배경 (Closes #121)
주간 캘린더에서 블록의 **목표(카테고리)·제목·소요시간**을 바꿔도 저장되지 않고 새로고침하면 원복되던 버그. `handleSave` 가 로컬 state 만 갱신하고 API 를 호출하지 않았음(드래그 시간이동만 PATCH 됨).

## 변경
- `WeeklyCalendarScreen.handleSave` → `plansApi.updateBlock(planId, blockId, { startAt, endAt, category, title })` 배선.
  - `day/time/dur → startAt/endAt` 변환은 `commitMove` 로직 재사용.
  - 성공: 응답의 `category/goalId/title` 로 로컬 갱신(색·라벨 #109 반영).
  - 422: `revert` + 에러 토스트(겹침/야간정책). 404: 임시 저장으로 간주.
  - 새 블록(`new-*`)·`planId` 없음: 로컬 임시 저장 유지.
- 타입: `BlockEditRequest` 에 `category?`/`title?`, `BlockEditResponse` 에 `category?`/`title?`/`goalId?` 추가.

## 검증 (Playwright, mock)
블록 탭 → 목표 '학습' + 제목 변경 → 저장 → **PATCH 1회 호출**, body `{ category:'study', title:'새 제목', startAt(10:00 KST) }` 확인. `tsc`/`check-api-contract`(PASS)/`build` 클린.

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)