### PR TITLE
feat(interview): 목표 심화 — 진행바 슬롯 추정치 반영 (B)

### DIFF
--- a/src/screens/GoalIntakeScreen.tsx
+++ b/src/screens/GoalIntakeScreen.tsx
@@ -21,7 +21,7 @@ interface ChatMessage {
 // 백엔드 mock은 필수 슬롯 12개 → ambiguityScore 0 ~ 12.
 // 답변할수록 줄어드므로 (1 - score/initial) * 100 으로 명료성 환산.
 // /interview/slot-catalog 가 응답하기 전(fetch 실패 포함) 의 안전 기본값.
-const REQUIRED_SLOTS_INIT = 12;
+const REQUIRED_SLOTS_INIT = 14;
 
 // slot-catalog 의 category 식별자 → 한국어 라벨 (chip 표시용).
 const CATEGORY_LABEL: Record<string, string> = {


### PR DESCRIPTION
## 이슈
백엔드 목표 심화(B-2)로 인터뷰 필수 슬롯 13→14. 프론트 진행바 초기 추정치 반영.

## 변경
- `GoalIntakeScreen`: `REQUIRED_SLOTS_INIT` 12→14 (실제 진행률은 백엔드 `ambiguityScore` 로 갱신). 새 `goals.current_level` 질문은 slot-catalog 기반으로 자동 렌더(text 입력).

## 어떻게 테스트했는지
- tsc 통과, 로컬 온보딩에서 "현재 수준" 질문 노출 확인.

## 리뷰어 체크 포인트
- 백엔드 PR(reaction-backend feat/goal-deepening) 선행 필요.

> ⚠️ base=`feat/interview-profile-memory` (stacked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)