### PR TITLE
feat(reflection): S17 저녁 회고 일괄 저장 배선 + step 2/2 목업 제거 (#143)

### DIFF
--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -8,3 +8,13 @@ export function localDateStr(d: Date): string {
   const p = (n: number) => String(n).padStart(2, '0');
   return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`;
 }
+
+// 그 날짜가 속한 주의 월요일 (YYYY-MM-DD). /plans/weekly·/reviews/weekly 의 weekStart 파라미터용.
+//
+// 날짜가 주 경계를 넘으면(일요일의 '내일' = 다음 주 월요일) 그 주의 월요일이 나와야 하므로,
+// 기준 날짜를 받아서 계산한다. 위 localDateStr 를 거치므로 KST 00:00~08:59 밀림(#92) 없음.
+export function weekStartStr(d: Date): string {
+  const monday = new Date(d);
+  monday.setDate(monday.getDate() - ((monday.getDay() + 6) % 7));
+  return localDateStr(monday);
+}

--- a/src/screens/EveningCheckInScreen.tsx
+++ b/src/screens/EveningCheckInScreen.tsx
@@ -1,8 +1,14 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { CheckCircle } from '@phosphor-icons/react';
 import { DemoNotice } from '../components/DemoNotice';
-import { reflectionApi } from '../lib/api';
-import type { ReflectionPendingItem } from '../types/api';
+import { plansApi, reflectionApi } from '../lib/api';
+import { localDateStr, weekStartStr } from '../lib/dates';
+import type {
+  CompletionStatus,
+  ReflectionBatchItem,
+  ReflectionPendingItem,
+  WeeklyBlock,
+} from '../types/api';
 
 interface EveningCheckInScreenProps {
   onDone: () => void;
@@ -27,17 +33,49 @@ const energyOptions = [
   { v: 5, label: '최상이에요', color: 'var(--brand)' },
 ];
 
+// Quick Check-in 4칩 (베이스라인 §1.4). 톤 잠금 "Be on your side, not on your case" —
+// 라벨에 '실패'·'못했' 같은 심판 어휘를 쓰지 않는다.
+// 용어는 오늘 화면(TodayScreen '일부만 함'/'잘 안됨')과 통일한다. 회복 코치(S19)도
+// "'일부만' 또는 '잘 안됨' 으로 표시한 카드" 라고 안내하므로 같은 말을 써야 흐름이 이어진다.
+const statusOptions: { v: CompletionStatus; label: string; color: string }[] = [
+  { v: 'done', label: '했어요', color: 'var(--success)' },
+  { v: 'partial_done', label: '일부만', color: 'var(--brand)' },
+  { v: 'failed', label: '잘 안됐어요', color: 'var(--text-3)' },
+  { v: 'over_done', label: '더 했어요', color: 'var(--brand)' },
+];
+
+// 같은 내용의 [모두 완료] 재전송은 같은 키 → 서버가 24h 안에 1회만 처리(중복 탭 방지).
+// 매번 새 키(Date.now() 등)를 쓰면 멱등 보호가 통째로 무력해진다.
+// 선택을 바꾸면 키도 바뀌어야 한다 — 같은 키에 다른 body 면 서버가 409 를 낸다.
+// 해시 충돌 시엔 409 를 받을 뿐 데이터가 섞이지는 않는다(안전 실패).
+function idempotencyKeyFor(items: ReflectionBatchItem[]): string {
+  const canonical = items
+    .map((i) => `${i.executionId}:${i.completionStatus}`)
+    .sort()
+    .join('|');
+  let h = 0;
+  for (let i = 0; i < canonical.length; i += 1) {
+    h = (Math.imul(31, h) + canonical.charCodeAt(i)) | 0;
+  }
+  return `batch-${(h >>> 0).toString(36)}-${items.length}`;
+}
+
 export function EveningCheckInScreen({ onDone }: EveningCheckInScreenProps) {
   const [step, setStep] = useState(0);
   const [energy, setEnergy] = useState<number | null>(null);
 
-  // GET /reflection/pending (#83) 은 백엔드 구현됨 — 최근 3일 미체크(in_progress) 실행을
-  // 실데이터로 보여준다. 실패 시 더미로 가리지 않고 빈 목록 + 안내로 정직하게(목업 제거 방침).
-  // /reflection/batch 저장은 이 화면이 에너지 1종만 모아 계약(executionId·completionStatus)에
-  // 안 맞아 아직 로컬 흐름만 유지한다(#82).
+  // GET /reflection/pending (#83) — 최근 3일 미체크(in_progress) 실행. 실패 시 더미로 가리지
+  // 않고 빈 목록 + 안내로 정직하게(목업 제거 방침).
   const [pending, setPending] = useState<ReflectionPendingItem[]>([]);
   const [usingRealPending, setUsingRealPending] = useState(false);
   const [pendingLoading, setPendingLoading] = useState(true);
+
+  // executionId → 사용자가 고른 4칩. 미선택 항목은 batch 에서 빠진다(강제하지 않는다).
+  const [picked, setPicked] = useState<Record<string, CompletionStatus>>({});
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  // 실패/부분완료인데 사유를 안 남긴 항목 — 서버가 알려준다(S18 유도 대상).
+  const [needsTags, setNeedsTags] = useState<string[]>([]);
 
   useEffect(() => {
     let cancelled = false;
@@ -53,6 +91,35 @@ export function EveningCheckInScreen({ onDone }: EveningCheckInScreenProps) {
     return () => { cancelled = true; };
   }, []);
 
+  const items = useMemo<ReflectionBatchItem[]>(
+    () => pending
+      .filter((p) => picked[p.executionId])
+      .map((p) => ({ executionId: p.executionId, completionStatus: picked[p.executionId] })),
+    [pending, picked],
+  );
+
+  // 창 밖(어제·그제) 건이 섞여 있으면 배너로 알린다 — "어제 회고 못한 것도 함께 정리해요".
+  const carriedOver = pending.filter((p) => relDayLabel(p.scheduledDate) !== '오늘').length;
+
+  const goNext = () => {
+    setSubmitError(null);
+    if (items.length === 0) { setStep(1); return; }
+    setSubmitting(true);
+    reflectionApi.batch({ items }, idempotencyKeyFor(items)).then(
+      (res) => {
+        setNeedsTags(res.needsFailureTags);
+        // 종결된 실행은 더 이상 미체크가 아니다 — 목록에서 뺀다.
+        const done = new Set(items.map((i) => i.executionId));
+        setPending((ps) => ps.filter((p) => !done.has(p.executionId)));
+        setStep(1);
+      },
+      () => {
+        // 저장 실패를 삼키지 않는다 — 삼키면 사용자는 기록된 줄 알고 넘어간다.
+        setSubmitError('기록을 저장하지 못했어요. 잠시 후 다시 시도해 주세요.');
+      },
+    ).finally(() => setSubmitting(false));
+  };
+
   if (step === 2) {
     const selectedEnergy = energyOptions.find((e) => e.v === energy);
     return (
@@ -62,12 +129,19 @@ export function EveningCheckInScreen({ onDone }: EveningCheckInScreenProps) {
         </div>
         <div style={{ fontFamily: 'var(--font-display)', fontSize: 28, fontWeight: 500, letterSpacing: '-0.01em' }}>저녁 체크인 완료.</div>
         <p style={{ fontSize: 14, color: 'var(--text-2)', lineHeight: 1.6, maxWidth: 260 }}>오늘의 실행 데이터가 저장됐어요. 내일 아침에 맞춤 모닝 브리프가 준비될 거예요.</p>
-        <div style={{ padding: '10px 14px', background: 'var(--brand-soft)', borderRadius: 12, border: '1px solid var(--coral-200)', fontSize: 12, color: 'var(--coral-700)', textAlign: 'left', width: '100%' }}>
-          <b>내일 반영 사항:</b><br />에너지 "{selectedEnergy?.label}" 기록 → 내일 블록 강도 자동 조정
-        </div>
+        {selectedEnergy && (
+          <div style={{ padding: '10px 14px', background: 'var(--brand-soft)', borderRadius: 12, border: '1px solid var(--coral-200)', fontSize: 12, color: 'var(--coral-700)', textAlign: 'left', width: '100%' }}>
+            <b>내일 반영 사항:</b><br />에너지 "{selectedEnergy.label}" 기록 → 내일 블록 강도 자동 조정
+          </div>
+        )}
+        {needsTags.length > 0 && (
+          <div style={{ padding: '10px 14px', background: 'var(--surface-raised)', borderRadius: 12, border: '1px solid var(--sand-200)', fontSize: 12, color: 'var(--text-2)', textAlign: 'left', width: '100%', lineHeight: 1.55 }}>
+            {needsTags.length}건은 무엇이 막았는지 남기면 그에 맞는 회복안을 제안해드려요. 오늘 화면에서 카드를 열면 이어서 할 수 있어요.
+          </div>
+        )}
         <div style={{ width: '100%' }}>
-          <DemoNotice storageKey="evening-batch">
-            이 데모에서는 에너지 기록이 임시 저장돼요. 실행별 소급 회고(일괄 저장)는 곧 연결됩니다.
+          <DemoNotice storageKey="evening-energy">
+            에너지 기록은 아직 임시 저장돼요(저장 계약 준비 중). 실행별 회고는 실제로 저장됩니다.
           </DemoNotice>
         </div>
         <button onClick={onDone} style={{ width: '100%', height: 44, borderRadius: 12, border: 'none', background: 'var(--text-1)', color: '#FAF6EE', fontWeight: 700, fontSize: 14, fontFamily: 'inherit', cursor: 'pointer' }}>주간 계획 보기 →</button>
@@ -76,36 +150,7 @@ export function EveningCheckInScreen({ onDone }: EveningCheckInScreenProps) {
   }
 
   if (step === 1) {
-    return (
-      <div style={{ height: '100%', overflowY: 'auto', padding: '16px 18px 32px', background: 'var(--surface-ground)', display: 'flex', flexDirection: 'column', gap: 14 }}>
-        <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--text-3)', fontFamily: 'var(--font-mono)' }}>저녁 체크인 · 2/2</div>
-        <h2 style={{ fontSize: 22, fontWeight: 700, letterSpacing: '-0.02em', margin: '0 0 6px' }}>내일 계획 미리보기</h2>
-        <div style={{ background: '#FBEEDA', border: '1px solid #F2D29A', borderRadius: 14, padding: 14 }}>
-          <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--warning)', marginBottom: 6 }}>↩ 이월 예정</div>
-          <div style={{ fontSize: 14, fontWeight: 700, color: 'var(--text-1)' }}>GROUP BY / HAVING 실습</div>
-          <div style={{ fontSize: 11, color: 'var(--text-3)', marginTop: 4 }}>오늘 미완료 → 내일 목요일 21:00으로 자동 배치</div>
-        </div>
-        <div style={{ background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', borderRadius: 14, padding: 14 }}>
-          <div style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-3)', marginBottom: 10 }}>목요일 예정 블록</div>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-            {[
-              { t: '전공 수업', time: '19:00', dur: '120분', carry: false },
-              { t: 'GROUP BY / HAVING 실습 (이월)', time: '21:30', dur: '60분', carry: true },
-            ].map((b, i) => (
-              <div key={i} style={{ display: 'flex', gap: 10, alignItems: 'center' }}>
-                <div className="tnum" style={{ width: 38, fontSize: 10, fontFamily: 'var(--font-mono)', color: 'var(--text-3)' }}>{b.time}</div>
-                <div style={{ flex: 1, fontSize: 13, fontWeight: 500, color: b.carry ? 'var(--warning)' : 'var(--text-1)' }}>{b.t}</div>
-                <span style={{ height: 'var(--ctrl-xs)', padding: '0 7px', background: 'var(--sand-100)', border: '1px solid var(--sand-200)', borderRadius: 9999, fontSize: 10, color: 'var(--text-2)', display: 'inline-flex', alignItems: 'center' }}>{b.dur}</span>
-              </div>
-            ))}
-          </div>
-        </div>
-        <div style={{ display: 'flex', gap: 8 }}>
-          <button onClick={() => setStep(0)} style={{ flex: 1, height: 44, borderRadius: 12, border: '1px solid var(--sand-200)', background: 'transparent', color: 'var(--text-1)', fontWeight: 600, fontSize: 13, fontFamily: 'inherit', cursor: 'pointer' }}>이전</button>
-          <button onClick={() => setStep(2)} style={{ flex: 2, height: 44, borderRadius: 12, border: 'none', background: 'var(--text-1)', color: '#FAF6EE', fontWeight: 600, fontSize: 13, fontFamily: 'inherit', cursor: 'pointer' }}>확인 →</button>
-        </div>
-      </div>
-    );
+    return <TomorrowPreview onBack={() => setStep(0)} onConfirm={() => setStep(2)} />;
   }
 
   return (
@@ -115,7 +160,7 @@ export function EveningCheckInScreen({ onDone }: EveningCheckInScreenProps) {
       <p style={{ fontSize: 13, color: 'var(--text-2)' }}>에너지 상태를 기록하면 내일 계획에 반영해요.</p>
 
       {/* 최근 3일 미체크(in_progress) 실행 — GET /reflection/pending 실연동 (#83).
-          로딩 중이거나 실제 항목이 있을 때만 박스를 띄우고, 실패 시엔 더미 없이 안내만. */}
+          카드별 4칩을 고르면 [다음]에서 POST /reflection/batch 로 한 번에 종결한다. */}
       {(pendingLoading || pending.length > 0) && (
         <div style={{ background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', borderRadius: 14, padding: 14, display: 'flex', flexDirection: 'column', gap: 10 }}>
           <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between' }}>
@@ -124,17 +169,46 @@ export function EveningCheckInScreen({ onDone }: EveningCheckInScreenProps) {
               <span className="tnum" style={{ fontSize: 11, fontFamily: 'var(--font-mono)', color: 'var(--text-3)' }}>{pending.length}건</span>
             )}
           </div>
+          {!pendingLoading && carriedOver > 0 && (
+            <div style={{ padding: '8px 10px', background: 'var(--brand-soft)', border: '1px solid var(--coral-200)', borderRadius: 10, fontSize: 12, color: 'var(--coral-700)', lineHeight: 1.5 }}>
+              어제·그제 정리 못한 {carriedOver}건도 함께 정리해요.
+            </div>
+          )}
           {pendingLoading ? (
             <div style={{ fontSize: 12, color: 'var(--text-3)' }}>불러오는 중…</div>
           ) : (
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
               {pending.map((p) => (
-                <div key={p.executionId} style={{ display: 'flex', gap: 10, alignItems: 'center' }}>
-                  <span style={{ height: 'var(--ctrl-xs)', minWidth: 34, padding: '0 7px', background: 'var(--sand-100)', border: '1px solid var(--sand-200)', borderRadius: 9999, fontSize: 10, color: 'var(--text-2)', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>{relDayLabel(p.scheduledDate)}</span>
-                  <div style={{ flex: 1, fontSize: 13, fontWeight: 500, color: 'var(--text-1)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{p.title}</div>
-                  {p.scheduledTime && (
-                    <div className="tnum" style={{ fontSize: 10, fontFamily: 'var(--font-mono)', color: 'var(--text-3)', flexShrink: 0 }}>{p.scheduledTime.slice(0, 5)}</div>
-                  )}
+                <div key={p.executionId} style={{ display: 'flex', flexDirection: 'column', gap: 7 }}>
+                  <div style={{ display: 'flex', gap: 10, alignItems: 'center' }}>
+                    <span style={{ height: 'var(--ctrl-xs)', minWidth: 34, padding: '0 7px', background: 'var(--sand-100)', border: '1px solid var(--sand-200)', borderRadius: 9999, fontSize: 10, color: 'var(--text-2)', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>{relDayLabel(p.scheduledDate)}</span>
+                    <div style={{ flex: 1, fontSize: 13, fontWeight: 500, color: 'var(--text-1)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{p.title}</div>
+                    {p.scheduledTime && (
+                      <div className="tnum" style={{ fontSize: 10, fontFamily: 'var(--font-mono)', color: 'var(--text-3)', flexShrink: 0 }}>{p.scheduledTime.slice(0, 5)}</div>
+                    )}
+                  </div>
+                  <div style={{ display: 'flex', gap: 5 }}>
+                    {statusOptions.map((s) => {
+                      const sel = picked[p.executionId] === s.v;
+                      return (
+                        <button
+                          key={s.v}
+                          aria-pressed={sel}
+                          onClick={() => setPicked((m) => {
+                            // 같은 칩을 다시 누르면 선택 해제 — 잘못 누른 걸 되돌릴 수 있어야 한다.
+                            if (m[p.executionId] === s.v) {
+                              const { [p.executionId]: _drop, ...rest } = m;
+                              return rest;
+                            }
+                            return { ...m, [p.executionId]: s.v };
+                          })}
+                          style={{ flex: 1, height: 30, borderRadius: 9999, border: `1px solid ${sel ? 'var(--text-1)' : 'var(--sand-200)'}`, background: sel ? 'var(--text-1)' : 'transparent', color: sel ? '#FAF6EE' : 'var(--text-2)', fontSize: 11, fontWeight: 600, fontFamily: 'inherit', cursor: 'pointer', transition: 'all 140ms' }}
+                        >
+                          {s.label}
+                        </button>
+                      );
+                    })}
+                  </div>
                 </div>
               ))}
             </div>
@@ -155,7 +229,83 @@ export function EveningCheckInScreen({ onDone }: EveningCheckInScreenProps) {
           </button>
         ))}
       </div>
-      <button onClick={() => energy && setStep(1)} style={{ width: '100%', height: 44, borderRadius: 12, border: 'none', background: 'var(--text-1)', color: '#FAF6EE', fontWeight: 700, fontSize: 14, fontFamily: 'inherit', cursor: 'pointer', opacity: energy ? 1 : 0.35 }}>다음 →</button>
+      {submitError && (
+        <div role="alert" style={{ padding: '10px 12px', background: '#FBE9E7', border: '1px solid var(--danger)', borderRadius: 10, fontSize: 12, color: 'var(--danger)', lineHeight: 1.5 }}>
+          {submitError}
+        </div>
+      )}
+      <button
+        onClick={goNext}
+        disabled={!energy || submitting}
+        style={{ width: '100%', height: 44, borderRadius: 12, border: 'none', background: 'var(--text-1)', color: '#FAF6EE', fontWeight: 700, fontSize: 14, fontFamily: 'inherit', cursor: energy && !submitting ? 'pointer' : 'default', opacity: energy && !submitting ? 1 : 0.35 }}
+      >
+        {submitting ? '기록하는 중…' : items.length > 0 ? `${items.length}건 기록하고 다음 →` : '다음 →'}
+      </button>
+    </div>
+  );
+}
+
+// 내일 예정 블록 — GET /plans/weekly 실데이터. (예전엔 요일·제목이 통째로 하드코딩돼 있어
+// 금요일에도 "내일 목요일"이 뜨고 21:00/21:30 이 서로 모순됐다.)
+function TomorrowPreview({ onBack, onConfirm }: { onBack: () => void; onConfirm: () => void }) {
+  const [blocks, setBlocks] = useState<WeeklyBlock[] | null>(null);
+  const [failed, setFailed] = useState(false);
+
+  const tomorrow = useMemo(() => {
+    const d = new Date();
+    d.setDate(d.getDate() + 1);
+    return d;
+  }, []);
+  const tomorrowStr = localDateStr(tomorrow);
+  const weekdayLabel = ['일', '월', '화', '수', '목', '금', '토'][tomorrow.getDay()];
+
+  useEffect(() => {
+    let cancelled = false;
+    // 내일이 다음 주면(일요일의 내일) 그 주의 월요일로 조회해야 한다.
+    plansApi.weekly(weekStartStr(tomorrow)).then(
+      (plan) => {
+        if (cancelled) return;
+        const day = plan.days.find((d) => d.date === tomorrowStr);
+        setBlocks(day?.blocks ?? []);
+      },
+      () => { if (!cancelled) setFailed(true); },
+    );
+    return () => { cancelled = true; };
+  }, [tomorrowStr, tomorrow]);
+
+  return (
+    <div style={{ height: '100%', overflowY: 'auto', padding: '16px 18px 32px', background: 'var(--surface-ground)', display: 'flex', flexDirection: 'column', gap: 14 }}>
+      <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--text-3)', fontFamily: 'var(--font-mono)' }}>저녁 체크인 · 2/2</div>
+      <h2 style={{ fontSize: 22, fontWeight: 700, letterSpacing: '-0.02em', margin: '0 0 6px' }}>내일 계획 미리보기</h2>
+      <div style={{ background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', borderRadius: 14, padding: 14 }}>
+        <div style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-3)', marginBottom: 10 }}>{weekdayLabel}요일 예정 블록 · {tomorrowStr.slice(5)}</div>
+        {blocks === null && !failed && <div style={{ fontSize: 12, color: 'var(--text-3)' }}>불러오는 중…</div>}
+        {failed && <div style={{ fontSize: 12, color: 'var(--text-3)' }}>내일 계획을 불러오지 못했어요.</div>}
+        {blocks !== null && blocks.length === 0 && (
+          <div style={{ fontSize: 12, color: 'var(--text-3)' }}>아직 잡힌 블록이 없어요. 주간 계획에서 추가할 수 있어요.</div>
+        )}
+        {blocks !== null && blocks.length > 0 && (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            {blocks.map((b) => {
+              const start = new Date(b.startAt);
+              const end = new Date(b.endAt);
+              const mins = Math.max(Math.round((end.getTime() - start.getTime()) / 60000), 0);
+              const hhmm = `${String(start.getHours()).padStart(2, '0')}:${String(start.getMinutes()).padStart(2, '0')}`;
+              return (
+                <div key={b.blockId} style={{ display: 'flex', gap: 10, alignItems: 'center' }}>
+                  <div className="tnum" style={{ width: 38, fontSize: 10, fontFamily: 'var(--font-mono)', color: 'var(--text-3)', flexShrink: 0 }}>{hhmm}</div>
+                  <div style={{ flex: 1, fontSize: 13, fontWeight: 500, color: 'var(--text-1)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{b.title}</div>
+                  <span style={{ height: 'var(--ctrl-xs)', padding: '0 7px', background: 'var(--sand-100)', border: '1px solid var(--sand-200)', borderRadius: 9999, fontSize: 10, color: 'var(--text-2)', display: 'inline-flex', alignItems: 'center', flexShrink: 0 }}>{mins}분</span>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+      <div style={{ display: 'flex', gap: 8 }}>
+        <button onClick={onBack} style={{ flex: 1, height: 44, borderRadius: 12, border: '1px solid var(--sand-200)', background: 'transparent', color: 'var(--text-1)', fontWeight: 600, fontSize: 13, fontFamily: 'inherit', cursor: 'pointer' }}>이전</button>
+        <button onClick={onConfirm} style={{ flex: 2, height: 44, borderRadius: 12, border: 'none', background: 'var(--text-1)', color: '#FAF6EE', fontWeight: 600, fontSize: 13, fontFamily: 'inherit', cursor: 'pointer' }}>확인 →</button>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## 배경 (Closes #143)
- `reflectionApi.batch` 가 **정의만 되고 호출부 0건** — 화면에 회고를 저장할 방법이 없었다.
- step 2/2 '내일 계획 미리보기'가 **전체 하드코딩** — 금요일에 열어도 "내일 목요일 21:00", 같은 화면의 "목요일 예정 블록"은 21:30 이라 자기모순(목업 제거 3차례에서 누락된 자리).

> 참고 구현인 **closed PR #142** 를 cherry-pick 후 톤/용어만 수정했습니다.

## S17 일괄 회고
- 카드별 **Quick Check-in 4칩** → `POST /reflection/batch` 일괄 종결. 미선택 항목은 payload 에서 제외(강제 X), 같은 칩 재탭 = 선택 해제.
- **Idempotency-Key 를 payload 에서 파생**(내용 해시). 매번 새 키(`Date.now()`)면 중복 탭 방지가 통째로 무력해짐 — 선택이 바뀌면 키도 바뀜.
- **저장 실패를 삼키지 않음**: 오류 노출 + 진행 중단(완료 화면으로 안 넘어감) → 조용한 데이터 유실 방지.
- 창 밖(어제·그제) 건 배너, 응답 `needsFailureTags` 안내(S19 회복안 유도).

## step 2/2 목업 제거
- `GET /plans/weekly` 실데이터로 교체(실제 요일·날짜·블록·소요분).
- **주 경계 안전**: `lib/dates.ts` 에 `weekStartStr` 공유 헬퍼 추가(일요일의 '내일' = 다음 주 월요일). `localDateStr` 경유로 KST 00:00~08:59 밀림(#92) 없음.
- 로딩 / 실패 / 빈 계획 상태를 각각 정직하게 표시.
- 에너지는 저장 계약 부재(BE #141) → DemoNotice 를 "에너지만 임시 저장, **실행별 회고는 실제로 저장됩니다**" 로 정정.

## 톤 — 참고 PR 대비 수정한 부분
PR #142 의 라벨 `조금`/`못 했어요` 는 이슈가 명시한 톤 잠금('실패'·'못했' 금지)에 **스스로 어긋나고**, 오늘 화면 용어와도 불일치했습니다. 회복 코치(S19)가 *"'일부만' 또는 '잘 안됨' 으로 표시한 카드"* 라고 안내하므로 같은 말을 써야 흐름이 이어집니다.
→ **`했어요 / 일부만 / 잘 안됐어요 / 더 했어요`** 로 통일.

## 검증 (Playwright, mock)
- 4칩 노출, **금지어(`못 했어요`·`조금`) 0건**, 이월 배너 1건
- `batch` 1회 호출, items `[{exec_a1,done},{exec_b2,failed}]`, key `batch-ahgytz-2`
- **동일 선택 재시도 → 동일 키**(payload 파생 확인)
- 7/17(금) → `weekStart=2026-07-13` 조회 + **"토요일 예정 블록 · 07-18"** 실데이터, 하드코딩 "목요일" 소멸
- batch 500 → **에러 노출 후 진행 중단**(step2 진입 안 함)

`tsc` / `check-api-contract`(PASS) / `build` 클린.

## 범위 밖 (별도 처리 필요)
- **에너지 기록**: 백엔드 저장 계약 부재 → BE #141 선행.
- **`RecoveredScreen.tsx` 의 `replan-${Date.now()}`**: 이슈가 지적한 같은 계열의 멱등키 버그지만 S17 범위 밖이라 손대지 않았습니다. 별도 이슈로 파거나 이어서 고치면 됩니다.

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)