### PR TITLE
chore(api): 백엔드 API 동기화 (routine)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -426,9 +426,80 @@
         "title": "AvailabilityProfile",
         "type": "object"
       },
-      "BlockEditRequest": {
-        "description": "PATCH /plans/{planId}/blocks/{blockId} — 15분 snap 이동.\n\n`endAt` 생략 시 기존 길이를 보존한 채 시작만 옮긴다. 시각은 KST ISO 8601.",
+      "BehavioralProfileView": {
+        "description": "behavioral_profiles 의 사용자 편집 대상 필드.",
         "properties": {
+          "attentionSpan": {
+            "title": "Attentionspan",
+            "type": "integer"
+          },
+          "energyCycle": {
+            "enum": [
+              "morning",
+              "afternoon",
+              "evening",
+              "night",
+              "varies"
+            ],
+            "title": "Energycycle",
+            "type": "string"
+          },
+          "preferredEndTime": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Preferredendtime"
+          },
+          "preferredStartTime": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Preferredstarttime"
+          },
+          "timeChunkPreference": {
+            "enum": [
+              "10",
+              "20",
+              "30",
+              "60",
+              "90"
+            ],
+            "title": "Timechunkpreference",
+            "type": "string"
+          }
+        },
+        "required": [
+          "energyCycle",
+          "attentionSpan",
+          "timeChunkPreference"
+        ],
+        "title": "BehavioralProfileView",
+        "type": "object"
+      },
+      "BlockEditRequest": {
+        "description": "PATCH /plans/{planId}/blocks/{blockId} — 15분 snap 이동 + 목표(category)/제목 수정.\n\n`endAt` 생략 시 기존 길이를 보존한 채 시작만 옮긴다. 시각은 KST ISO 8601.\n`category`/`title` 을 주면 블록이 매달린 action_item 을 갱신한다 — 같은 액션의 모든\n세션 블록에 반영되며, 미지원 category 는 'other' 로 정규화한다. 미지정 필드는 유지.",
+        "properties": {
+          "category": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Category"
+          },
           "endAt": {
             "anyOf": [
               {
@@ -443,6 +514,17 @@
           "startAt": {
             "title": "Startat",
             "type": "string"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
           }
         },
         "required": [
@@ -1025,6 +1107,16 @@
       "FirstPlanGenerateRequest": {
         "description": "POST /plans/generate (첫 계획) 요청.\n\n`interview_session_id` 로 확정된 `InterviewOutcome` 을 참조하거나(서버가 로드),\n온보딩 흐름에서 outcome 을 인라인 전달할 수 있다(`outcome`). 둘 중 하나는 필수 —\n검증은 라우터/오케스트레이터 VALIDATING 단계에서 수행.",
         "properties": {
+          "density": {
+            "default": "standard",
+            "enum": [
+              "light",
+              "standard",
+              "intense"
+            ],
+            "title": "Density",
+            "type": "string"
+          },
           "interviewSessionId": {
             "anyOf": [
               {
@@ -1045,6 +1137,15 @@
                 "type": "null"
               }
             ]
+          },
+          "scope": {
+            "default": "horizon",
+            "enum": [
+              "week",
+              "horizon"
+            ],
+            "title": "Scope",
+            "type": "string"
           },
           "targetDate": {
             "anyOf": [
@@ -1367,6 +1468,17 @@
             "minimum": 0.0,
             "title": "Confidence",
             "type": "number"
+          },
+          "currentLevel": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Currentlevel"
           },
           "deadline": {
             "anyOf": [
@@ -2099,6 +2211,21 @@
             ],
             "title": "Promotedgoalid"
           },
+          "promotedTo": {
+            "anyOf": [
+              {
+                "enum": [
+                  "goal",
+                  "action"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Promotedto"
+          },
           "rawText": {
             "title": "Rawtext",
             "type": "string"
@@ -2171,6 +2298,55 @@
           }
         },
         "title": "InboxUpdateRequest",
+        "type": "object"
+      },
+      "InteractionStyleView": {
+        "description": "interaction_styles 의 사용자 편집 대상 필드.",
+        "properties": {
+          "explanationDepth": {
+            "enum": [
+              "brief",
+              "normal",
+              "detailed"
+            ],
+            "title": "Explanationdepth",
+            "type": "string"
+          },
+          "recoveryTone": {
+            "enum": [
+              "gentle",
+              "normal",
+              "encouraging"
+            ],
+            "title": "Recoverytone",
+            "type": "string"
+          },
+          "reminderFrequency": {
+            "enum": [
+              "minimal",
+              "standard",
+              "active"
+            ],
+            "title": "Reminderfrequency",
+            "type": "string"
+          },
+          "suggestionStyle": {
+            "enum": [
+              "soft",
+              "neutral",
+              "firm"
+            ],
+            "title": "Suggestionstyle",
+            "type": "string"
+          }
+        },
+        "required": [
+          "recoveryTone",
+          "suggestionStyle",
+          "explanationDepth",
+          "reminderFrequency"
+        ],
+        "title": "InteractionStyleView",
         "type": "object"
       },
       "InterviewOutcome": {
@@ -2705,6 +2881,203 @@
         "title": "PreferenceProfile",
         "type": "object"
       },
+      "ProfileResponse": {
+        "description": "GET/PATCH /settings/profile — 지속형 프로필 메모리.\n\n인터뷰가 아직 안 채웠으면 각 항목 null (행 없음).\n`downscopeUnitMin`/`restOk` 는 회복 선호 — `users.focus_mode_preferences`(JSONB) 출처.",
+        "properties": {
+          "behavioral": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BehavioralProfileView"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "downscopeUnitMin": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Downscopeunitmin"
+          },
+          "interaction": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/InteractionStyleView"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "restOk": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Restok"
+          }
+        },
+        "required": [
+          "behavioral",
+          "interaction"
+        ],
+        "title": "ProfileResponse",
+        "type": "object"
+      },
+      "ProfileUpdateRequest": {
+        "description": "PATCH /settings/profile — 지정 필드만 부분 갱신. 미지정(None)은 유지.\n\nenum 외 값은 Pydantic Literal → 422 `COMMON_VALIDATION_ERROR`.",
+        "properties": {
+          "attentionSpan": {
+            "anyOf": [
+              {
+                "maximum": 240.0,
+                "minimum": 5.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Attentionspan"
+          },
+          "downscopeUnitMin": {
+            "anyOf": [
+              {
+                "maximum": 120.0,
+                "minimum": 1.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Downscopeunitmin"
+          },
+          "energyCycle": {
+            "anyOf": [
+              {
+                "enum": [
+                  "morning",
+                  "afternoon",
+                  "evening",
+                  "night",
+                  "varies"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Energycycle"
+          },
+          "explanationDepth": {
+            "anyOf": [
+              {
+                "enum": [
+                  "brief",
+                  "normal",
+                  "detailed"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Explanationdepth"
+          },
+          "recoveryTone": {
+            "anyOf": [
+              {
+                "enum": [
+                  "gentle",
+                  "normal",
+                  "encouraging"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recoverytone"
+          },
+          "reminderFrequency": {
+            "anyOf": [
+              {
+                "enum": [
+                  "minimal",
+                  "standard",
+                  "active"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reminderfrequency"
+          },
+          "restOk": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Restok"
+          },
+          "suggestionStyle": {
+            "anyOf": [
+              {
+                "enum": [
+                  "soft",
+                  "neutral",
+                  "firm"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Suggestionstyle"
+          },
+          "timeChunkPreference": {
+            "anyOf": [
+              {
+                "enum": [
+                  "10",
+                  "20",
+                  "30",
+                  "60",
+                  "90"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Timechunkpreference"
+          }
+        },
+        "title": "ProfileUpdateRequest",
+        "type": "object"
+      },
       "PushSubscribeRequest": {
         "description": "POST /notifications/subscribe 요청 — Web Push subscription 객체.",
         "properties": {
@@ -3223,6 +3596,53 @@
         "title": "ReplanBlock",
         "type": "object"
       },
+      "ReplanBlockPreview": {
+        "description": "재계획 미리보기 블록 — 기존 ActionItem 에 연결(actionId). 시각은 KST.\n\n`replacesBlockId` 는 이 새 블록이 교체하는 옛 미래 블록의 **대표 id**(미리보기용, 없으면\n백로그라 null). 실제 승인 재조정은 payload 의 `oldBlocks`(액션당 옛 블록 **전부**)를 권위로\n삼아 액션 단위로 취소·생성한다 — 한 액션이 여러 세션으로 쪼개진 경우까지 정확히(#117).",
+        "properties": {
+          "actionId": {
+            "title": "Actionid",
+            "type": "string"
+          },
+          "category": {
+            "title": "Category",
+            "type": "string"
+          },
+          "end": {
+            "format": "date-time",
+            "title": "End",
+            "type": "string"
+          },
+          "replacesBlockId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Replacesblockid"
+          },
+          "start": {
+            "format": "date-time",
+            "title": "Start",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "actionId",
+          "title",
+          "category",
+          "start",
+          "end"
+        ],
+        "title": "ReplanBlockPreview",
+        "type": "object"
+      },
       "ReplanDiffResponse": {
         "description": "GET /replan/{executionId} — S20 before/after 프리뷰 (Draft Layer).\n\n승인 전까지 `is_draft=True`. `already_approved=True` 면 이미 approve 로 블록이\n배치된 상태(멱등 재조회).",
         "properties": {
@@ -3273,6 +3693,72 @@
           "after"
         ],
         "title": "ReplanDiffResponse",
+        "type": "object"
+      },
+      "ReplanResponse": {
+        "description": "주간 재계획 미리보기 — 항상 Draft. 승인은 `/plans/replan/{planId}/approve`.",
+        "properties": {
+          "aiSource": {
+            "default": "llm",
+            "enum": [
+              "llm",
+              "rule"
+            ],
+            "title": "Aisource",
+            "type": "string"
+          },
+          "blocks": {
+            "items": {
+              "$ref": "#/components/schemas/ReplanBlockPreview"
+            },
+            "title": "Blocks",
+            "type": "array"
+          },
+          "generatedAt": {
+            "format": "date-time",
+            "title": "Generatedat",
+            "type": "string"
+          },
+          "horizon": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Horizon"
+          },
+          "isDraft": {
+            "default": true,
+            "title": "Isdraft",
+            "type": "boolean"
+          },
+          "planId": {
+            "title": "Planid",
+            "type": "string"
+          },
+          "warnings": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Warnings",
+            "type": "array"
+          },
+          "windowStart": {
+            "title": "Windowstart",
+            "type": "string"
+          }
+        },
+        "required": [
+          "planId",
+          "windowStart",
+          "horizon",
+          "blocks",
+          "generatedAt"
+        ],
+        "title": "ReplanResponse",
         "type": "object"
       },
       "ScheduledBlockPreview": {
@@ -3863,6 +4349,47 @@
           "days"
         ],
         "title": "WeeklyPlanResponse",
+        "type": "object"
+      },
+      "WeeklyReplanApproveResponse": {
+        "description": "주간 forward 재계획 승인 결과 — 재조정 카운트. `is_draft=False`.\n\nstarted/finished 로 바뀐 옛 블록·다른 계획 승인분은 건드리지 않으므로(재조정),\n`skipped` 는 그렇게 보존된 항목 수다.\n\n⚠️ 이름 주의: `schemas/recovery.py` 의 `ReplanApproveResponse`(S20 실행단위 replan,\n`POST /replan/{executionId}/approve`)와 **다른 것**이다. 같은 이름을 쓰면 FastAPI 가\n중복 모델명을 양쪽 다 full-qualify 로 바꿔(`reaction_backend__schemas__recovery__...`)\n이 PR 이 건드리지도 않은 회복 endpoint 의 OpenAPI 컴포넌트명이 변하고 FE 생성\n클라이언트가 깨진다. 'Weekly' 접두사는 그 충돌을 피하기 위한 것 — 지우지 말 것.",
+        "properties": {
+          "activatedAt": {
+            "format": "date-time",
+            "title": "Activatedat",
+            "type": "string"
+          },
+          "cancelledBlocks": {
+            "title": "Cancelledblocks",
+            "type": "integer"
+          },
+          "createdBlocks": {
+            "title": "Createdblocks",
+            "type": "integer"
+          },
+          "isDraft": {
+            "const": false,
+            "default": false,
+            "title": "Isdraft",
+            "type": "boolean"
+          },
+          "planId": {
+            "title": "Planid",
+            "type": "string"
+          },
+          "skippedBlocks": {
+            "title": "Skippedblocks",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "planId",
+          "cancelledBlocks",
+          "createdBlocks",
+          "skippedBlocks",
+          "activatedAt"
+        ],
+        "title": "WeeklyReplanApproveResponse",
         "type": "object"
       },
       "WeeklyReviewResponse": {
@@ -5428,7 +5955,7 @@
     },
     "/inbox": {
       "get": {
-        "description": "내 inbox 항목. `?status=captured|classified|promoted` 필터.",
+        "description": "내 inbox 항목. `?status=captured|classified|promoted|archived` 필터.\n\n`status` 미지정 시 활성 항목(archived 제외)만. `status=archived` 는 보관함(soft-deleted)\n조회 — `POST /inbox/{id}/restore` 로 되살릴 수 있다.",
         "operationId": "list_inbox_inbox_get",
         "parameters": [
           {
@@ -5788,6 +6315,65 @@
           }
         },
         "summary": "Convert To Goal",
+        "tags": [
+          "inbox"
+        ]
+      }
+    },
+    "/inbox/{inbox_id}/restore": {
+      "post": {
+        "description": "보관 취소 — `archived_at` 클리어 + status 를 활성(classified/captured)으로 복원.\n\n보관함(`status=archived`)에서만 의미. 이미 활성이면 멱등(현재 상태 그대로 반환).\n존재하지 않으면 404 `INBOX_NOT_FOUND`. hard delete 는 없으므로 언제든 되살릴 수 있다.",
+        "operationId": "restore_inbox_inbox__inbox_id__restore_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "inbox_id",
+            "required": true,
+            "schema": {
+              "title": "Inbox Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InboxItem"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Restore Inbox",
         "tags": [
           "inbox"
         ]
@@ -6462,6 +7048,115 @@
         ]
       }
     },
+    "/plans/replan": {
+      "post": {
+        "description": "주간 리포트를 작성하고, 남은 작업 + 수락한 회복을 **다음 주부터 마감까지** 다시 배치.\n\n- 대상: 다음 주 이후 미착수 블록의 액션 + 활성 블록 없는 planned 백로그(수락한 회복 포함).\n  과거·시작/완료·user_edit 블록은 불변. 실패 원본은 미래 블록이 없어 자동 제외.\n- busy = 확정(시작/완료·user_edit) 블록 + DB 시간정책 + **고정일정(#112 정합)**.\n- 각 새 블록에 '교체할 옛 블록 id'(replacesBlockId)를 실어, 승인이 blanket-cancel 없이\n  그 블록만 현재 상태로 재조정 취소하게 한다(#117). 산출물은 Draft — 자동 적용 금지.",
+        "operationId": "generate_replan_plans_replan_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReplanResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Generate Replan",
+        "tags": [
+          "planning"
+        ]
+      }
+    },
+    "/plans/replan/{plan_id}/approve": {
+      "post": {
+        "description": "재계획 Draft 승인 → **action 단위 재조정**으로 미래 블록 교체(#117 재작업).\n\n#115 스케줄러가 긴 액션을 **여러 세션 블록**으로 쪼개므로, 재조정은 개별 블록이 아니라\n**액션당 '옛 블록 집합'(payload `oldBlocks`)** 을 통째 다룬다 — 옛 블록 1개만 취소하면\n나머지가 유령으로 남거나 새 세션이 드롭되던 문제 방지(리뷰 대응). 액션마다 현재 DB 상태로:\n- 옛 블록 집합 중 하나라도 `started/finished`(사용자 착수) → 이 액션 **전체 보존**(skip).\n- 활성(`scheduled`) 옛 블록이 하나도 없음(그새 전부 취소·삭제) → 중복 방지 skip.\n- 그 외 → 활성 옛 블록 **전부 취소** + 새 세션 블록 **전부 생성**.\n- 백로그(옛 블록 없음): 그새 그 action 이 활성 블록을 얻었으면 생성 skip.\n- action 이 그새 아카이브/삭제됐으면(예: #113 First Plan 교체) 전체 skip(좀비 블록 방지).\n\nDraft 로드·검사~쓰기를 `user_agent_lock`(xact-scoped) 안에서 단일 commit 으로 원자화한다\n(동시 더블 승인 봉합, #113 패턴). 과거·시작/완료·user_edit 블록은 불변. 항상 Draft→HITL.",
+        "operationId": "approve_replan_plans_replan__plan_id__approve_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "plan_id",
+            "required": true,
+            "schema": {
+              "title": "Plan Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WeeklyReplanApproveResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Approve Replan",
+        "tags": [
+          "planning"
+        ]
+      }
+    },
     "/plans/weekly": {
       "get": {
         "description": "주간 블록 그리드 (S14). weekStart 생략 시 이번 주 월요일 기준.",
@@ -6530,7 +7225,7 @@
     },
     "/plans/{plan_id}": {
       "get": {
-        "description": "저장된 First Plan Draft 미리보기 — LLM 재호출 없이 스냅샷 재구성.",
+        "description": "저장된 First Plan Draft 미리보기 — LLM 재호출 없이 스냅샷 재구성.\n\n재계획(`kind='replan'`) Draft 는 payload 모양이 달라(goal_nodes 가 없다) 여기서 다루지\n않는다 — 가드가 없으면 `_draft_to_response` 가 `KeyError: 'goal_nodes'` 로 500 을 낸다.\n승인 endpoint 의 반대편 가드(approve_replan 의 `kind != \"replan\"` 검사)와 대칭.",
         "operationId": "get_plan_plans__plan_id__get",
         "parameters": [
           {
@@ -6589,7 +7284,7 @@
     },
     "/plans/{plan_id}/approve": {
       "post": {
-        "description": "First Plan Draft 승인 → SAVING (goal 트리 단일 가드 트랜잭션 영속화, ADR-0005 §2.5.1).\n\n`plan_id` 로 저장된 Draft 를 로드해 goals/goal_nodes/action_items/scheduled_blocks 를\n단일 트랜잭션으로 영속화(+최대 3회 재시도). `policy_guarded_transaction`(PR #30 재사용)이\n절대 시간 정책 위반 시 롤백 → 422 `PLAN_POLICY_VIOLATION`, 그 외 실패는 롤백 후 500\n`PLAN_SAVE_FAILED`. 만료된 Draft 는 410 `PLAN_DRAFT_EXPIRED`. 이미 승인된 Draft 는 멱등.\n\n부수 효과: 첫 계획 승인 = 온보딩 완료 → onboarding_state 를 `ACTIVE` 로 전이(멱등,\n어느 온보딩 단계에서든). 원설계(FIRST_PLAN → NOTIFICATIONS)는 실제 FE 흐름에서 상태가\nWELCOME 에 고정돼 새로고침 시 재-온보딩되던 문제가 있어 승인에서 ACTIVE 로 마감\n(api-contract §3).\n응답은 명시 승인이므로 `is_draft=false` (ADR-0005 §7.2).",
+        "description": "First Plan Draft 승인 → SAVING (goal 트리 단일 가드 트랜잭션 영속화, ADR-0005 §2.5.1).\n\n`plan_id` 로 저장된 Draft 를 로드해 goals/goal_nodes/action_items/scheduled_blocks 를\n단일 트랜잭션으로 영속화(+최대 3회 재시도). `policy_guarded_transaction`(PR #30 재사용)이\n절대 시간 정책 위반 시 롤백 → 422 `PLAN_POLICY_VIOLATION`, 그 외 실패는 롤백 후 500\n`PLAN_SAVE_FAILED`. 만료된 Draft 는 410 `PLAN_DRAFT_EXPIRED`. 이미 승인된 Draft 는 멱등.\n\n승인 = 교체: 같은 target_date 의 이전 AI 계획 산출물 중 사용자가 손대지 않은\n카드(source=goal·status=planned, user_edit 블록 없는 것)와 그 블록을 soft 정리\n(archived/cancelled)하고, heaviest goal 의 기존 분해 트리도 보관한 뒤 새 계획을\n영속화한다 — 재생성→재승인 반복으로 같은 날짜에 카드/블록/노드가 겹겹이 누적되던\n문제 방지 (`first_plan_adapter.supersede_previous_plan`).\n\n동시성(더블클릭·다중 디바이스 동시 승인): advisory lock 은 **트랜잭션 스코프**\n(`pg_advisory_xact_lock`) 라 commit/rollback 마다 풀린다. 그래서 시도(attempt)마다\nlock 을 새로 잡고, Draft 로드·만료·멱등 검사 → 영속화 → Draft 승인 마킹·온보딩\n전이(`on_success` — 가드 트랜잭션 내부)까지를 **한 트랜잭션 단일 commit** 으로 묶는다.\nlock 이 풀리는 순간엔 항상 status=approved 가 이미 커밋돼 있어, 대기하던 요청은\n멱등 응답으로 빠진다. 재시도(ADR-0005 §2.5.1, 3회)는 이 라우터 루프가 담당한다\n(adapter 내부 재시도는 rollback 으로 lock 을 잃은 채 돌게 되므로 `max_retries=1`).\n\n부수 효과: 첫 계획 승인 = 온보딩 완료 → onboarding_state 를 `ACTIVE` 로 전이(멱등,\n어느 온보딩 단계에서든). 원설계(FIRST_PLAN → NOTIFICATIONS)는 실제 FE 흐름에서 상태가\nWELCOME 에 고정돼 새로고침 시 재-온보딩되던 문제가 있어 승인에서 ACTIVE 로 마감\n(api-contract §3).\n응답은 명시 승인이므로 `is_draft=false` (ADR-0005 §7.2).",
         "operationId": "approve_plan_plans__plan_id__approve_post",
         "parameters": [
           {
@@ -6648,7 +7343,7 @@
     },
     "/plans/{plan_id}/blocks/{block_id}": {
       "patch": {
-        "description": "블록 15분 snap 이동 (S15). 충돌 422 `PLAN_BLOCK_CONFLICT` / 정책 422 `POLICY_VIOLATION`.",
+        "description": "블록 15분 snap 이동 + 목표(category)/제목 수정 (S15).\n\n충돌 422 `PLAN_BLOCK_CONFLICT` / 정책 422 `POLICY_VIOLATION`. `category`/`title` 을 주면\n블록이 매달린 action_item 을 갱신한다(같은 액션의 모든 세션 블록 공유). 정책 검사는\n**변경된 category** 로 수행하고, 변경 반영은 성공 commit 시에만 영속된다(422 면 롤백).",
         "operationId": "edit_block_plans__plan_id__blocks__block_id__patch",
         "parameters": [
           {
@@ -7697,6 +8392,114 @@
           }
         },
         "summary": "Anonymize",
+        "tags": [
+          "settings"
+        ]
+      }
+    },
+    "/settings/profile": {
+      "get": {
+        "description": "지속형 프로필 메모리 — 에너지/시간(behavioral) + 톤/빈도(interaction) + 회복 선호.\n\n인터뷰가 아직 안 채웠으면 해당 항목 null (행/키를 생성하지 않는다).",
+        "operationId": "get_profile_settings_profile_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProfileResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Profile",
+        "tags": [
+          "settings"
+        ]
+      },
+      "patch": {
+        "description": "프로필 메모리 부분 수정 — 지정 필드만 갱신(미지정 유지). 행/키 없으면 생성.\n\nenum 검증은 스키마 Literal (그 외 값 → 422 `COMMON_VALIDATION_ERROR`).\n회복 선호(downscopeUnitMin·restOk)는 `users.focus_mode_preferences`(JSONB)에 병합 저장.",
+        "operationId": "update_profile_settings_profile_patch",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProfileUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProfileResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update Profile",
         "tags": [
           "settings"
         ]

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -40,6 +40,8 @@ import type {
   NotificationSettings,
   NotificationSettingsUpdateRequest,
   OnboardingStatus,
+  ProfileResponse,
+  ProfileUpdateRequest,
   BlockEditRequest,
   BlockEditResponse,
   PushSubscribeRequest,
@@ -555,6 +557,12 @@ export const settingsApi = {
 
   anonymize: (body: AnonymizeRequest) =>
     request<void>('/settings/anonymize', { method: 'POST', body }),
+
+  // 지속형 선호 프로필 — 인터뷰 산출물(행동/상호작용 스타일)을 읽고 부분 갱신.
+  getProfile: () => request<ProfileResponse>('/settings/profile'),
+
+  updateProfile: (body: ProfileUpdateRequest) =>
+    request<ProfileResponse>('/settings/profile', { method: 'PATCH', body }),
 };
 
 export const privacyApi = {

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -1,9 +1,45 @@
 import { useEffect, useState } from 'react';
-import { CaretLeft, Sparkle, BellRinging, BellSlash, Shield, Warning, Check, ArrowClockwise } from '@phosphor-icons/react';
+import { CaretLeft, Sparkle, BellRinging, BellSlash, Shield, Warning, Check, ArrowClockwise, Brain } from '@phosphor-icons/react';
 import { ApiError, notificationsApi, privacyApi, settingsApi } from '../lib/api';
 import { subscribePush, unsubscribePush, getPushPermission } from '../lib/push';
+import { DemoNotice } from '../components/DemoNotice';
 import { useNavigation } from '../contexts/NavigationContext';
-import type { ConsentRecord, ConsentType, ToneMode, UserSettings } from '../types/api';
+import type {
+  ConsentRecord,
+  ConsentType,
+  EnergyCycle,
+  ProfileResponse,
+  ProfileUpdateRequest,
+  RecoveryTone,
+  ReminderFrequency,
+  ToneMode,
+  UserSettings,
+} from '../types/api';
+
+// 선호 프로필 편집 칩 — 백엔드 GET/PATCH /settings/profile.
+const ENERGY_OPTIONS: { value: EnergyCycle; label: string }[] = [
+  { value: 'morning', label: '아침형' },
+  { value: 'afternoon', label: '오후형' },
+  { value: 'evening', label: '저녁형' },
+  { value: 'night', label: '야행형' },
+  { value: 'varies', label: '그때그때' },
+];
+const RECOVERY_TONE_OPTIONS: { value: RecoveryTone; label: string }[] = [
+  { value: 'gentle', label: '부드럽게' },
+  { value: 'normal', label: '보통' },
+  { value: 'encouraging', label: '응원하기' },
+];
+const REMINDER_OPTIONS: { value: ReminderFrequency; label: string }[] = [
+  { value: 'minimal', label: '최소' },
+  { value: 'standard', label: '보통' },
+  { value: 'active', label: '자주' },
+];
+
+// 백엔드가 아직 프로필을 안 채웠을 때(행 없음) 보여줄 데모 기본값.
+const DEMO_PROFILE: ProfileResponse = {
+  behavioral: { energyCycle: 'morning', attentionSpan: 25, timeChunkPreference: '30' },
+  interaction: { recoveryTone: 'gentle', suggestionStyle: 'neutral', explanationDepth: 'normal', reminderFrequency: 'standard' },
+};
 
 const TONE_OPTIONS: { mode: ToneMode; label: string; desc: string }[] = [
   { mode: 'gentle', label: '부드럽게', desc: '실패도 격려로. 압박 적은 톤.' },
@@ -20,6 +56,9 @@ const CONSENT_TYPES: { type: ConsentType; label: string; desc: string }[] = [
 export function SettingsScreen() {
   const { user, setScreen } = useNavigation();
   const [settings, setSettings] = useState<UserSettings | null>(null);
+  // 선호 프로필 — 성공 시 실데이터, 실패/미구현 시 데모 기본값으로 fallback(화면 유지).
+  const [profile, setProfile] = useState<ProfileResponse>(DEMO_PROFILE);
+  const [usingRealProfile, setUsingRealProfile] = useState(false);
   const [consents, setConsents] = useState<ConsentRecord[]>([]);
   const [pushEnabled, setPushEnabled] = useState(false);
   const [pushBusy, setPushBusy] = useState(false);
@@ -37,6 +76,23 @@ export function SettingsScreen() {
           setSettings({ toneMode: user.toneMode, language: 'ko', timezone: user.timezone });
         }
       },
+    );
+    settingsApi.getProfile().then(
+      (p) => {
+        if (cancelled) return;
+        // behavioral/interaction 중 하나라도 채워져 있으면 실데이터로 간주.
+        // 둘 다 null(인터뷰 전)이면 데모 기본값을 유지하되 실연결 배지는 켜지 않는다.
+        if (p.behavioral || p.interaction) {
+          setProfile({
+            behavioral: p.behavioral ?? DEMO_PROFILE.behavioral,
+            interaction: p.interaction ?? DEMO_PROFILE.interaction,
+            downscopeUnitMin: p.downscopeUnitMin,
+            restOk: p.restOk,
+          });
+          setUsingRealProfile(true);
+        }
+      },
+      () => { /* 미구현/오류 — 데모 기본값 유지 */ },
     );
     privacyApi.consents().then(
       (c) => { if (!cancelled) setConsents(c); },
@@ -63,6 +119,23 @@ export function SettingsScreen() {
       if (err instanceof ApiError) showToast('서버 미동작 — 로컬에만 적용');
     }
   };
+
+  // 선호 프로필 부분 갱신 — optimistic + PATCH. 실패는 조용히(로컬만).
+  const patchProfile = async (body: ProfileUpdateRequest, next: ProfileResponse) => {
+    setProfile(next);
+    try {
+      await settingsApi.updateProfile(body);
+      if (usingRealProfile) showToast('선호가 저장됐어요');
+    } catch (err) {
+      if (err instanceof ApiError) showToast('서버 미동작 — 로컬에만 적용');
+    }
+  };
+  const setEnergyCycle = (energyCycle: EnergyCycle) =>
+    patchProfile({ energyCycle }, { ...profile, behavioral: { ...(profile.behavioral ?? DEMO_PROFILE.behavioral!), energyCycle } });
+  const setRecoveryTone = (recoveryTone: RecoveryTone) =>
+    patchProfile({ recoveryTone }, { ...profile, interaction: { ...(profile.interaction ?? DEMO_PROFILE.interaction!), recoveryTone } });
+  const setReminderFrequency = (reminderFrequency: ReminderFrequency) =>
+    patchProfile({ reminderFrequency }, { ...profile, interaction: { ...(profile.interaction ?? DEMO_PROFILE.interaction!), reminderFrequency } });
 
   const togglePush = async () => {
     setPushBusy(true);
@@ -160,6 +233,23 @@ export function SettingsScreen() {
                 </button>
               );
             })}
+          </div>
+        </section>
+
+        {/* Preference profile — GET/PATCH /settings/profile */}
+        <section>
+          <SectionLabel icon={<Brain size={11} weight="fill" />}>선호 프로필</SectionLabel>
+          {!usingRealProfile && (
+            <div style={{ marginBottom: 8 }}>
+              <DemoNotice storageKey="settings-profile">
+                아직 인터뷰로 채워진 선호가 없어요. 지금 고른 값은 로컬 미리보기이며, 인터뷰를 마치면 실제 프로필로 바뀝니다.
+              </DemoNotice>
+            </div>
+          )}
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 14, background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', borderRadius: 14, padding: '14px 14px' }}>
+            <ChipRow label="집중 에너지 사이클" value={profile.behavioral?.energyCycle} options={ENERGY_OPTIONS} onSelect={setEnergyCycle} />
+            <ChipRow label="회복 톤" value={profile.interaction?.recoveryTone} options={RECOVERY_TONE_OPTIONS} onSelect={setRecoveryTone} />
+            <ChipRow label="알림 빈도" value={profile.interaction?.reminderFrequency} options={REMINDER_OPTIONS} onSelect={setReminderFrequency} />
           </div>
         </section>
 
@@ -268,6 +358,36 @@ function SectionLabel({ icon, children, tone = 'default' }: { icon?: React.React
     <div style={{ display: 'flex', alignItems: 'center', gap: 5, fontSize: 10, fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: tone === 'danger' ? 'var(--danger)' : 'var(--text-3)', fontFamily: 'var(--font-mono)', marginBottom: 8 }}>
       {icon}
       {children}
+    </div>
+  );
+}
+
+// 선호 프로필용 단일선택 칩 그룹. value 미확정(undefined)이면 아무 것도 강조 안 함.
+function ChipRow<T extends string>({
+  label, value, options, onSelect,
+}: {
+  label: string;
+  value: T | undefined;
+  options: { value: T; label: string }[];
+  onSelect: (v: T) => void;
+}) {
+  return (
+    <div>
+      <div style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-3)', marginBottom: 8 }}>{label}</div>
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+        {options.map((o) => {
+          const active = value === o.value;
+          return (
+            <button
+              key={o.value}
+              onClick={() => onSelect(o.value)}
+              style={{ padding: '7px 12px', borderRadius: 9999, background: active ? 'var(--brand-soft)' : 'var(--surface-ground)', color: active ? 'var(--brand)' : 'var(--text-2)', border: `1.5px solid ${active ? 'var(--brand)' : 'var(--sand-200)'}`, fontSize: 12, fontWeight: 600, cursor: 'pointer', fontFamily: 'inherit', transition: 'all 160ms' }}
+            >
+              {o.label}
+            </button>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -64,6 +64,8 @@ export interface GoalCandidate {
   deadline?: string | null;
   whyNow?: string | null;
   successImage?: string | null;
+  // 현재 수준(자기평가) — 인터뷰가 채우면 값, 아니면 null. goal_node 분해 입력(#백엔드).
+  currentLevel?: string | null;
   tentativeTier: 'focus' | 'maintain' | 'parked';
   confidence: number;
 }
@@ -601,6 +603,10 @@ export interface FirstPlanGenerateRequest {
   interviewSessionId?: string | null;
   targetDate?: string | null; // YYYY-MM-DD
   outcome?: Record<string, unknown> | null; // InterviewOutcome (보통 서버 파생)
+  // 계획 밀도 — light/standard(기본)/intense. 서버가 블록 개수·강도에 반영.
+  density?: 'light' | 'standard' | 'intense';
+  // 생성 범위 — week(이번 주만) / horizon(기본, 목표 지평 전체).
+  scope?: 'week' | 'horizon';
 }
 
 // POST /plans/{planId}/approve
@@ -714,6 +720,53 @@ export interface ToneModeUpdateRequest {
 
 export interface AnonymizeRequest {
   confirmationToken: string;
+}
+
+// ── Profile Memory (GET/PATCH /settings/profile) — 백엔드 신규 ──
+// 지속형 선호 프로필. 인터뷰가 아직 안 채웠으면 behavioral/interaction 이 null.
+export type EnergyCycle = 'morning' | 'afternoon' | 'evening' | 'night' | 'varies';
+export type TimeChunkPreference = '10' | '20' | '30' | '60' | '90';
+export type RecoveryTone = 'gentle' | 'normal' | 'encouraging';
+export type SuggestionStyle = 'soft' | 'neutral' | 'firm';
+export type ExplanationDepth = 'brief' | 'normal' | 'detailed';
+export type ReminderFrequency = 'minimal' | 'standard' | 'active';
+
+// behavioral_profiles 의 사용자 편집 대상 필드.
+export interface BehavioralProfileView {
+  energyCycle: EnergyCycle;
+  attentionSpan: number; // 분
+  timeChunkPreference: TimeChunkPreference;
+  preferredStartTime?: string | null;
+  preferredEndTime?: string | null;
+}
+
+// interaction_styles 의 사용자 편집 대상 필드.
+export interface InteractionStyleView {
+  recoveryTone: RecoveryTone;
+  suggestionStyle: SuggestionStyle;
+  explanationDepth: ExplanationDepth;
+  reminderFrequency: ReminderFrequency;
+}
+
+export interface ProfileResponse {
+  behavioral: BehavioralProfileView | null;
+  interaction: InteractionStyleView | null;
+  // 회복 선호 — users.focus_mode_preferences(JSONB) 출처.
+  downscopeUnitMin?: number | null;
+  restOk?: boolean | null;
+}
+
+// PATCH /settings/profile — 지정 필드만 부분 갱신. 미지정은 유지.
+export interface ProfileUpdateRequest {
+  energyCycle?: EnergyCycle;
+  attentionSpan?: number; // 5~240
+  timeChunkPreference?: TimeChunkPreference;
+  recoveryTone?: RecoveryTone;
+  suggestionStyle?: SuggestionStyle;
+  explanationDepth?: ExplanationDepth;
+  reminderFrequency?: ReminderFrequency;
+  downscopeUnitMin?: number; // 1~120
+  restOk?: boolean;
 }
 
 export type ConsentType = 'marketing' | 'research' | 'analytics' | string;

--- a/src/types/openapi.d.ts
+++ b/src/types/openapi.d.ts
@@ -427,7 +427,10 @@ export interface paths {
         };
         /**
          * List Inbox
-         * @description 내 inbox 항목. `?status=captured|classified|promoted` 필터.
+         * @description 내 inbox 항목. `?status=captured|classified|promoted|archived` 필터.
+         *
+         *     `status` 미지정 시 활성 항목(archived 제외)만. `status=archived` 는 보관함(soft-deleted)
+         *     조회 — `POST /inbox/{id}/restore` 로 되살릴 수 있다.
          */
         get: operations["list_inbox_inbox_get"];
         put?: never;
@@ -516,6 +519,29 @@ export interface paths {
          * @description Inbox → Goal 변환 (tier=maintain default, 한도 enforce). inbox.status=promoted.
          */
         post: operations["convert_to_goal_inbox__inbox_id__convert_to_goal_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/inbox/{inbox_id}/restore": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Restore Inbox
+         * @description 보관 취소 — `archived_at` 클리어 + status 를 활성(classified/captured)으로 복원.
+         *
+         *     보관함(`status=archived`)에서만 의미. 이미 활성이면 멱등(현재 상태 그대로 반환).
+         *     존재하지 않으면 404 `INBOX_NOT_FOUND`. hard delete 는 없으므로 언제든 되살릴 수 있다.
+         */
+        post: operations["restore_inbox_inbox__inbox_id__restore_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -749,6 +775,64 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/plans/replan": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Generate Replan
+         * @description 주간 리포트를 작성하고, 남은 작업 + 수락한 회복을 **다음 주부터 마감까지** 다시 배치.
+         *
+         *     - 대상: 다음 주 이후 미착수 블록의 액션 + 활성 블록 없는 planned 백로그(수락한 회복 포함).
+         *       과거·시작/완료·user_edit 블록은 불변. 실패 원본은 미래 블록이 없어 자동 제외.
+         *     - busy = 확정(시작/완료·user_edit) 블록 + DB 시간정책 + **고정일정(#112 정합)**.
+         *     - 각 새 블록에 '교체할 옛 블록 id'(replacesBlockId)를 실어, 승인이 blanket-cancel 없이
+         *       그 블록만 현재 상태로 재조정 취소하게 한다(#117). 산출물은 Draft — 자동 적용 금지.
+         */
+        post: operations["generate_replan_plans_replan_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/plans/replan/{plan_id}/approve": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Approve Replan
+         * @description 재계획 Draft 승인 → **action 단위 재조정**으로 미래 블록 교체(#117 재작업).
+         *
+         *     #115 스케줄러가 긴 액션을 **여러 세션 블록**으로 쪼개므로, 재조정은 개별 블록이 아니라
+         *     **액션당 '옛 블록 집합'(payload `oldBlocks`)** 을 통째 다룬다 — 옛 블록 1개만 취소하면
+         *     나머지가 유령으로 남거나 새 세션이 드롭되던 문제 방지(리뷰 대응). 액션마다 현재 DB 상태로:
+         *     - 옛 블록 집합 중 하나라도 `started/finished`(사용자 착수) → 이 액션 **전체 보존**(skip).
+         *     - 활성(`scheduled`) 옛 블록이 하나도 없음(그새 전부 취소·삭제) → 중복 방지 skip.
+         *     - 그 외 → 활성 옛 블록 **전부 취소** + 새 세션 블록 **전부 생성**.
+         *     - 백로그(옛 블록 없음): 그새 그 action 이 활성 블록을 얻었으면 생성 skip.
+         *     - action 이 그새 아카이브/삭제됐으면(예: #113 First Plan 교체) 전체 skip(좀비 블록 방지).
+         *
+         *     Draft 로드·검사~쓰기를 `user_agent_lock`(xact-scoped) 안에서 단일 commit 으로 원자화한다
+         *     (동시 더블 승인 봉합, #113 패턴). 과거·시작/완료·user_edit 블록은 불변. 항상 Draft→HITL.
+         */
+        post: operations["approve_replan_plans_replan__plan_id__approve_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/plans/weekly": {
         parameters: {
             query?: never;
@@ -779,6 +863,10 @@ export interface paths {
         /**
          * Get Plan
          * @description 저장된 First Plan Draft 미리보기 — LLM 재호출 없이 스냅샷 재구성.
+         *
+         *     재계획(`kind='replan'`) Draft 는 payload 모양이 달라(goal_nodes 가 없다) 여기서 다루지
+         *     않는다 — 가드가 없으면 `_draft_to_response` 가 `KeyError: 'goal_nodes'` 로 500 을 낸다.
+         *     승인 endpoint 의 반대편 가드(approve_replan 의 `kind != "replan"` 검사)와 대칭.
          */
         get: operations["get_plan_plans__plan_id__get"];
         put?: never;
@@ -806,6 +894,20 @@ export interface paths {
          *     단일 트랜잭션으로 영속화(+최대 3회 재시도). `policy_guarded_transaction`(PR #30 재사용)이
          *     절대 시간 정책 위반 시 롤백 → 422 `PLAN_POLICY_VIOLATION`, 그 외 실패는 롤백 후 500
          *     `PLAN_SAVE_FAILED`. 만료된 Draft 는 410 `PLAN_DRAFT_EXPIRED`. 이미 승인된 Draft 는 멱등.
+         *
+         *     승인 = 교체: 같은 target_date 의 이전 AI 계획 산출물 중 사용자가 손대지 않은
+         *     카드(source=goal·status=planned, user_edit 블록 없는 것)와 그 블록을 soft 정리
+         *     (archived/cancelled)하고, heaviest goal 의 기존 분해 트리도 보관한 뒤 새 계획을
+         *     영속화한다 — 재생성→재승인 반복으로 같은 날짜에 카드/블록/노드가 겹겹이 누적되던
+         *     문제 방지 (`first_plan_adapter.supersede_previous_plan`).
+         *
+         *     동시성(더블클릭·다중 디바이스 동시 승인): advisory lock 은 **트랜잭션 스코프**
+         *     (`pg_advisory_xact_lock`) 라 commit/rollback 마다 풀린다. 그래서 시도(attempt)마다
+         *     lock 을 새로 잡고, Draft 로드·만료·멱등 검사 → 영속화 → Draft 승인 마킹·온보딩
+         *     전이(`on_success` — 가드 트랜잭션 내부)까지를 **한 트랜잭션 단일 commit** 으로 묶는다.
+         *     lock 이 풀리는 순간엔 항상 status=approved 가 이미 커밋돼 있어, 대기하던 요청은
+         *     멱등 응답으로 빠진다. 재시도(ADR-0005 §2.5.1, 3회)는 이 라우터 루프가 담당한다
+         *     (adapter 내부 재시도는 rollback 으로 lock 을 잃은 채 돌게 되므로 `max_retries=1`).
          *
          *     부수 효과: 첫 계획 승인 = 온보딩 완료 → onboarding_state 를 `ACTIVE` 로 전이(멱등,
          *     어느 온보딩 단계에서든). 원설계(FIRST_PLAN → NOTIFICATIONS)는 실제 FE 흐름에서 상태가
@@ -835,7 +937,11 @@ export interface paths {
         head?: never;
         /**
          * Edit Block
-         * @description 블록 15분 snap 이동 (S15). 충돌 422 `PLAN_BLOCK_CONFLICT` / 정책 422 `POLICY_VIOLATION`.
+         * @description 블록 15분 snap 이동 + 목표(category)/제목 수정 (S15).
+         *
+         *     충돌 422 `PLAN_BLOCK_CONFLICT` / 정책 422 `POLICY_VIOLATION`. `category`/`title` 을 주면
+         *     블록이 매달린 action_item 을 갱신한다(같은 액션의 모든 세션 블록 공유). 정책 검사는
+         *     **변경된 category** 로 수행하고, 변경 반영은 성공 commit 시에만 영속된다(422 면 롤백).
          */
         patch: operations["edit_block_plans__plan_id__blocks__block_id__patch"];
         trace?: never;
@@ -1195,6 +1301,35 @@ export interface paths {
         options?: never;
         head?: never;
         patch?: never;
+        trace?: never;
+    };
+    "/settings/profile": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Profile
+         * @description 지속형 프로필 메모리 — 에너지/시간(behavioral) + 톤/빈도(interaction) + 회복 선호.
+         *
+         *     인터뷰가 아직 안 채웠으면 해당 항목 null (행/키를 생성하지 않는다).
+         */
+        get: operations["get_profile_settings_profile_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Update Profile
+         * @description 프로필 메모리 부분 수정 — 지정 필드만 갱신(미지정 유지). 행/키 없으면 생성.
+         *
+         *     enum 검증은 스키마 Literal (그 외 값 → 422 `COMMON_VALIDATION_ERROR`).
+         *     회복 선호(downscopeUnitMin·restOk)는 `users.focus_mode_preferences`(JSONB)에 병합 저장.
+         */
+        patch: operations["update_profile_settings_profile_patch"];
         trace?: never;
     };
     "/settings/tone-mode": {
@@ -1603,16 +1738,44 @@ export interface components {
             peakWindow: string[];
         };
         /**
+         * BehavioralProfileView
+         * @description behavioral_profiles 의 사용자 편집 대상 필드.
+         */
+        BehavioralProfileView: {
+            /** Attentionspan */
+            attentionSpan: number;
+            /**
+             * Energycycle
+             * @enum {string}
+             */
+            energyCycle: "morning" | "afternoon" | "evening" | "night" | "varies";
+            /** Preferredendtime */
+            preferredEndTime?: string | null;
+            /** Preferredstarttime */
+            preferredStartTime?: string | null;
+            /**
+             * Timechunkpreference
+             * @enum {string}
+             */
+            timeChunkPreference: "10" | "20" | "30" | "60" | "90";
+        };
+        /**
          * BlockEditRequest
-         * @description PATCH /plans/{planId}/blocks/{blockId} — 15분 snap 이동.
+         * @description PATCH /plans/{planId}/blocks/{blockId} — 15분 snap 이동 + 목표(category)/제목 수정.
          *
          *     `endAt` 생략 시 기존 길이를 보존한 채 시작만 옮긴다. 시각은 KST ISO 8601.
+         *     `category`/`title` 을 주면 블록이 매달린 action_item 을 갱신한다 — 같은 액션의 모든
+         *     세션 블록에 반영되며, 미지원 category 는 'other' 로 정규화한다. 미지정 필드는 유지.
          */
         BlockEditRequest: {
+            /** Category */
+            category?: string | null;
             /** Endat */
             endAt?: string | null;
             /** Startat */
             startAt: string;
+            /** Title */
+            title?: string | null;
         };
         /**
          * BlockEditResponse
@@ -1901,9 +2064,21 @@ export interface components {
          *     검증은 라우터/오케스트레이터 VALIDATING 단계에서 수행.
          */
         FirstPlanGenerateRequest: {
+            /**
+             * Density
+             * @default standard
+             * @enum {string}
+             */
+            density: "light" | "standard" | "intense";
             /** Interviewsessionid */
             interviewSessionId?: string | null;
             outcome?: components["schemas"]["InterviewOutcome"] | null;
+            /**
+             * Scope
+             * @default horizon
+             * @enum {string}
+             */
+            scope: "week" | "horizon";
             /** Targetdate */
             targetDate?: string | null;
         };
@@ -2030,6 +2205,8 @@ export interface components {
             category: string;
             /** Confidence */
             confidence: number;
+            /** Currentlevel */
+            currentLevel?: string | null;
             /** Deadline */
             deadline?: string | null;
             /**
@@ -2339,6 +2516,8 @@ export interface components {
             inboxId: string;
             /** Promotedgoalid */
             promotedGoalId: string | null;
+            /** Promotedto */
+            promotedTo?: ("goal" | "action") | null;
             /** Rawtext */
             rawText: string;
             /** Status */
@@ -2355,6 +2534,32 @@ export interface components {
             status?: ("captured" | "classified" | "archived" | "promoted") | null;
             /** Usercategory */
             userCategory?: ("study" | "project" | "health" | "routine" | "schedule" | "other") | null;
+        };
+        /**
+         * InteractionStyleView
+         * @description interaction_styles 의 사용자 편집 대상 필드.
+         */
+        InteractionStyleView: {
+            /**
+             * Explanationdepth
+             * @enum {string}
+             */
+            explanationDepth: "brief" | "normal" | "detailed";
+            /**
+             * Recoverytone
+             * @enum {string}
+             */
+            recoveryTone: "gentle" | "normal" | "encouraging";
+            /**
+             * Reminderfrequency
+             * @enum {string}
+             */
+            reminderFrequency: "minimal" | "standard" | "active";
+            /**
+             * Suggestionstyle
+             * @enum {string}
+             */
+            suggestionStyle: "soft" | "neutral" | "firm";
         };
         /**
          * InterviewOutcome
@@ -2599,6 +2804,47 @@ export interface components {
             restOk: boolean;
             /** Weeklyenergy */
             weeklyEnergy?: string | null;
+        };
+        /**
+         * ProfileResponse
+         * @description GET/PATCH /settings/profile — 지속형 프로필 메모리.
+         *
+         *     인터뷰가 아직 안 채웠으면 각 항목 null (행 없음).
+         *     `downscopeUnitMin`/`restOk` 는 회복 선호 — `users.focus_mode_preferences`(JSONB) 출처.
+         */
+        ProfileResponse: {
+            behavioral: components["schemas"]["BehavioralProfileView"] | null;
+            /** Downscopeunitmin */
+            downscopeUnitMin?: number | null;
+            interaction: components["schemas"]["InteractionStyleView"] | null;
+            /** Restok */
+            restOk?: boolean | null;
+        };
+        /**
+         * ProfileUpdateRequest
+         * @description PATCH /settings/profile — 지정 필드만 부분 갱신. 미지정(None)은 유지.
+         *
+         *     enum 외 값은 Pydantic Literal → 422 `COMMON_VALIDATION_ERROR`.
+         */
+        ProfileUpdateRequest: {
+            /** Attentionspan */
+            attentionSpan?: number | null;
+            /** Downscopeunitmin */
+            downscopeUnitMin?: number | null;
+            /** Energycycle */
+            energyCycle?: ("morning" | "afternoon" | "evening" | "night" | "varies") | null;
+            /** Explanationdepth */
+            explanationDepth?: ("brief" | "normal" | "detailed") | null;
+            /** Recoverytone */
+            recoveryTone?: ("gentle" | "normal" | "encouraging") | null;
+            /** Reminderfrequency */
+            reminderFrequency?: ("minimal" | "standard" | "active") | null;
+            /** Restok */
+            restOk?: boolean | null;
+            /** Suggestionstyle */
+            suggestionStyle?: ("soft" | "neutral" | "firm") | null;
+            /** Timechunkpreference */
+            timeChunkPreference?: ("10" | "20" | "30" | "60" | "90") | null;
         };
         /**
          * PushSubscribeRequest
@@ -2863,6 +3109,34 @@ export interface components {
             title: string;
         };
         /**
+         * ReplanBlockPreview
+         * @description 재계획 미리보기 블록 — 기존 ActionItem 에 연결(actionId). 시각은 KST.
+         *
+         *     `replacesBlockId` 는 이 새 블록이 교체하는 옛 미래 블록의 **대표 id**(미리보기용, 없으면
+         *     백로그라 null). 실제 승인 재조정은 payload 의 `oldBlocks`(액션당 옛 블록 **전부**)를 권위로
+         *     삼아 액션 단위로 취소·생성한다 — 한 액션이 여러 세션으로 쪼개진 경우까지 정확히(#117).
+         */
+        ReplanBlockPreview: {
+            /** Actionid */
+            actionId: string;
+            /** Category */
+            category: string;
+            /**
+             * End
+             * Format: date-time
+             */
+            end: string;
+            /** Replacesblockid */
+            replacesBlockId?: string | null;
+            /**
+             * Start
+             * Format: date-time
+             */
+            start: string;
+            /** Title */
+            title: string;
+        };
+        /**
          * ReplanDiffResponse
          * @description GET /replan/{executionId} — S20 before/after 프리뷰 (Draft Layer).
          *
@@ -2895,6 +3169,38 @@ export interface components {
              * @enum {string}
              */
             optionGroup: "DOWNSCOPE" | "RESCHEDULE" | "CARRY_OVER" | "PARK";
+        };
+        /**
+         * ReplanResponse
+         * @description 주간 재계획 미리보기 — 항상 Draft. 승인은 `/plans/replan/{planId}/approve`.
+         */
+        ReplanResponse: {
+            /**
+             * Aisource
+             * @default llm
+             * @enum {string}
+             */
+            aiSource: "llm" | "rule";
+            /** Blocks */
+            blocks: components["schemas"]["ReplanBlockPreview"][];
+            /**
+             * Generatedat
+             * Format: date-time
+             */
+            generatedAt: string;
+            /** Horizon */
+            horizon: string | null;
+            /**
+             * Isdraft
+             * @default true
+             */
+            isDraft: boolean;
+            /** Planid */
+            planId: string;
+            /** Warnings */
+            warnings?: string[];
+            /** Windowstart */
+            windowStart: string;
         };
         /**
          * ScheduledBlockPreview
@@ -3177,6 +3483,40 @@ export interface components {
              * Format: date
              */
             weekStart: string;
+        };
+        /**
+         * WeeklyReplanApproveResponse
+         * @description 주간 forward 재계획 승인 결과 — 재조정 카운트. `is_draft=False`.
+         *
+         *     started/finished 로 바뀐 옛 블록·다른 계획 승인분은 건드리지 않으므로(재조정),
+         *     `skipped` 는 그렇게 보존된 항목 수다.
+         *
+         *     ⚠️ 이름 주의: `schemas/recovery.py` 의 `ReplanApproveResponse`(S20 실행단위 replan,
+         *     `POST /replan/{executionId}/approve`)와 **다른 것**이다. 같은 이름을 쓰면 FastAPI 가
+         *     중복 모델명을 양쪽 다 full-qualify 로 바꿔(`reaction_backend__schemas__recovery__...`)
+         *     이 PR 이 건드리지도 않은 회복 endpoint 의 OpenAPI 컴포넌트명이 변하고 FE 생성
+         *     클라이언트가 깨진다. 'Weekly' 접두사는 그 충돌을 피하기 위한 것 — 지우지 말 것.
+         */
+        WeeklyReplanApproveResponse: {
+            /**
+             * Activatedat
+             * Format: date-time
+             */
+            activatedAt: string;
+            /** Cancelledblocks */
+            cancelledBlocks: number;
+            /** Createdblocks */
+            createdBlocks: number;
+            /**
+             * Isdraft
+             * @default false
+             * @constant
+             */
+            isDraft: false;
+            /** Planid */
+            planId: string;
+            /** Skippedblocks */
+            skippedBlocks: number;
         };
         /**
          * WeeklyReviewResponse
@@ -4282,6 +4622,39 @@ export interface operations {
             };
         };
     };
+    restore_inbox_inbox__inbox_id__restore_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                inbox_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InboxItem"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     start_session_interview_sessions_post: {
         parameters: {
             query?: never;
@@ -4663,6 +5036,70 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["FirstPlanResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    generate_replan_plans_replan_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ReplanResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    approve_replan_plans_replan__plan_id__approve_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                plan_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WeeklyReplanApproveResponse"];
                 };
             };
             /** @description Validation Error */
@@ -5365,6 +5802,72 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AnonymizeResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_profile_settings_profile_get: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProfileResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_profile_settings_profile_patch: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ProfileUpdateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProfileResponse"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
백엔드(`reaction-backend`)의 최신 OpenAPI 를 다시 덤프해 프론트 타입·래퍼·화면에 반영한 자동 동기화 PR 입니다.

## (a) 신규 / 변경 엔드포인트
- **신규** `GET/PATCH /settings/profile` — 지속형 선호 프로필(행동 스타일 + 상호작용 스타일). `settingsApi.getProfile()/updateProfile()` 래퍼와 타입(`ProfileResponse`, `BehavioralProfileView`, `InteractionStyleView`, `ProfileUpdateRequest`) 추가.
- **스키마 드리프트 교정** (수기 타입 ↔ 실제 스키마 정합):
  - `GoalCandidate.currentLevel` 추가
  - `FirstPlanGenerateRequest.density`(`light`/`standard`/`intense`) · `scope`(`week`/`horizon`) 추가
- 참고: `BlockEditRequest.category/title`, `InboxItem.promotedTo` 는 이미 수기 타입이 앞서 반영돼 있어 스키마 재확인만 됨.
- 아직 래퍼 미추가(NEW, 백엔드 신규): `/plans/replan`, `/plans/replan/{}/approve`, `/settings/profile` 외 `/calendar/*`, `/policy-snapshot/current`, `PATCH /habits/{}` — 대응 화면이 아직 없어 이번 범위에서 제외.

## (b) 화면 실연동
- **SettingsScreen** 에 "선호 프로필" 섹션 신규 실연동 — `GET /settings/profile` 로드 → 에너지 사이클 / 회복 톤 / 알림 빈도를 칩으로 편집하면 `PATCH /settings/profile` 로 부분 갱신.
  - 기존 mock-and-replace 패턴 유지: fetch 실패·미구현이거나 인터뷰 전(행 없음)이면 데모 기본값으로 fallback 하고 `DemoNotice` 노출, 실데이터가 채워졌을 때만 배지를 숨기고 저장 토스트 표시.
- 그 외 이미 연동된 화면(Today 아젠다/실패태그, Focus start·pause·resume·check-in, EveningCheckIn 회고 pending/batch, WeeklyCalendar, WeeklyReview, First Plan, Recovery)은 스키마 변화가 없어 그대로 둠.

## (c) check:api 요약
```
✅ OK   75  (백엔드 구현됨, 메서드 일치)
⚠️  WARN 0
❌ GONE 0
🆕 NEW  8   (openapi 에 있으나 래퍼 없음 — 위 (a) 참조)
결과: PASS
```

## 검증 게이트
- `npm run check:api` → GONE 0 / WARN 0 ✅
- `npx tsc --noEmit` → 통과 ✅
- `npm run build` → 통과 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3LMG2YiEYuKwVSvWpDhvz

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3LMG2YiEYuKwVSvWpDhvz)_