### PR TITLE
feat(reflection): S17 저녁 회고 일괄 저장 배선 + 내일 미리보기 실데이터 (#8)

### DIFF
--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -8,3 +8,13 @@ export function localDateStr(d: Date): string {
   const p = (n: number) => String(n).padStart(2, '0');
   return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`;
 }
+
+// 그 날짜가 속한 주의 월요일 (YYYY-MM-DD). /plans/weekly·/reviews/weekly 의 weekStart 파라미터용.
+//
+// 날짜가 주 경계를 넘으면(일요일의 '내일' = 다음 주 월요일) 그 주의 월요일이 나와야 하므로,
+// 기준 날짜를 받아서 계산한다. 위 localDateStr 를 거치므로 KST 00:00~08:59 밀림(#92) 없음.
+export function weekStartStr(d: Date): string {
+  const monday = new Date(d);
+  monday.setDate(monday.getDate() - ((monday.getDay() + 6) % 7));
+  return localDateStr(monday);
+}

--- a/src/screens/EveningCheckInScreen.tsx
+++ b/src/screens/EveningCheckInScreen.tsx
@@ -1,8 +1,14 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { CheckCircle } from '@phosphor-icons/react';
 import { DemoNotice } from '../components/DemoNotice';
-import { reflectionApi } from '../lib/api';
-import type { ReflectionPendingItem } from '../types/api';
+import { plansApi, reflectionApi } from '../lib/api';
+import { localDateStr, weekStartStr } from '../lib/dates';
+import type {
+  CompletionStatus,
+  ReflectionBatchItem,
+  ReflectionPendingItem,
+  WeeklyBlock,
+} from '../types/api';
 
 interface EveningCheckInScreenProps {
   onDone: () => void;
@@ -27,17 +33,47 @@ const energyOptions = [
   { v: 5, label: '최상이에요', color: 'var(--brand)' },
 ];
 
+// Quick Check-in 4칩 (베이스라인 §1.4). 톤 잠금 "Be on your side, not on your case" —
+// 라벨에 '실패'·'못했' 같은 심판 어휘를 쓰지 않는다.
+const statusOptions: { v: CompletionStatus; label: string; color: string }[] = [
+  { v: 'done', label: '했어요', color: 'var(--success)' },
+  { v: 'partial_done', label: '조금', color: 'var(--brand)' },
+  { v: 'failed', label: '못 했어요', color: 'var(--text-3)' },
+  { v: 'over_done', label: '더 했어요', color: 'var(--brand)' },
+];
+
+// 같은 내용의 [모두 완료] 재전송은 같은 키 → 서버가 24h 안에 1회만 처리(중복 탭 방지).
+// 매번 새 키(Date.now() 등)를 쓰면 멱등 보호가 통째로 무력해진다.
+// 선택을 바꾸면 키도 바뀌어야 한다 — 같은 키에 다른 body 면 서버가 409 를 낸다.
+// 해시 충돌 시엔 409 를 받을 뿐 데이터가 섞이지는 않는다(안전 실패).
+function idempotencyKeyFor(items: ReflectionBatchItem[]): string {
+  const canonical = items
+    .map((i) => `${i.executionId}:${i.completionStatus}`)
+    .sort()
+    .join('|');
+  let h = 0;
+  for (let i = 0; i < canonical.length; i += 1) {
+    h = (Math.imul(31, h) + canonical.charCodeAt(i)) | 0;
+  }
+  return `batch-${(h >>> 0).toString(36)}-${items.length}`;
+}
+
 export function EveningCheckInScreen({ onDone }: EveningCheckInScreenProps) {
   const [step, setStep] = useState(0);
   const [energy, setEnergy] = useState<number | null>(null);
 
-  // GET /reflection/pending (#83) 은 백엔드 구현됨 — 최근 3일 미체크(in_progress) 실행을
-  // 실데이터로 보여준다. 실패 시 더미로 가리지 않고 빈 목록 + 안내로 정직하게(목업 제거 방침).
-  // /reflection/batch 저장은 이 화면이 에너지 1종만 모아 계약(executionId·completionStatus)에
-  // 안 맞아 아직 로컬 흐름만 유지한다(#82).
+  // GET /reflection/pending (#83) — 최근 3일 미체크(in_progress) 실행. 실패 시 더미로 가리지
+  // 않고 빈 목록 + 안내로 정직하게(목업 제거 방침).
   const [pending, setPending] = useState<ReflectionPendingItem[]>([]);
   const [usingRealPending, setUsingRealPending] = useState(false);
   const [pendingLoading, setPendingLoading] = useState(true);
+
+  // executionId → 사용자가 고른 4칩. 미선택 항목은 batch 에서 빠진다(강제하지 않는다).
+  const [picked, setPicked] = useState<Record<string, CompletionStatus>>({});
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  // 실패/부분완료인데 사유를 안 남긴 항목 — 서버가 알려준다(S18 유도 대상).
+  const [needsTags, setNeedsTags] = useState<string[]>([]);
 
   useEffect(() => {
     let cancelled = false;
@@ -53,6 +89,35 @@ export function EveningCheckInScreen({ onDone }: EveningCheckInScreenProps) {
     return () => { cancelled = true; };
   }, []);
 
+  const items = useMemo<ReflectionBatchItem[]>(
+    () => pending
+      .filter((p) => picked[p.executionId])
+      .map((p) => ({ executionId: p.executionId, completionStatus: picked[p.executionId] })),
+    [pending, picked],
+  );
+
+  // 창 밖(어제·그제) 건이 섞여 있으면 배너로 알린다 — "어제 회고 못한 것도 함께 정리해요".
+  const carriedOver = pending.filter((p) => relDayLabel(p.scheduledDate) !== '오늘').length;
+
+  const goNext = () => {
+    setSubmitError(null);
+    if (items.length === 0) { setStep(1); return; }
+    setSubmitting(true);
+    reflectionApi.batch({ items }, idempotencyKeyFor(items)).then(
+      (res) => {
+        setNeedsTags(res.needsFailureTags);
+        // 종결된 실행은 더 이상 미체크가 아니다 — 목록에서 뺀다.
+        const done = new Set(items.map((i) => i.executionId));
+        setPending((ps) => ps.filter((p) => !done.has(p.executionId)));
+        setStep(1);
+      },
+      () => {
+        // 저장 실패를 삼키지 않는다 — 삼키면 사용자는 기록된 줄 알고 넘어간다.
+        setSubmitError('기록을 저장하지 못했어요. 잠시 후 다시 시도해 주세요.');
+      },
+    ).finally(() => setSubmitting(false));
+  };
+
   if (step === 2) {
     const selectedEnergy = energyOptions.find((e) => e.v === energy);
     return (
@@ -62,12 +127,19 @@ export function EveningCheckInScreen({ onDone }: EveningCheckInScreenProps) {
         </div>
         <div style={{ fontFamily: 'var(--font-display)', fontSize: 28, fontWeight: 500, letterSpacing: '-0.01em' }}>저녁 체크인 완료.</div>
         <p style={{ fontSize: 14, color: 'var(--text-2)', lineHeight: 1.6, maxWidth: 260 }}>오늘의 실행 데이터가 저장됐어요. 내일 아침에 맞춤 모닝 브리프가 준비될 거예요.</p>
-        <div style={{ padding: '10px 14px', background: 'var(--brand-soft)', borderRadius: 12, border: '1px solid var(--coral-200)', fontSize: 12, color: 'var(--coral-700)', textAlign: 'left', width: '100%' }}>
-          <b>내일 반영 사항:</b><br />에너지 "{selectedEnergy?.label}" 기록 → 내일 블록 강도 자동 조정
-        </div>
+        {selectedEnergy && (
+          <div style={{ padding: '10px 14px', background: 'var(--brand-soft)', borderRadius: 12, border: '1px solid var(--coral-200)', fontSize: 12, color: 'var(--coral-700)', textAlign: 'left', width: '100%' }}>
+            <b>내일 반영 사항:</b><br />에너지 "{selectedEnergy.label}" 기록 → 내일 블록 강도 자동 조정
+          </div>
+        )}
+        {needsTags.length > 0 && (
+          <div style={{ padding: '10px 14px', background: 'var(--surface-raised)', borderRadius: 12, border: '1px solid var(--sand-200)', fontSize: 12, color: 'var(--text-2)', textAlign: 'left', width: '100%', lineHeight: 1.55 }}>
+            {needsTags.length}건은 무엇이 막았는지 남기면 그에 맞는 회복안을 제안해드려요. 오늘 화면에서 카드를 열면 이어서 할 수 있어요.
+          </div>
+        )}
         <div style={{ width: '100%' }}>
-          <DemoNotice storageKey="evening-batch">
-            이 데모에서는 에너지 기록이 임시 저장돼요. 실행별 소급 회고(일괄 저장)는 곧 연결됩니다.
+          <DemoNotice storageKey="evening-energy">
+            에너지 기록은 아직 임시 저장돼요(저장 계약 준비 중). 실행별 회고는 실제로 저장됩니다.
           </DemoNotice>
         </div>
         <button onClick={onDone} style={{ width: '100%', height: 44, borderRadius: 12, border: 'none', background: 'var(--text-1)', color: '#FAF6EE', fontWeight: 700, fontSize: 14, fontFamily: 'inherit', cursor: 'pointer' }}>주간 계획 보기 →</button>
@@ -76,36 +148,7 @@ export function EveningCheckInScreen({ onDone }: EveningCheckInScreenProps) {
   }
 
   if (step === 1) {
-    return (
-      <div style={{ height: '100%', overflowY: 'auto', padding: '16px 18px 32px', background: 'var(--surface-ground)', display: 'flex', flexDirection: 'column', gap: 14 }}>
-        <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--text-3)', fontFamily: 'var(--font-mono)' }}>저녁 체크인 · 2/2</div>
-        <h2 style={{ fontSize: 22, fontWeight: 700, letterSpacing: '-0.02em', margin: '0 0 6px' }}>내일 계획 미리보기</h2>
-        <div style={{ background: '#FBEEDA', border: '1px solid #F2D29A', borderRadius: 14, padding: 14 }}>
-          <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--warning)', marginBottom: 6 }}>↩ 이월 예정</div>
-          <div style={{ fontSize: 14, fontWeight: 700, color: 'var(--text-1)' }}>GROUP BY / HAVING 실습</div>
-          <div style={{ fontSize: 11, color: 'var(--text-3)', marginTop: 4 }}>오늘 미완료 → 내일 목요일 21:00으로 자동 배치</div>
-        </div>
-        <div style={{ background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', borderRadius: 14, padding: 14 }}>
-          <div style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-3)', marginBottom: 10 }}>목요일 예정 블록</div>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-            {[
-              { t: '전공 수업', time: '19:00', dur: '120분', carry: false },
-              { t: 'GROUP BY / HAVING 실습 (이월)', time: '21:30', dur: '60분', carry: true },
-            ].map((b, i) => (
-              <div key={i} style={{ display: 'flex', gap: 10, alignItems: 'center' }}>
-                <div className="tnum" style={{ width: 38, fontSize: 10, fontFamily: 'var(--font-mono)', color: 'var(--text-3)' }}>{b.time}</div>
-                <div style={{ flex: 1, fontSize: 13, fontWeight: 500, color: b.carry ? 'var(--warning)' : 'var(--text-1)' }}>{b.t}</div>
-                <span style={{ height: 'var(--ctrl-xs)', padding: '0 7px', background: 'var(--sand-100)', border: '1px solid var(--sand-200)', borderRadius: 9999, fontSize: 10, color: 'var(--text-2)', display: 'inline-flex', alignItems: 'center' }}>{b.dur}</span>
-              </div>
-            ))}
-          </div>
-        </div>
-        <div style={{ display: 'flex', gap: 8 }}>
-          <button onClick={() => setStep(0)} style={{ flex: 1, height: 44, borderRadius: 12, border: '1px solid var(--sand-200)', background: 'transparent', color: 'var(--text-1)', fontWeight: 600, fontSize: 13, fontFamily: 'inherit', cursor: 'pointer' }}>이전</button>
-          <button onClick={() => setStep(2)} style={{ flex: 2, height: 44, borderRadius: 12, border: 'none', background: 'var(--text-1)', color: '#FAF6EE', fontWeight: 600, fontSize: 13, fontFamily: 'inherit', cursor: 'pointer' }}>확인 →</button>
-        </div>
-      </div>
-    );
+    return <TomorrowPreview onBack={() => setStep(0)} onConfirm={() => setStep(2)} />;
   }
 
   return (
@@ -115,7 +158,7 @@ export function EveningCheckInScreen({ onDone }: EveningCheckInScreenProps) {
       <p style={{ fontSize: 13, color: 'var(--text-2)' }}>에너지 상태를 기록하면 내일 계획에 반영해요.</p>
 
       {/* 최근 3일 미체크(in_progress) 실행 — GET /reflection/pending 실연동 (#83).
-          로딩 중이거나 실제 항목이 있을 때만 박스를 띄우고, 실패 시엔 더미 없이 안내만. */}
+          카드별 4칩을 고르면 [다음]에서 POST /reflection/batch 로 한 번에 종결한다. */}
       {(pendingLoading || pending.length > 0) && (
         <div style={{ background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', borderRadius: 14, padding: 14, display: 'flex', flexDirection: 'column', gap: 10 }}>
           <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between' }}>
@@ -124,17 +167,46 @@ export function EveningCheckInScreen({ onDone }: EveningCheckInScreenProps) {
               <span className="tnum" style={{ fontSize: 11, fontFamily: 'var(--font-mono)', color: 'var(--text-3)' }}>{pending.length}건</span>
             )}
           </div>
+          {!pendingLoading && carriedOver > 0 && (
+            <div style={{ padding: '8px 10px', background: 'var(--brand-soft)', border: '1px solid var(--coral-200)', borderRadius: 10, fontSize: 12, color: 'var(--coral-700)', lineHeight: 1.5 }}>
+              어제·그제 정리 못한 {carriedOver}건도 함께 정리해요.
+            </div>
+          )}
           {pendingLoading ? (
             <div style={{ fontSize: 12, color: 'var(--text-3)' }}>불러오는 중…</div>
           ) : (
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
               {pending.map((p) => (
-                <div key={p.executionId} style={{ display: 'flex', gap: 10, alignItems: 'center' }}>
-                  <span style={{ height: 'var(--ctrl-xs)', minWidth: 34, padding: '0 7px', background: 'var(--sand-100)', border: '1px solid var(--sand-200)', borderRadius: 9999, fontSize: 10, color: 'var(--text-2)', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>{relDayLabel(p.scheduledDate)}</span>
-                  <div style={{ flex: 1, fontSize: 13, fontWeight: 500, color: 'var(--text-1)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{p.title}</div>
-                  {p.scheduledTime && (
-                    <div className="tnum" style={{ fontSize: 10, fontFamily: 'var(--font-mono)', color: 'var(--text-3)', flexShrink: 0 }}>{p.scheduledTime.slice(0, 5)}</div>
-                  )}
+                <div key={p.executionId} style={{ display: 'flex', flexDirection: 'column', gap: 7 }}>
+                  <div style={{ display: 'flex', gap: 10, alignItems: 'center' }}>
+                    <span style={{ height: 'var(--ctrl-xs)', minWidth: 34, padding: '0 7px', background: 'var(--sand-100)', border: '1px solid var(--sand-200)', borderRadius: 9999, fontSize: 10, color: 'var(--text-2)', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>{relDayLabel(p.scheduledDate)}</span>
+                    <div style={{ flex: 1, fontSize: 13, fontWeight: 500, color: 'var(--text-1)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{p.title}</div>
+                    {p.scheduledTime && (
+                      <div className="tnum" style={{ fontSize: 10, fontFamily: 'var(--font-mono)', color: 'var(--text-3)', flexShrink: 0 }}>{p.scheduledTime.slice(0, 5)}</div>
+                    )}
+                  </div>
+                  <div style={{ display: 'flex', gap: 5 }}>
+                    {statusOptions.map((s) => {
+                      const sel = picked[p.executionId] === s.v;
+                      return (
+                        <button
+                          key={s.v}
+                          aria-pressed={sel}
+                          onClick={() => setPicked((m) => {
+                            // 같은 칩을 다시 누르면 선택 해제 — 잘못 누른 걸 되돌릴 수 있어야 한다.
+                            if (m[p.executionId] === s.v) {
+                              const { [p.executionId]: _drop, ...rest } = m;
+                              return rest;
+                            }
+                            return { ...m, [p.executionId]: s.v };
+                          })}
+                          style={{ flex: 1, height: 30, borderRadius: 9999, border: `1px solid ${sel ? 'var(--text-1)' : 'var(--sand-200)'}`, background: sel ? 'var(--text-1)' : 'transparent', color: sel ? '#FAF6EE' : 'var(--text-2)', fontSize: 11, fontWeight: 600, fontFamily: 'inherit', cursor: 'pointer', transition: 'all 140ms' }}
+                        >
+                          {s.label}
+                        </button>
+                      );
+                    })}
+                  </div>
                 </div>
               ))}
             </div>
@@ -155,7 +227,83 @@ export function EveningCheckInScreen({ onDone }: EveningCheckInScreenProps) {
           </button>
         ))}
       </div>
-      <button onClick={() => energy && setStep(1)} style={{ width: '100%', height: 44, borderRadius: 12, border: 'none', background: 'var(--text-1)', color: '#FAF6EE', fontWeight: 700, fontSize: 14, fontFamily: 'inherit', cursor: 'pointer', opacity: energy ? 1 : 0.35 }}>다음 →</button>
+      {submitError && (
+        <div role="alert" style={{ padding: '10px 12px', background: '#FBE9E7', border: '1px solid var(--danger)', borderRadius: 10, fontSize: 12, color: 'var(--danger)', lineHeight: 1.5 }}>
+          {submitError}
+        </div>
+      )}
+      <button
+        onClick={goNext}
+        disabled={!energy || submitting}
+        style={{ width: '100%', height: 44, borderRadius: 12, border: 'none', background: 'var(--text-1)', color: '#FAF6EE', fontWeight: 700, fontSize: 14, fontFamily: 'inherit', cursor: energy && !submitting ? 'pointer' : 'default', opacity: energy && !submitting ? 1 : 0.35 }}
+      >
+        {submitting ? '기록하는 중…' : items.length > 0 ? `${items.length}건 기록하고 다음 →` : '다음 →'}
+      </button>
+    </div>
+  );
+}
+
+// 내일 예정 블록 — GET /plans/weekly 실데이터. (예전엔 요일·제목이 통째로 하드코딩돼 있어
+// 금요일에도 "내일 목요일"이 뜨고 21:00/21:30 이 서로 모순됐다.)
+function TomorrowPreview({ onBack, onConfirm }: { onBack: () => void; onConfirm: () => void }) {
+  const [blocks, setBlocks] = useState<WeeklyBlock[] | null>(null);
+  const [failed, setFailed] = useState(false);
+
+  const tomorrow = useMemo(() => {
+    const d = new Date();
+    d.setDate(d.getDate() + 1);
+    return d;
+  }, []);
+  const tomorrowStr = localDateStr(tomorrow);
+  const weekdayLabel = ['일', '월', '화', '수', '목', '금', '토'][tomorrow.getDay()];
+
+  useEffect(() => {
+    let cancelled = false;
+    // 내일이 다음 주면(일요일의 내일) 그 주의 월요일로 조회해야 한다.
+    plansApi.weekly(weekStartStr(tomorrow)).then(
+      (plan) => {
+        if (cancelled) return;
+        const day = plan.days.find((d) => d.date === tomorrowStr);
+        setBlocks(day?.blocks ?? []);
+      },
+      () => { if (!cancelled) setFailed(true); },
+    );
+    return () => { cancelled = true; };
+  }, [tomorrowStr, tomorrow]);
+
+  return (
+    <div style={{ height: '100%', overflowY: 'auto', padding: '16px 18px 32px', background: 'var(--surface-ground)', display: 'flex', flexDirection: 'column', gap: 14 }}>
+      <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--text-3)', fontFamily: 'var(--font-mono)' }}>저녁 체크인 · 2/2</div>
+      <h2 style={{ fontSize: 22, fontWeight: 700, letterSpacing: '-0.02em', margin: '0 0 6px' }}>내일 계획 미리보기</h2>
+      <div style={{ background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', borderRadius: 14, padding: 14 }}>
+        <div style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-3)', marginBottom: 10 }}>{weekdayLabel}요일 예정 블록 · {tomorrowStr.slice(5)}</div>
+        {blocks === null && !failed && <div style={{ fontSize: 12, color: 'var(--text-3)' }}>불러오는 중…</div>}
+        {failed && <div style={{ fontSize: 12, color: 'var(--text-3)' }}>내일 계획을 불러오지 못했어요.</div>}
+        {blocks !== null && blocks.length === 0 && (
+          <div style={{ fontSize: 12, color: 'var(--text-3)' }}>아직 잡힌 블록이 없어요. 주간 계획에서 추가할 수 있어요.</div>
+        )}
+        {blocks !== null && blocks.length > 0 && (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            {blocks.map((b) => {
+              const start = new Date(b.startAt);
+              const end = new Date(b.endAt);
+              const mins = Math.max(Math.round((end.getTime() - start.getTime()) / 60000), 0);
+              const hhmm = `${String(start.getHours()).padStart(2, '0')}:${String(start.getMinutes()).padStart(2, '0')}`;
+              return (
+                <div key={b.blockId} style={{ display: 'flex', gap: 10, alignItems: 'center' }}>
+                  <div className="tnum" style={{ width: 38, fontSize: 10, fontFamily: 'var(--font-mono)', color: 'var(--text-3)', flexShrink: 0 }}>{hhmm}</div>
+                  <div style={{ flex: 1, fontSize: 13, fontWeight: 500, color: 'var(--text-1)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{b.title}</div>
+                  <span style={{ height: 'var(--ctrl-xs)', padding: '0 7px', background: 'var(--sand-100)', border: '1px solid var(--sand-200)', borderRadius: 9999, fontSize: 10, color: 'var(--text-2)', display: 'inline-flex', alignItems: 'center', flexShrink: 0 }}>{mins}분</span>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+      <div style={{ display: 'flex', gap: 8 }}>
+        <button onClick={onBack} style={{ flex: 1, height: 44, borderRadius: 12, border: '1px solid var(--sand-200)', background: 'transparent', color: 'var(--text-1)', fontWeight: 600, fontSize: 13, fontFamily: 'inherit', cursor: 'pointer' }}>이전</button>
+        <button onClick={onConfirm} style={{ flex: 2, height: 44, borderRadius: 12, border: 'none', background: 'var(--text-1)', color: '#FAF6EE', fontWeight: 600, fontSize: 13, fontFamily: 'inherit', cursor: 'pointer' }}>확인 →</button>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## 이슈

partially addresses #8 (Issue 11 FE — 저녁 회고 + 회복 + 리플랜 UI) · BE 미러: hanium-reaction/reaction-backend#20

S17 만 다룹니다. S18·S19·S20 은 이미 실연동 완료라 건드리지 않았습니다.

## 문제

`reflectionApi.batch` 가 `lib/api.ts` 에 **정의만 되고 호출부가 0건**이었습니다. 3일 누적 카드를 읽기 전용 목록으로 보여주기만 하고, **회고를 저장할 방법이 화면에 없었습니다** — S17 의 핵심인 일괄 처리가 통째로 비어 있던 셈입니다. 백엔드(`POST /reflection/batch`)는 #107 로 이미 완성돼 있었습니다.

step 2/2 '내일 계획 미리보기'는 initial commit(2026-05-18)부터 **전체가 하드코딩 목업**이었습니다. 날짜 계산도 API 호출도 0이라 금요일에 열어도 "내일 **목요일** 21:00 자동 배치" 가 뜨고, 같은 화면의 "목요일 예정 블록" 은 21:30 이라 자기모순이었습니다. 목업 제거 3차례(#82/#83·#87·#97)에서 전부 누락된 자리입니다.

## 변경

### S17 일괄 회고 (신규 배선)
- 카드별 **Quick Check-in 4칩**(했어요 / 조금 / 못 했어요 / 더 했어요) → **[N건 기록하고 다음 →]** 으로 `POST /reflection/batch` 일괄 종결. 미선택 항목은 강제하지 않고 payload 에서 빠집니다. 같은 칩 재클릭 = 선택 해제.
- **Idempotency-Key 를 payload 에서 파생**(`batch-<hash>-<n>`). 같은 내용 재전송은 같은 키라 서버가 24h 안에 1회만 처리합니다. 매번 새 키(`Date.now()` 등)를 쓰면 중복 탭 방지가 통째로 무력해집니다 — 선택이 바뀌면 키도 바뀌므로 "같은 키 다른 body → 409" 도 피합니다.
- **저장 실패를 삼키지 않습니다.** 오류 배너를 띄우고 진행을 멈춥니다. 기존 코드베이스의 `.catch(() => {})` 패턴은 사용자가 "저장됐어요" 화면까지 그대로 넘어가 데이터가 조용히 유실됩니다.
- 창 밖(어제·그제) 건이 섞이면 배너 — "어제·그제 정리 못한 N건도 함께 정리해요" (이슈의 S17 요구사항).
- 서버의 `needsFailureTags` 를 안내로 노출 — 사유를 남기면 회복안(S19)으로 이어진다는 유도.
- 톤 잠금 준수: 라벨에 '실패'·'못했' 같은 심판 어휘를 쓰지 않았습니다("Be on your side, not on your case").

### step 2/2 목업 제거
- `GET /plans/weekly` 실데이터로 교체. 실제 요일·날짜·블록·소요분을 보여줍니다.
- 주 경계를 넘는 '일요일의 내일'(= 다음 주 월요일)을 위해 **기준 날짜로 주차를 계산**하는 `weekStartStr(date)` 를 `lib/dates.ts` 에 추가했습니다. `localDateStr` 를 거치므로 KST 00:00~08:59 밀림(#92) 없음 — `WeeklyCalendarScreen` 이 인라인으로 하던 같은 계산의 공유 버전입니다(그쪽 리팩터는 스코프 밖).
- 로딩 / 실패 / 빈 계획 상태를 각각 정직하게 표시(더미로 가리지 않음).

## 어떻게 테스트했는지

로컬 dev 서버 + **실 컴포넌트·실 `api.ts`** 를 그대로 태우고 네트워크만 스텁해 브라우저에서 클릭으로 검증했습니다(라이브 BE 는 실 구글 로그인이 필요해 단독 E2E 불가, 로컬 BE 는 `AUTH_STUB_MODE` 가 꺼져 있고 #94 이력 때문에 켜지 않았습니다). 검증용 하니스는 커밋에 포함하지 않았습니다.

관측된 실제 요청 순서:
```
GET  /api/reflection/pending
POST /api/reflection/batch   Idempotency-Key: batch-ahgytz-2
     {"items":[{"executionId":"exec_a1","completionStatus":"done"},
                {"executionId":"exec_b2","completionStatus":"failed"}]}
GET  /api/plans/weekly?weekStart=2026-07-13
```
- 오늘 7/17(금) → 내일 7/18(토) → 그 주 월요일 **7/13**. 주차 계산 정확.
- 화면: "어제·그제 정리 못한 2건도 함께 정리해요" 배너 / 버튼이 "2건 기록하고 다음 →" 으로 변함 / 에너지 미선택 시 버튼 disabled.
- step 2/2 가 **"토요일 예정 블록 · 07-18"** 로 실제 날짜 표시 (기존: 금요일에도 "목요일" 고정).
- `needsFailureTags: ['exec_b2']` → "1건은 무엇이 막았는지 남기면…" 안내 정확히 노출.
- **실패 경로**: batch 를 500 으로 떨어뜨리니 "기록을 저장하지 못했어요" 가 뜨고 **진행이 멈춤**(완료 화면으로 안 넘어감).
- 모바일 폭에서 4칩 각 85px, 텍스트 잘림·가로 넘침 없음.

`npx tsc --noEmit` 통과 · `npm run build` 성공.

## 리뷰어 체크 포인트

- **에너지 기록은 여전히 미저장** — `POST /reflection/batch` 계약에 필드가 없고(`executionId`/`completionStatus`/`failureTags`/`memo` 뿐), BE 어느 스키마·모델에도 energy 가 없습니다. FE 만으로는 닫을 수 없어 이번 범위에서 뺐습니다. DemoNotice 문구를 "에너지만 임시 저장, **실행별 회고는 실제로 저장**" 으로 정정해 더 이상 전체가 데모인 것처럼 읽히지 않게 했습니다. → BE 후속 필요(#82).
- **Idempotency 해시 충돌 시** 서버가 409 를 낼 뿐 데이터가 섞이지는 않습니다(안전 실패).
- **`needsFailureTags` 후속 유도**는 안내 문구까지만 — 저녁 화면에서 S19 회복으로 직접 라우팅하는 건 `ReActionMerged` 상태 변경이 필요해 별도 건으로 뒀습니다.
- FE 테스트 파일이 레포에 0건이라 회귀 테스트를 추가하지 못했습니다(기존 관행).

🤖 Generated with [Claude Code](https://claude.com/claude-code)