### PR TITLE
chore(api): 백엔드 API 동기화 (routine)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -427,8 +427,19 @@
         "type": "object"
       },
       "BlockEditRequest": {
-        "description": "PATCH /plans/{planId}/blocks/{blockId} — 15분 snap 이동.\n\n`endAt` 생략 시 기존 길이를 보존한 채 시작만 옮긴다. 시각은 KST ISO 8601.",
+        "description": "PATCH /plans/{planId}/blocks/{blockId} — 15분 snap 이동 + 목표(category)/제목 수정.\n\n`endAt` 생략 시 기존 길이를 보존한 채 시작만 옮긴다. 시각은 KST ISO 8601.\n`category`/`title` 을 주면 블록이 매달린 action_item 을 갱신한다 — 같은 액션의 모든\n세션 블록에 반영되며, 미지원 category 는 'other' 로 정규화한다. 미지정 필드는 유지.",
         "properties": {
+          "category": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Category"
+          },
           "endAt": {
             "anyOf": [
               {
@@ -443,6 +454,17 @@
           "startAt": {
             "title": "Startat",
             "type": "string"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
           }
         },
         "required": [
@@ -1045,6 +1067,15 @@
                 "type": "null"
               }
             ]
+          },
+          "scope": {
+            "default": "horizon",
+            "enum": [
+              "week",
+              "horizon"
+            ],
+            "title": "Scope",
+            "type": "string"
           },
           "targetDate": {
             "anyOf": [
@@ -2098,6 +2129,21 @@
               }
             ],
             "title": "Promotedgoalid"
+          },
+          "promotedTo": {
+            "anyOf": [
+              {
+                "enum": [
+                  "goal",
+                  "action"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Promotedto"
           },
           "rawText": {
             "title": "Rawtext",
@@ -5428,7 +5474,7 @@
     },
     "/inbox": {
       "get": {
-        "description": "내 inbox 항목. `?status=captured|classified|promoted` 필터.",
+        "description": "내 inbox 항목. `?status=captured|classified|promoted|archived` 필터.\n\n`status` 미지정 시 활성 항목(archived 제외)만. `status=archived` 는 보관함(soft-deleted)\n조회 — `POST /inbox/{id}/restore` 로 되살릴 수 있다.",
         "operationId": "list_inbox_inbox_get",
         "parameters": [
           {
@@ -5788,6 +5834,65 @@
           }
         },
         "summary": "Convert To Goal",
+        "tags": [
+          "inbox"
+        ]
+      }
+    },
+    "/inbox/{inbox_id}/restore": {
+      "post": {
+        "description": "보관 취소 — `archived_at` 클리어 + status 를 활성(classified/captured)으로 복원.\n\n보관함(`status=archived`)에서만 의미. 이미 활성이면 멱등(현재 상태 그대로 반환).\n존재하지 않으면 404 `INBOX_NOT_FOUND`. hard delete 는 없으므로 언제든 되살릴 수 있다.",
+        "operationId": "restore_inbox_inbox__inbox_id__restore_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "inbox_id",
+            "required": true,
+            "schema": {
+              "title": "Inbox Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InboxItem"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Restore Inbox",
         "tags": [
           "inbox"
         ]
@@ -6589,7 +6694,7 @@
     },
     "/plans/{plan_id}/approve": {
       "post": {
-        "description": "First Plan Draft 승인 → SAVING (goal 트리 단일 가드 트랜잭션 영속화, ADR-0005 §2.5.1).\n\n`plan_id` 로 저장된 Draft 를 로드해 goals/goal_nodes/action_items/scheduled_blocks 를\n단일 트랜잭션으로 영속화(+최대 3회 재시도). `policy_guarded_transaction`(PR #30 재사용)이\n절대 시간 정책 위반 시 롤백 → 422 `PLAN_POLICY_VIOLATION`, 그 외 실패는 롤백 후 500\n`PLAN_SAVE_FAILED`. 만료된 Draft 는 410 `PLAN_DRAFT_EXPIRED`. 이미 승인된 Draft 는 멱등.\n\n부수 효과: 첫 계획 승인 = 온보딩 완료 → onboarding_state 를 `ACTIVE` 로 전이(멱등,\n어느 온보딩 단계에서든). 원설계(FIRST_PLAN → NOTIFICATIONS)는 실제 FE 흐름에서 상태가\nWELCOME 에 고정돼 새로고침 시 재-온보딩되던 문제가 있어 승인에서 ACTIVE 로 마감\n(api-contract §3).\n응답은 명시 승인이므로 `is_draft=false` (ADR-0005 §7.2).",
+        "description": "First Plan Draft 승인 → SAVING (goal 트리 단일 가드 트랜잭션 영속화, ADR-0005 §2.5.1).\n\n`plan_id` 로 저장된 Draft 를 로드해 goals/goal_nodes/action_items/scheduled_blocks 를\n단일 트랜잭션으로 영속화(+최대 3회 재시도). `policy_guarded_transaction`(PR #30 재사용)이\n절대 시간 정책 위반 시 롤백 → 422 `PLAN_POLICY_VIOLATION`, 그 외 실패는 롤백 후 500\n`PLAN_SAVE_FAILED`. 만료된 Draft 는 410 `PLAN_DRAFT_EXPIRED`. 이미 승인된 Draft 는 멱등.\n\n승인 = 교체: 같은 target_date 의 이전 AI 계획 산출물 중 사용자가 손대지 않은\n카드(source=goal·status=planned, user_edit 블록 없는 것)와 그 블록을 soft 정리\n(archived/cancelled)하고, heaviest goal 의 기존 분해 트리도 보관한 뒤 새 계획을\n영속화한다 — 재생성→재승인 반복으로 같은 날짜에 카드/블록/노드가 겹겹이 누적되던\n문제 방지 (`first_plan_adapter.supersede_previous_plan`).\n\n동시성(더블클릭·다중 디바이스 동시 승인): advisory lock 은 **트랜잭션 스코프**\n(`pg_advisory_xact_lock`) 라 commit/rollback 마다 풀린다. 그래서 시도(attempt)마다\nlock 을 새로 잡고, Draft 로드·만료·멱등 검사 → 영속화 → Draft 승인 마킹·온보딩\n전이(`on_success` — 가드 트랜잭션 내부)까지를 **한 트랜잭션 단일 commit** 으로 묶는다.\nlock 이 풀리는 순간엔 항상 status=approved 가 이미 커밋돼 있어, 대기하던 요청은\n멱등 응답으로 빠진다. 재시도(ADR-0005 §2.5.1, 3회)는 이 라우터 루프가 담당한다\n(adapter 내부 재시도는 rollback 으로 lock 을 잃은 채 돌게 되므로 `max_retries=1`).\n\n부수 효과: 첫 계획 승인 = 온보딩 완료 → onboarding_state 를 `ACTIVE` 로 전이(멱등,\n어느 온보딩 단계에서든). 원설계(FIRST_PLAN → NOTIFICATIONS)는 실제 FE 흐름에서 상태가\nWELCOME 에 고정돼 새로고침 시 재-온보딩되던 문제가 있어 승인에서 ACTIVE 로 마감\n(api-contract §3).\n응답은 명시 승인이므로 `is_draft=false` (ADR-0005 §7.2).",
         "operationId": "approve_plan_plans__plan_id__approve_post",
         "parameters": [
           {
@@ -6648,7 +6753,7 @@
     },
     "/plans/{plan_id}/blocks/{block_id}": {
       "patch": {
-        "description": "블록 15분 snap 이동 (S15). 충돌 422 `PLAN_BLOCK_CONFLICT` / 정책 422 `POLICY_VIOLATION`.",
+        "description": "블록 15분 snap 이동 + 목표(category)/제목 수정 (S15).\n\n충돌 422 `PLAN_BLOCK_CONFLICT` / 정책 422 `POLICY_VIOLATION`. `category`/`title` 을 주면\n블록이 매달린 action_item 을 갱신한다(같은 액션의 모든 세션 블록 공유). 정책 검사는\n**변경된 category** 로 수행하고, 변경 반영은 성공 commit 시에만 영속된다(422 면 롤백).",
         "operationId": "edit_block_plans__plan_id__blocks__block_id__patch",
         "parameters": [
           {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -601,6 +601,9 @@ export interface FirstPlanGenerateRequest {
   interviewSessionId?: string | null;
   targetDate?: string | null; // YYYY-MM-DD
   outcome?: Record<string, unknown> | null; // InterviewOutcome (보통 서버 파생)
+  // 배치 범위: 'horizon'(기본, 마감까지 전 구간) | 'week'(target_date 가 속한 주만).
+  // 서버 기본값 'horizon' 이라 생략 가능.
+  scope?: 'week' | 'horizon';
 }
 
 // POST /plans/{planId}/approve

--- a/src/types/openapi.d.ts
+++ b/src/types/openapi.d.ts
@@ -427,7 +427,10 @@ export interface paths {
         };
         /**
          * List Inbox
-         * @description 내 inbox 항목. `?status=captured|classified|promoted` 필터.
+         * @description 내 inbox 항목. `?status=captured|classified|promoted|archived` 필터.
+         *
+         *     `status` 미지정 시 활성 항목(archived 제외)만. `status=archived` 는 보관함(soft-deleted)
+         *     조회 — `POST /inbox/{id}/restore` 로 되살릴 수 있다.
          */
         get: operations["list_inbox_inbox_get"];
         put?: never;
@@ -516,6 +519,29 @@ export interface paths {
          * @description Inbox → Goal 변환 (tier=maintain default, 한도 enforce). inbox.status=promoted.
          */
         post: operations["convert_to_goal_inbox__inbox_id__convert_to_goal_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/inbox/{inbox_id}/restore": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Restore Inbox
+         * @description 보관 취소 — `archived_at` 클리어 + status 를 활성(classified/captured)으로 복원.
+         *
+         *     보관함(`status=archived`)에서만 의미. 이미 활성이면 멱등(현재 상태 그대로 반환).
+         *     존재하지 않으면 404 `INBOX_NOT_FOUND`. hard delete 는 없으므로 언제든 되살릴 수 있다.
+         */
+        post: operations["restore_inbox_inbox__inbox_id__restore_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -807,6 +833,20 @@ export interface paths {
          *     절대 시간 정책 위반 시 롤백 → 422 `PLAN_POLICY_VIOLATION`, 그 외 실패는 롤백 후 500
          *     `PLAN_SAVE_FAILED`. 만료된 Draft 는 410 `PLAN_DRAFT_EXPIRED`. 이미 승인된 Draft 는 멱등.
          *
+         *     승인 = 교체: 같은 target_date 의 이전 AI 계획 산출물 중 사용자가 손대지 않은
+         *     카드(source=goal·status=planned, user_edit 블록 없는 것)와 그 블록을 soft 정리
+         *     (archived/cancelled)하고, heaviest goal 의 기존 분해 트리도 보관한 뒤 새 계획을
+         *     영속화한다 — 재생성→재승인 반복으로 같은 날짜에 카드/블록/노드가 겹겹이 누적되던
+         *     문제 방지 (`first_plan_adapter.supersede_previous_plan`).
+         *
+         *     동시성(더블클릭·다중 디바이스 동시 승인): advisory lock 은 **트랜잭션 스코프**
+         *     (`pg_advisory_xact_lock`) 라 commit/rollback 마다 풀린다. 그래서 시도(attempt)마다
+         *     lock 을 새로 잡고, Draft 로드·만료·멱등 검사 → 영속화 → Draft 승인 마킹·온보딩
+         *     전이(`on_success` — 가드 트랜잭션 내부)까지를 **한 트랜잭션 단일 commit** 으로 묶는다.
+         *     lock 이 풀리는 순간엔 항상 status=approved 가 이미 커밋돼 있어, 대기하던 요청은
+         *     멱등 응답으로 빠진다. 재시도(ADR-0005 §2.5.1, 3회)는 이 라우터 루프가 담당한다
+         *     (adapter 내부 재시도는 rollback 으로 lock 을 잃은 채 돌게 되므로 `max_retries=1`).
+         *
          *     부수 효과: 첫 계획 승인 = 온보딩 완료 → onboarding_state 를 `ACTIVE` 로 전이(멱등,
          *     어느 온보딩 단계에서든). 원설계(FIRST_PLAN → NOTIFICATIONS)는 실제 FE 흐름에서 상태가
          *     WELCOME 에 고정돼 새로고침 시 재-온보딩되던 문제가 있어 승인에서 ACTIVE 로 마감
@@ -835,7 +875,11 @@ export interface paths {
         head?: never;
         /**
          * Edit Block
-         * @description 블록 15분 snap 이동 (S15). 충돌 422 `PLAN_BLOCK_CONFLICT` / 정책 422 `POLICY_VIOLATION`.
+         * @description 블록 15분 snap 이동 + 목표(category)/제목 수정 (S15).
+         *
+         *     충돌 422 `PLAN_BLOCK_CONFLICT` / 정책 422 `POLICY_VIOLATION`. `category`/`title` 을 주면
+         *     블록이 매달린 action_item 을 갱신한다(같은 액션의 모든 세션 블록 공유). 정책 검사는
+         *     **변경된 category** 로 수행하고, 변경 반영은 성공 commit 시에만 영속된다(422 면 롤백).
          */
         patch: operations["edit_block_plans__plan_id__blocks__block_id__patch"];
         trace?: never;
@@ -1604,15 +1648,21 @@ export interface components {
         };
         /**
          * BlockEditRequest
-         * @description PATCH /plans/{planId}/blocks/{blockId} — 15분 snap 이동.
+         * @description PATCH /plans/{planId}/blocks/{blockId} — 15분 snap 이동 + 목표(category)/제목 수정.
          *
          *     `endAt` 생략 시 기존 길이를 보존한 채 시작만 옮긴다. 시각은 KST ISO 8601.
+         *     `category`/`title` 을 주면 블록이 매달린 action_item 을 갱신한다 — 같은 액션의 모든
+         *     세션 블록에 반영되며, 미지원 category 는 'other' 로 정규화한다. 미지정 필드는 유지.
          */
         BlockEditRequest: {
+            /** Category */
+            category?: string | null;
             /** Endat */
             endAt?: string | null;
             /** Startat */
             startAt: string;
+            /** Title */
+            title?: string | null;
         };
         /**
          * BlockEditResponse
@@ -1904,6 +1954,12 @@ export interface components {
             /** Interviewsessionid */
             interviewSessionId?: string | null;
             outcome?: components["schemas"]["InterviewOutcome"] | null;
+            /**
+             * Scope
+             * @default horizon
+             * @enum {string}
+             */
+            scope: "week" | "horizon";
             /** Targetdate */
             targetDate?: string | null;
         };
@@ -2339,6 +2395,8 @@ export interface components {
             inboxId: string;
             /** Promotedgoalid */
             promotedGoalId: string | null;
+            /** Promotedto */
+            promotedTo?: ("goal" | "action") | null;
             /** Rawtext */
             rawText: string;
             /** Status */
@@ -4250,6 +4308,39 @@ export interface operations {
         };
     };
     convert_to_goal_inbox__inbox_id__convert_to_goal_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                inbox_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InboxItem"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    restore_inbox_inbox__inbox_id__restore_post: {
         parameters: {
             query?: never;
             header?: {


### PR DESCRIPTION
백엔드(`reaction-backend` main) OpenAPI 를 재덤프해 프론트 타입·계약과 동기화한 루틴 PR 입니다.

## (a) 신규/변경 엔드포인트
- **신규** `POST /inbox/{inboxId}/restore` → 보관함(archived) 항목 복원. api.ts 래퍼(`inboxApi.restore`)는 이미 존재 → 계약 일치 확인만.
- **변경** `POST /plans/generate` (`FirstPlanGenerateRequest`): `scope: 'week' | 'horizon'`(기본 `horizon`) 필드 추가 → 수기 타입 `src/types/api.ts` 에 반영.
- **변경(문서·필드)** `PATCH /plans/{planId}/blocks/{blockId}` (`BlockEditRequest`): `category`/`title` 추가 — 프론트 타입엔 이미 반영돼 있어 openapi 스키마만 최신화.
- **변경** `InboxItem.promotedTo`(`'goal'|'action'|null`) — 프론트 타입엔 이미 반영돼 있어 openapi 스키마만 최신화.
- 그 외: `/plans/{planId}/approve`·`/inbox` 등 설명(docstring) 최신화.

## (b) 화면 실연동
- 이번 회차에 **새로 연동한 화면 없음**. 직전까지 미구현(WARN)이던 `today/agenda`, `today/focus` pause·resume, `reflection/pending`·`batch` 는 이미 OK 상태이며 해당 화면(MorningBrief·Today·Focus·EveningCheckIn 등)이 실호출로 연동돼 있어 추가 작업이 불필요했습니다.
- 남은 NEW 엔드포인트(`calendar/sync-preview`, `calendar/events/approve-insert`, `PATCH /habits/{}`, `policy-snapshot/current`)는 아직 대응 화면이 없어 이번 범위에서 제외.

## (c) check:api 요약
```
openapi 경로 65개 · api.ts 호출 73개
✅ OK   73   ⚠️ WARN 0   ❌ GONE 0   🆕 NEW 6
결과: PASS
```
검증 게이트: `check:api`(GONE 0) · `tsc --noEmit`(0) · `npm run build`(성공) 모두 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018bGNE5hUwPzXTKyLoHTBHa)_