### PR TITLE
feat: 딥 인터뷰·계획 FE — density 셀렉터·프로필 편집·내 정보 탭

### DIFF
--- a/src/app/ReActionMerged.tsx
+++ b/src/app/ReActionMerged.tsx
@@ -10,6 +10,7 @@ import { MorningBriefScreen } from '../screens/MorningBriefScreen';
 import { InboxScreen } from '../screens/InboxScreen';
 import { GoalsScreen } from '../screens/GoalsScreen';
 import { SettingsScreen } from '../screens/SettingsScreen';
+import { MyInfoScreen } from '../screens/MyInfoScreen';
 import { MergedTodayScreen } from '../screens/TodayScreen';
 import { FocusScreen } from '../screens/FocusScreen';
 import { MergedRecoveryScreen } from '../screens/RecoveryScreen';
@@ -44,6 +45,7 @@ const NAV_META: Record<ScreenId, { label: string; back: ScreenId | null }> = {
   'review':                 { label: '주간 리뷰',      back: null },
   'goals':                  { label: '목표 관리',      back: 'today' },
   'settings':               { label: '설정',           back: 'today' },
+  'my-info':                { label: '내 정보',        back: 'settings' },
 };
 
 const TAB_SCREENS: ScreenId[] = ['today', 'weekly', 'inbox', 'review'];
@@ -281,6 +283,7 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
         {screen === 'review' && <WeeklyReviewScreenV2 />}
         {screen === 'goals' && <GoalsScreen />}
         {screen === 'settings' && <SettingsScreen />}
+        {screen === 'my-info' && <MyInfoScreen />}
       </div>
 
       {showTabs && <MergedTabBar active={tab} onChange={handleTabChange} />}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -59,6 +59,8 @@ import type {
   ToneModeUpdateRequest,
   UserProfile,
   UserSettings,
+  ProfileSettings,
+  ProfileUpdate,
   HabitPenaltyAcceptResponse,
   HabitPenaltyListResponse,
   WeeklyGenerateRequest,
@@ -552,6 +554,11 @@ export const settingsApi = {
 
   updateToneMode: (body: ToneModeUpdateRequest) =>
     request<UserSettings>('/settings/tone-mode', { method: 'PATCH', body }),
+
+  // 지속형 프로필 메모리 — 인터뷰가 채운 에너지/톤/시간을 조회·편집 (#A-2).
+  getProfile: () => request<ProfileSettings>('/settings/profile'),
+  updateProfile: (body: ProfileUpdate) =>
+    request<ProfileSettings>('/settings/profile', { method: 'PATCH', body }),
 
   anonymize: (body: AnonymizeRequest) =>
     request<void>('/settings/anonymize', { method: 'POST', body }),

--- a/src/screens/GoalIntakeScreen.tsx
+++ b/src/screens/GoalIntakeScreen.tsx
@@ -21,7 +21,7 @@ interface ChatMessage {
 // 백엔드 mock은 필수 슬롯 12개 → ambiguityScore 0 ~ 12.
 // 답변할수록 줄어드므로 (1 - score/initial) * 100 으로 명료성 환산.
 // /interview/slot-catalog 가 응답하기 전(fetch 실패 포함) 의 안전 기본값.
-const REQUIRED_SLOTS_INIT = 12;
+const REQUIRED_SLOTS_INIT = 14;
 
 // slot-catalog 의 category 식별자 → 한국어 라벨 (chip 표시용).
 const CATEGORY_LABEL: Record<string, string> = {

--- a/src/screens/MyInfoScreen.tsx
+++ b/src/screens/MyInfoScreen.tsx
@@ -1,0 +1,286 @@
+import { useEffect, useState } from 'react';
+import { CaretLeft, Waveform, IdentificationCard } from '@phosphor-icons/react';
+import { ApiError, settingsApi } from '../lib/api';
+import { useNavigation } from '../contexts/NavigationContext';
+import type {
+  EnergyCycle,
+  ProfileSettings,
+  ProfileUpdate,
+  RecoveryTone,
+  ReminderFrequency,
+} from '../types/api';
+
+const ENERGY_OPTIONS: { v: EnergyCycle; label: string }[] = [
+  { v: 'morning', label: '오전' },
+  { v: 'afternoon', label: '오후' },
+  { v: 'evening', label: '저녁' },
+  { v: 'night', label: '심야' },
+  { v: 'varies', label: '변동' },
+];
+const RECOVERY_OPTIONS: { v: RecoveryTone; label: string }[] = [
+  { v: 'gentle', label: '부드럽게' },
+  { v: 'normal', label: '보통' },
+  { v: 'encouraging', label: '응원' },
+];
+const REMINDER_OPTIONS: { v: ReminderFrequency; label: string }[] = [
+  { v: 'minimal', label: '최소' },
+  { v: 'standard', label: '보통' },
+  { v: 'active', label: '적극' },
+];
+
+// 설정에서 분리한 '내 정보' — 온보딩 인터뷰가 파악한 사용자 메모리(리듬/선호)를 조회하고,
+// 인터뷰를 다시 하지 않아도 여기서 바로 수정할 수 있다(#A-2). 수정값은 재인터뷰 시드에 우선 반영.
+export function MyInfoScreen() {
+  const { user, setScreen } = useNavigation();
+  const [profile, setProfile] = useState<ProfileSettings | null>(null);
+  const [loaded, setLoaded] = useState(false);
+  const [toast, setToast] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    settingsApi.getProfile().then(
+      (p) => { if (!cancelled) { setProfile(p); setLoaded(true); } },
+      () => { if (!cancelled) setLoaded(true); },
+    );
+    return () => { cancelled = true; };
+  }, []);
+
+  const showToast = (msg: string) => {
+    setToast(msg);
+    setTimeout(() => setToast(null), 1800);
+  };
+
+  const patchProfile = async (patch: ProfileUpdate) => {
+    try {
+      const updated = await settingsApi.updateProfile(patch);
+      setProfile(updated); // 서버가 병합된 전체 프로필을 돌려줌 (진실 소스)
+      showToast('저장했어요');
+    } catch (err) {
+      if (err instanceof ApiError) showToast('저장에 실패했어요');
+    }
+  };
+
+  const hasProfile =
+    !!profile && (profile.behavioral != null || profile.interaction != null || profile.downscopeUnitMin != null);
+
+  return (
+    <div style={{ height: '100%', display: 'flex', flexDirection: 'column', background: 'var(--surface-ground)', position: 'relative' }}>
+      <div style={{ flex: 1, overflowY: 'auto', padding: '14px 18px 32px', display: 'flex', flexDirection: 'column', gap: 18 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <button
+            onClick={() => setScreen('settings')}
+            style={{ width: 36, height: 36, borderRadius: 9999, border: 'none', background: 'var(--surface-raised)', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer' }}
+            aria-label="뒤로"
+          >
+            <CaretLeft size={16} />
+          </button>
+          <h1 style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 24, letterSpacing: '-0.02em', margin: 0 }}>내 정보</h1>
+        </div>
+
+        {user && (
+          <div style={{ background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', borderRadius: 14, padding: 12, display: 'flex', alignItems: 'center', gap: 12 }}>
+            <div style={{ width: 44, height: 44, borderRadius: 9999, background: 'var(--brand-soft)', color: 'var(--brand)', display: 'flex', alignItems: 'center', justifyContent: 'center', fontWeight: 700, flexShrink: 0 }}>
+              {user.name.slice(0, 1)}
+            </div>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontWeight: 700, fontSize: 14, color: 'var(--text-1)' }}>{user.name}</div>
+              <div style={{ fontSize: 11, color: 'var(--text-3)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{user.email}</div>
+            </div>
+          </div>
+        )}
+
+        {/* 프로필 메모리 (리듬/선호) — 인터뷰가 파악한 값 조회 + 편집 (#A-2) */}
+        <section>
+          <SectionLabel icon={<Waveform size={11} weight="fill" />}>나의 리듬 (프로필)</SectionLabel>
+          {hasProfile ? (
+            <div style={{ background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', borderRadius: 14, padding: 14, display: 'flex', flexDirection: 'column', gap: 14 }}>
+              <ChoiceGroup
+                label="주로 집중되는 시간대"
+                options={ENERGY_OPTIONS}
+                value={profile?.behavioral?.energyCycle}
+                onPick={(v) => patchProfile({ energyCycle: v })}
+              />
+              <MinuteField
+                label="한 번에 집중하는 길이"
+                value={profile?.behavioral?.attentionSpan}
+                onSave={(n) => patchProfile({ attentionSpan: n })}
+              />
+              <ChoiceGroup
+                label="회복 대화 톤"
+                options={RECOVERY_OPTIONS}
+                value={profile?.interaction?.recoveryTone}
+                onPick={(v) => patchProfile({ recoveryTone: v })}
+              />
+              <ChoiceGroup
+                label="알림 빈도"
+                options={REMINDER_OPTIONS}
+                value={profile?.interaction?.reminderFrequency}
+                onPick={(v) => patchProfile({ reminderFrequency: v })}
+              />
+              <MinuteField
+                label="회복 시 최소 단위 (막혔을 때 이만큼만 해보기)"
+                value={profile?.downscopeUnitMin ?? undefined}
+                onSave={(n) => patchProfile({ downscopeUnitMin: n })}
+              />
+              <ToggleRow
+                label="지칠 땐 휴식 제안 받기"
+                on={profile?.restOk ?? false}
+                onToggle={() => patchProfile({ restOk: !(profile?.restOk ?? false) })}
+              />
+              <div style={{ fontSize: 10, color: 'var(--text-3)', lineHeight: 1.5 }}>
+                온보딩 인터뷰에서 파악한 값이에요. 여기서 바꾸면 인터뷰를 다시 하지 않아도 반영돼요.
+              </div>
+            </div>
+          ) : (
+            <div style={{ background: 'var(--surface-raised)', border: '1px dashed var(--sand-300)', borderRadius: 14, padding: '20px 14px', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 8, textAlign: 'center' }}>
+              <IdentificationCard size={26} color="var(--text-3)" />
+              <div style={{ fontSize: 12, color: 'var(--text-3)', lineHeight: 1.5 }}>
+                {loaded ? '아직 파악된 정보가 없어요. 온보딩 인터뷰를 마치면 여기에 나의 리듬이 채워져요.' : '불러오는 중…'}
+              </div>
+            </div>
+          )}
+        </section>
+      </div>
+
+      {toast && (
+        <div style={{ position: 'absolute', bottom: 'max(16px, env(safe-area-inset-bottom, 16px))', left: 16, right: 16, padding: '10px 14px', background: 'var(--text-1)', color: '#FAF6EE', borderRadius: 10, fontSize: 12, textAlign: 'center', boxShadow: 'var(--shadow-md)' }}>
+          {toast}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SectionLabel({ icon, children }: { icon?: React.ReactNode; children: React.ReactNode }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 5, fontSize: 10, fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--text-3)', fontFamily: 'var(--font-mono)', marginBottom: 8 }}>
+      {icon}
+      {children}
+    </div>
+  );
+}
+
+// 사람마다 다른 '분' 값 — 고정 선택지 대신 자유 수정 입력(스텝 5분 · 5~240 범위).
+function MinuteField({
+  label,
+  value,
+  onSave,
+}: {
+  label: string;
+  value: number | undefined;
+  onSave: (n: number) => void;
+}) {
+  const [text, setText] = useState(value != null ? String(value) : '');
+  useEffect(() => {
+    setText(value != null ? String(value) : '');
+  }, [value]);
+
+  const clamp = (n: number) => Math.min(240, Math.max(5, n));
+  const commit = () => {
+    const n = parseInt(text, 10);
+    if (!Number.isNaN(n)) {
+      const c = clamp(n);
+      if (c !== value) onSave(c);
+      else setText(String(c));
+    } else {
+      setText(value != null ? String(value) : ''); // 무효 입력 되돌림
+    }
+  };
+  const bump = (delta: number) => onSave(clamp((value ?? 30) + delta));
+
+  const stepBtn = (labelTxt: string, onClick: () => void) => (
+    <button
+      onClick={onClick}
+      style={{ width: 34, height: 'var(--ctrl-sm)', borderRadius: 9, border: '1.5px solid var(--sand-200)', background: 'var(--surface-raised)', color: 'var(--text-1)', fontSize: 16, fontWeight: 700, cursor: 'pointer', fontFamily: 'inherit', lineHeight: 1 }}
+    >
+      {labelTxt}
+    </button>
+  );
+
+  return (
+    <div>
+      <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--text-2)', marginBottom: 7 }}>{label}</div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+        {stepBtn('−', () => bump(-5))}
+        <input
+          type="number"
+          inputMode="numeric"
+          value={text}
+          min={5}
+          max={240}
+          onChange={(e) => setText(e.target.value)}
+          onBlur={commit}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') (e.target as HTMLInputElement).blur();
+          }}
+          style={{ width: 64, height: 'var(--ctrl-sm)', textAlign: 'center', borderRadius: 9, border: '1.5px solid var(--sand-200)', background: 'var(--surface-raised)', color: 'var(--text-1)', fontSize: 14, fontWeight: 700, fontFamily: 'inherit', outline: 'none' }}
+        />
+        <span style={{ fontSize: 12, color: 'var(--text-3)' }}>분</span>
+        {stepBtn('+', () => bump(5))}
+      </div>
+    </div>
+  );
+}
+
+function ToggleRow({ label, on, onToggle }: { label: string; on: boolean; onToggle: () => void }) {
+  return (
+    <button
+      onClick={onToggle}
+      style={{ display: 'flex', alignItems: 'center', gap: 10, width: '100%', padding: 0, background: 'transparent', border: 'none', cursor: 'pointer', fontFamily: 'inherit', textAlign: 'left' }}
+    >
+      <div style={{ flex: 1, fontSize: 12, fontWeight: 600, color: 'var(--text-2)' }}>{label}</div>
+      <Toggle on={on} />
+    </button>
+  );
+}
+
+function ChoiceGroup<T extends string | number>({
+  label,
+  options,
+  value,
+  onPick,
+}: {
+  label: string;
+  options: { v: T; label: string }[];
+  value: T | undefined;
+  onPick: (v: T) => void;
+}) {
+  return (
+    <div>
+      <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--text-2)', marginBottom: 7 }}>{label}</div>
+      <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+        {options.map((o) => {
+          const active = value === o.v;
+          return (
+            <button
+              key={String(o.v)}
+              onClick={() => onPick(o.v)}
+              style={{
+                height: 'var(--ctrl-sm)',
+                padding: '0 13px',
+                borderRadius: 9999,
+                border: `1.5px solid ${active ? 'var(--brand)' : 'var(--sand-200)'}`,
+                background: active ? 'var(--brand-soft)' : 'var(--surface-raised)',
+                color: active ? 'var(--brand)' : 'var(--text-2)',
+                fontSize: 12,
+                fontWeight: 600,
+                cursor: 'pointer',
+                fontFamily: 'inherit',
+              }}
+            >
+              {o.label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function Toggle({ on }: { on: boolean }) {
+  return (
+    <div style={{ width: 36, height: 20, borderRadius: 9999, background: on ? 'var(--brand)' : 'var(--sand-300)', position: 'relative', flexShrink: 0 }}>
+      <div style={{ position: 'absolute', top: 2, left: on ? 18 : 2, width: 16, height: 16, borderRadius: 9999, background: '#fff', transition: 'left 160ms' }} />
+    </div>
+  );
+}

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -1,9 +1,37 @@
 import { useEffect, useState } from 'react';
-import { CaretLeft, Sparkle, BellRinging, BellSlash, Shield, Warning, Check, ArrowClockwise } from '@phosphor-icons/react';
+import { CaretLeft, Sparkle, BellRinging, BellSlash, Shield, Warning, Check, ArrowClockwise, Waveform } from '@phosphor-icons/react';
 import { ApiError, notificationsApi, privacyApi, settingsApi } from '../lib/api';
 import { subscribePush, unsubscribePush, getPushPermission } from '../lib/push';
 import { useNavigation } from '../contexts/NavigationContext';
-import type { ConsentRecord, ConsentType, ToneMode, UserSettings } from '../types/api';
+import type {
+  ConsentRecord,
+  ConsentType,
+  EnergyCycle,
+  ProfileSettings,
+  ProfileUpdate,
+  RecoveryTone,
+  ReminderFrequency,
+  ToneMode,
+  UserSettings,
+} from '../types/api';
+
+const ENERGY_OPTIONS: { v: EnergyCycle; label: string }[] = [
+  { v: 'morning', label: '오전' },
+  { v: 'afternoon', label: '오후' },
+  { v: 'evening', label: '저녁' },
+  { v: 'night', label: '심야' },
+  { v: 'varies', label: '변동' },
+];
+const RECOVERY_OPTIONS: { v: RecoveryTone; label: string }[] = [
+  { v: 'gentle', label: '부드럽게' },
+  { v: 'normal', label: '보통' },
+  { v: 'encouraging', label: '응원' },
+];
+const REMINDER_OPTIONS: { v: ReminderFrequency; label: string }[] = [
+  { v: 'minimal', label: '최소' },
+  { v: 'standard', label: '보통' },
+  { v: 'active', label: '적극' },
+];
 
 const TONE_OPTIONS: { mode: ToneMode; label: string; desc: string }[] = [
   { mode: 'gentle', label: '부드럽게', desc: '실패도 격려로. 압박 적은 톤.' },
@@ -20,6 +48,7 @@ const CONSENT_TYPES: { type: ConsentType; label: string; desc: string }[] = [
 export function SettingsScreen() {
   const { user, setScreen } = useNavigation();
   const [settings, setSettings] = useState<UserSettings | null>(null);
+  const [profile, setProfile] = useState<ProfileSettings | null>(null);
   const [consents, setConsents] = useState<ConsentRecord[]>([]);
   const [pushEnabled, setPushEnabled] = useState(false);
   const [pushBusy, setPushBusy] = useState(false);
@@ -37,6 +66,10 @@ export function SettingsScreen() {
           setSettings({ toneMode: user.toneMode, language: 'ko', timezone: user.timezone });
         }
       },
+    );
+    settingsApi.getProfile().then(
+      (p) => { if (!cancelled) setProfile(p); },
+      () => { /* 미구현/네트워크 — 프로필 섹션 숨김 */ },
     );
     privacyApi.consents().then(
       (c) => { if (!cancelled) setConsents(c); },
@@ -61,6 +94,16 @@ export function SettingsScreen() {
       showToast('톤이 바뀌었어요');
     } catch (err) {
       if (err instanceof ApiError) showToast('서버 미동작 — 로컬에만 적용');
+    }
+  };
+
+  const patchProfile = async (patch: ProfileUpdate) => {
+    try {
+      const updated = await settingsApi.updateProfile(patch);
+      setProfile(updated); // 서버가 병합된 전체 프로필을 돌려줌 (진실 소스)
+      showToast('저장했어요');
+    } catch (err) {
+      if (err instanceof ApiError) showToast('저장에 실패했어요');
     }
   };
 
@@ -162,6 +205,51 @@ export function SettingsScreen() {
             })}
           </div>
         </section>
+
+        {/* 프로필 메모리 (리듬/선호) — 인터뷰가 채운 값을 재인터뷰 없이 편집 (#A-2) */}
+        {profile && (
+          <section>
+            <SectionLabel icon={<Waveform size={11} weight="fill" />}>나의 리듬 (프로필)</SectionLabel>
+            <div style={{ background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', borderRadius: 14, padding: 14, display: 'flex', flexDirection: 'column', gap: 14 }}>
+              <ChoiceGroup
+                label="주로 집중되는 시간대"
+                options={ENERGY_OPTIONS}
+                value={profile.behavioral?.energyCycle}
+                onPick={(v) => patchProfile({ energyCycle: v })}
+              />
+              <MinuteField
+                label="한 번에 집중하는 길이"
+                value={profile.behavioral?.attentionSpan}
+                onSave={(n) => patchProfile({ attentionSpan: n })}
+              />
+              <ChoiceGroup
+                label="회복 대화 톤"
+                options={RECOVERY_OPTIONS}
+                value={profile.interaction?.recoveryTone}
+                onPick={(v) => patchProfile({ recoveryTone: v })}
+              />
+              <ChoiceGroup
+                label="알림 빈도"
+                options={REMINDER_OPTIONS}
+                value={profile.interaction?.reminderFrequency}
+                onPick={(v) => patchProfile({ reminderFrequency: v })}
+              />
+              <MinuteField
+                label="회복 시 최소 단위 (막혔을 때 이만큼만 해보기)"
+                value={profile.downscopeUnitMin ?? undefined}
+                onSave={(n) => patchProfile({ downscopeUnitMin: n })}
+              />
+              <ToggleRow
+                label="지칠 땐 휴식 제안 받기"
+                on={profile.restOk ?? false}
+                onToggle={() => patchProfile({ restOk: !(profile.restOk ?? false) })}
+              />
+              <div style={{ fontSize: 10, color: 'var(--text-3)', lineHeight: 1.5 }}>
+                온보딩 인터뷰에서 파악한 값이에요. 여기서 바꾸면 인터뷰를 다시 하지 않아도 반영돼요.
+              </div>
+            </div>
+          </section>
+        )}
 
         {/* Push */}
         <section>
@@ -268,6 +356,123 @@ function SectionLabel({ icon, children, tone = 'default' }: { icon?: React.React
     <div style={{ display: 'flex', alignItems: 'center', gap: 5, fontSize: 10, fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: tone === 'danger' ? 'var(--danger)' : 'var(--text-3)', fontFamily: 'var(--font-mono)', marginBottom: 8 }}>
       {icon}
       {children}
+    </div>
+  );
+}
+
+// 사람마다 다른 '분' 값 — 고정 선택지 대신 자유 수정 입력(스텝 5분 · 5~240 범위).
+function MinuteField({
+  label,
+  value,
+  onSave,
+}: {
+  label: string;
+  value: number | undefined;
+  onSave: (n: number) => void;
+}) {
+  const [text, setText] = useState(value != null ? String(value) : '');
+  useEffect(() => {
+    setText(value != null ? String(value) : '');
+  }, [value]);
+
+  const clamp = (n: number) => Math.min(240, Math.max(5, n));
+  const commit = () => {
+    const n = parseInt(text, 10);
+    if (!Number.isNaN(n)) {
+      const c = clamp(n);
+      if (c !== value) onSave(c);
+      else setText(String(c));
+    } else {
+      setText(value != null ? String(value) : ''); // 무효 입력 되돌림
+    }
+  };
+  const bump = (delta: number) => onSave(clamp((value ?? 30) + delta));
+
+  const stepBtn = (labelTxt: string, onClick: () => void) => (
+    <button
+      onClick={onClick}
+      style={{ width: 34, height: 'var(--ctrl-sm)', borderRadius: 9, border: '1.5px solid var(--sand-200)', background: 'var(--surface-raised)', color: 'var(--text-1)', fontSize: 16, fontWeight: 700, cursor: 'pointer', fontFamily: 'inherit', lineHeight: 1 }}
+    >
+      {labelTxt}
+    </button>
+  );
+
+  return (
+    <div>
+      <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--text-2)', marginBottom: 7 }}>{label}</div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+        {stepBtn('−', () => bump(-5))}
+        <input
+          type="number"
+          inputMode="numeric"
+          value={text}
+          min={5}
+          max={240}
+          onChange={(e) => setText(e.target.value)}
+          onBlur={commit}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') (e.target as HTMLInputElement).blur();
+          }}
+          style={{ width: 64, height: 'var(--ctrl-sm)', textAlign: 'center', borderRadius: 9, border: '1.5px solid var(--sand-200)', background: 'var(--surface-raised)', color: 'var(--text-1)', fontSize: 14, fontWeight: 700, fontFamily: 'inherit', outline: 'none' }}
+        />
+        <span style={{ fontSize: 12, color: 'var(--text-3)' }}>분</span>
+        {stepBtn('+', () => bump(5))}
+      </div>
+    </div>
+  );
+}
+
+function ToggleRow({ label, on, onToggle }: { label: string; on: boolean; onToggle: () => void }) {
+  return (
+    <button
+      onClick={onToggle}
+      style={{ display: 'flex', alignItems: 'center', gap: 10, width: '100%', padding: 0, background: 'transparent', border: 'none', cursor: 'pointer', fontFamily: 'inherit', textAlign: 'left' }}
+    >
+      <div style={{ flex: 1, fontSize: 12, fontWeight: 600, color: 'var(--text-2)' }}>{label}</div>
+      <Toggle on={on} />
+    </button>
+  );
+}
+
+function ChoiceGroup<T extends string | number>({
+  label,
+  options,
+  value,
+  onPick,
+}: {
+  label: string;
+  options: { v: T; label: string }[];
+  value: T | undefined;
+  onPick: (v: T) => void;
+}) {
+  return (
+    <div>
+      <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--text-2)', marginBottom: 7 }}>{label}</div>
+      <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+        {options.map((o) => {
+          const active = value === o.v;
+          return (
+            <button
+              key={String(o.v)}
+              onClick={() => onPick(o.v)}
+              style={{
+                height: 'var(--ctrl-sm)',
+                padding: '0 13px',
+                borderRadius: 9999,
+                border: `1.5px solid ${active ? 'var(--brand)' : 'var(--sand-200)'}`,
+                background: active ? 'var(--brand-soft)' : 'var(--surface-raised)',
+                color: active ? 'var(--brand)' : 'var(--text-2)',
+                fontSize: 12,
+                fontWeight: 600,
+                cursor: 'pointer',
+                fontFamily: 'inherit',
+              }}
+            >
+              {o.label}
+            </button>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -1,37 +1,14 @@
 import { useEffect, useState } from 'react';
-import { CaretLeft, Sparkle, BellRinging, BellSlash, Shield, Warning, Check, ArrowClockwise, Waveform } from '@phosphor-icons/react';
+import { CaretLeft, CaretRight, Sparkle, BellRinging, BellSlash, Shield, Warning, Check, ArrowClockwise, IdentificationCard } from '@phosphor-icons/react';
 import { ApiError, notificationsApi, privacyApi, settingsApi } from '../lib/api';
 import { subscribePush, unsubscribePush, getPushPermission } from '../lib/push';
 import { useNavigation } from '../contexts/NavigationContext';
 import type {
   ConsentRecord,
   ConsentType,
-  EnergyCycle,
-  ProfileSettings,
-  ProfileUpdate,
-  RecoveryTone,
-  ReminderFrequency,
   ToneMode,
   UserSettings,
 } from '../types/api';
-
-const ENERGY_OPTIONS: { v: EnergyCycle; label: string }[] = [
-  { v: 'morning', label: '오전' },
-  { v: 'afternoon', label: '오후' },
-  { v: 'evening', label: '저녁' },
-  { v: 'night', label: '심야' },
-  { v: 'varies', label: '변동' },
-];
-const RECOVERY_OPTIONS: { v: RecoveryTone; label: string }[] = [
-  { v: 'gentle', label: '부드럽게' },
-  { v: 'normal', label: '보통' },
-  { v: 'encouraging', label: '응원' },
-];
-const REMINDER_OPTIONS: { v: ReminderFrequency; label: string }[] = [
-  { v: 'minimal', label: '최소' },
-  { v: 'standard', label: '보통' },
-  { v: 'active', label: '적극' },
-];
 
 const TONE_OPTIONS: { mode: ToneMode; label: string; desc: string }[] = [
   { mode: 'gentle', label: '부드럽게', desc: '실패도 격려로. 압박 적은 톤.' },
@@ -48,7 +25,6 @@ const CONSENT_TYPES: { type: ConsentType; label: string; desc: string }[] = [
 export function SettingsScreen() {
   const { user, setScreen } = useNavigation();
   const [settings, setSettings] = useState<UserSettings | null>(null);
-  const [profile, setProfile] = useState<ProfileSettings | null>(null);
   const [consents, setConsents] = useState<ConsentRecord[]>([]);
   const [pushEnabled, setPushEnabled] = useState(false);
   const [pushBusy, setPushBusy] = useState(false);
@@ -66,10 +42,6 @@ export function SettingsScreen() {
           setSettings({ toneMode: user.toneMode, language: 'ko', timezone: user.timezone });
         }
       },
-    );
-    settingsApi.getProfile().then(
-      (p) => { if (!cancelled) setProfile(p); },
-      () => { /* 미구현/네트워크 — 프로필 섹션 숨김 */ },
     );
     privacyApi.consents().then(
       (c) => { if (!cancelled) setConsents(c); },
@@ -94,16 +66,6 @@ export function SettingsScreen() {
       showToast('톤이 바뀌었어요');
     } catch (err) {
       if (err instanceof ApiError) showToast('서버 미동작 — 로컬에만 적용');
-    }
-  };
-
-  const patchProfile = async (patch: ProfileUpdate) => {
-    try {
-      const updated = await settingsApi.updateProfile(patch);
-      setProfile(updated); // 서버가 병합된 전체 프로필을 돌려줌 (진실 소스)
-      showToast('저장했어요');
-    } catch (err) {
-      if (err instanceof ApiError) showToast('저장에 실패했어요');
     }
   };
 
@@ -206,50 +168,20 @@ export function SettingsScreen() {
           </div>
         </section>
 
-        {/* 프로필 메모리 (리듬/선호) — 인터뷰가 채운 값을 재인터뷰 없이 편집 (#A-2) */}
-        {profile && (
-          <section>
-            <SectionLabel icon={<Waveform size={11} weight="fill" />}>나의 리듬 (프로필)</SectionLabel>
-            <div style={{ background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', borderRadius: 14, padding: 14, display: 'flex', flexDirection: 'column', gap: 14 }}>
-              <ChoiceGroup
-                label="주로 집중되는 시간대"
-                options={ENERGY_OPTIONS}
-                value={profile.behavioral?.energyCycle}
-                onPick={(v) => patchProfile({ energyCycle: v })}
-              />
-              <MinuteField
-                label="한 번에 집중하는 길이"
-                value={profile.behavioral?.attentionSpan}
-                onSave={(n) => patchProfile({ attentionSpan: n })}
-              />
-              <ChoiceGroup
-                label="회복 대화 톤"
-                options={RECOVERY_OPTIONS}
-                value={profile.interaction?.recoveryTone}
-                onPick={(v) => patchProfile({ recoveryTone: v })}
-              />
-              <ChoiceGroup
-                label="알림 빈도"
-                options={REMINDER_OPTIONS}
-                value={profile.interaction?.reminderFrequency}
-                onPick={(v) => patchProfile({ reminderFrequency: v })}
-              />
-              <MinuteField
-                label="회복 시 최소 단위 (막혔을 때 이만큼만 해보기)"
-                value={profile.downscopeUnitMin ?? undefined}
-                onSave={(n) => patchProfile({ downscopeUnitMin: n })}
-              />
-              <ToggleRow
-                label="지칠 땐 휴식 제안 받기"
-                on={profile.restOk ?? false}
-                onToggle={() => patchProfile({ restOk: !(profile.restOk ?? false) })}
-              />
-              <div style={{ fontSize: 10, color: 'var(--text-3)', lineHeight: 1.5 }}>
-                온보딩 인터뷰에서 파악한 값이에요. 여기서 바꾸면 인터뷰를 다시 하지 않아도 반영돼요.
-              </div>
+        {/* 내 정보 — 사용자 메모리(리듬/선호)는 별도 화면에서 조회·편집 */}
+        <section>
+          <SectionLabel icon={<IdentificationCard size={11} weight="fill" />}>내 정보</SectionLabel>
+          <button
+            onClick={() => setScreen('my-info')}
+            style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '12px 14px', width: '100%', background: 'var(--surface-raised)', border: '1.5px solid var(--sand-200)', borderRadius: 12, cursor: 'pointer', fontFamily: 'inherit', textAlign: 'left' }}
+          >
+            <div style={{ flex: 1 }}>
+              <div style={{ fontWeight: 600, fontSize: 13, color: 'var(--text-1)' }}>나의 리듬 · 프로필</div>
+              <div style={{ fontSize: 11, color: 'var(--text-3)', marginTop: 2 }}>인터뷰가 파악한 집중 시간·회복 선호를 확인하고 바꿔요.</div>
             </div>
-          </section>
-        )}
+            <CaretRight size={16} color="var(--text-3)" />
+          </button>
+        </section>
 
         {/* Push */}
         <section>
@@ -356,123 +288,6 @@ function SectionLabel({ icon, children, tone = 'default' }: { icon?: React.React
     <div style={{ display: 'flex', alignItems: 'center', gap: 5, fontSize: 10, fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: tone === 'danger' ? 'var(--danger)' : 'var(--text-3)', fontFamily: 'var(--font-mono)', marginBottom: 8 }}>
       {icon}
       {children}
-    </div>
-  );
-}
-
-// 사람마다 다른 '분' 값 — 고정 선택지 대신 자유 수정 입력(스텝 5분 · 5~240 범위).
-function MinuteField({
-  label,
-  value,
-  onSave,
-}: {
-  label: string;
-  value: number | undefined;
-  onSave: (n: number) => void;
-}) {
-  const [text, setText] = useState(value != null ? String(value) : '');
-  useEffect(() => {
-    setText(value != null ? String(value) : '');
-  }, [value]);
-
-  const clamp = (n: number) => Math.min(240, Math.max(5, n));
-  const commit = () => {
-    const n = parseInt(text, 10);
-    if (!Number.isNaN(n)) {
-      const c = clamp(n);
-      if (c !== value) onSave(c);
-      else setText(String(c));
-    } else {
-      setText(value != null ? String(value) : ''); // 무효 입력 되돌림
-    }
-  };
-  const bump = (delta: number) => onSave(clamp((value ?? 30) + delta));
-
-  const stepBtn = (labelTxt: string, onClick: () => void) => (
-    <button
-      onClick={onClick}
-      style={{ width: 34, height: 'var(--ctrl-sm)', borderRadius: 9, border: '1.5px solid var(--sand-200)', background: 'var(--surface-raised)', color: 'var(--text-1)', fontSize: 16, fontWeight: 700, cursor: 'pointer', fontFamily: 'inherit', lineHeight: 1 }}
-    >
-      {labelTxt}
-    </button>
-  );
-
-  return (
-    <div>
-      <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--text-2)', marginBottom: 7 }}>{label}</div>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-        {stepBtn('−', () => bump(-5))}
-        <input
-          type="number"
-          inputMode="numeric"
-          value={text}
-          min={5}
-          max={240}
-          onChange={(e) => setText(e.target.value)}
-          onBlur={commit}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') (e.target as HTMLInputElement).blur();
-          }}
-          style={{ width: 64, height: 'var(--ctrl-sm)', textAlign: 'center', borderRadius: 9, border: '1.5px solid var(--sand-200)', background: 'var(--surface-raised)', color: 'var(--text-1)', fontSize: 14, fontWeight: 700, fontFamily: 'inherit', outline: 'none' }}
-        />
-        <span style={{ fontSize: 12, color: 'var(--text-3)' }}>분</span>
-        {stepBtn('+', () => bump(5))}
-      </div>
-    </div>
-  );
-}
-
-function ToggleRow({ label, on, onToggle }: { label: string; on: boolean; onToggle: () => void }) {
-  return (
-    <button
-      onClick={onToggle}
-      style={{ display: 'flex', alignItems: 'center', gap: 10, width: '100%', padding: 0, background: 'transparent', border: 'none', cursor: 'pointer', fontFamily: 'inherit', textAlign: 'left' }}
-    >
-      <div style={{ flex: 1, fontSize: 12, fontWeight: 600, color: 'var(--text-2)' }}>{label}</div>
-      <Toggle on={on} />
-    </button>
-  );
-}
-
-function ChoiceGroup<T extends string | number>({
-  label,
-  options,
-  value,
-  onPick,
-}: {
-  label: string;
-  options: { v: T; label: string }[];
-  value: T | undefined;
-  onPick: (v: T) => void;
-}) {
-  return (
-    <div>
-      <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--text-2)', marginBottom: 7 }}>{label}</div>
-      <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
-        {options.map((o) => {
-          const active = value === o.v;
-          return (
-            <button
-              key={String(o.v)}
-              onClick={() => onPick(o.v)}
-              style={{
-                height: 'var(--ctrl-sm)',
-                padding: '0 13px',
-                borderRadius: 9999,
-                border: `1.5px solid ${active ? 'var(--brand)' : 'var(--sand-200)'}`,
-                background: active ? 'var(--brand-soft)' : 'var(--surface-raised)',
-                color: active ? 'var(--brand)' : 'var(--text-2)',
-                fontSize: 12,
-                fontWeight: 600,
-                cursor: 'pointer',
-                fontFamily: 'inherit',
-              }}
-            >
-              {o.label}
-            </button>
-          );
-        })}
-      </div>
     </div>
   );
 }

--- a/src/screens/WeeklyPlanGenerationScreen.tsx
+++ b/src/screens/WeeklyPlanGenerationScreen.tsx
@@ -9,7 +9,7 @@ import { ApiError, plansApi } from '../lib/api';
 import { localDateStr } from '../lib/dates';
 import { useNavigation } from '../contexts/NavigationContext';
 import type { Block } from '../types';
-import type { FirstPlanGenerateRequest, ScheduledBlockPreview, WeeklyPlanResponse } from '../types/api';
+import type { FirstPlanGenerateRequest, PlanDensity, ScheduledBlockPreview, WeeklyPlanResponse } from '../types/api';
 
 // 이미 저장된 이번 주 계획(GET /plans/weekly) → 화면 Block. 온보딩 4/4 에서 새 draft
 // 뒤에 흐리게 겹쳐 보여줘 "기존 계획이 사라진 것처럼" 보이는 오해를 없앤다(#103).
@@ -131,6 +131,11 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
   const [usingRealPlan, setUsingRealPlan] = useState(false);
   // 라이브 호출을 실제로 시도했으나 실패했는지 — 배너 문구를 정직하게 맞추는 용도.
   const [genFailed, setGenFailed] = useState(false);
+  // 계획 분량(밀도) — 재생성 시 body.density 로 전달. ref 로 최신값을 읽어 generatePlan
+  // 콜백의 deps 를 바꾸지 않는다(density 변경만으로 자동 재생성되지 않게).
+  const [density, setDensity] = useState<PlanDensity>('standard');
+  const densityRef = React.useRef(density);
+  densityRef.current = density;
   // 응답의 aiSource — 'rule' 이면 AiDraftCard 가 "오프라인 모드(룰 기반)" 안내를 띄운다(#12).
   const [planAiSource, setPlanAiSource] = useState<'llm' | 'rule'>('llm');
   // 응답의 warnings[] — 스케줄러가 남긴 경고(예: 슬롯 부족) 헤더 표시(#6).
@@ -182,7 +187,7 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
     const attempt = async (): Promise<void> => {
       for (let i = 0; i < 3; i++) {
         try {
-          const plan = await plansApi.generate(generateInput, key);
+          const plan = await plansApi.generate({ ...generateInput, density: densityRef.current }, key);
           planIdRef.current = plan.planId;
           // 200 응답 = 연동 성공. 블록이 0개여도 '예시'가 아니라 '아직 계획 없음'인
           // 실데이터다 — 더미로 가리지 않고 그대로 반영한다.
@@ -451,6 +456,44 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
           onAccept 은 우리 handleContinue (plansApi.approve mock-and-replace 포함) 사용.
           onReject 는 generating=true 로 되돌려 useEffect 의 plansApi.generate 재호출. */}
       <div style={{ flexShrink: 0, padding: '10px 14px', paddingBottom: 'max(14px, env(safe-area-inset-bottom, 14px))', background: 'var(--surface-ground)' }}>
+        {/* 계획 분량(밀도) 선택 — '재생성' 시 body.density 로 전달돼 생성되는 카드 수를 좌우한다.
+            선택만으로는 재생성하지 않는다(아래 재생성 버튼을 눌러야 반영). */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 10 }}>
+          <span style={{ fontSize: 11, color: 'var(--text-3)', flexShrink: 0 }}>계획 분량</span>
+          <div style={{ display: 'inline-flex', gap: 3, background: 'rgba(0,0,0,0.05)', borderRadius: 9999, padding: 3 }}>
+            {(
+              [
+                ['light', '가볍게'],
+                ['standard', '표준'],
+                ['intense', '촘촘히'],
+              ] as [PlanDensity, string][]
+            ).map(([val, label]) => {
+              const active = density === val;
+              return (
+                <button
+                  key={val}
+                  onClick={() => setDensity(val)}
+                  disabled={generating}
+                  style={{
+                    height: 'var(--ctrl-xs)',
+                    padding: '0 12px',
+                    borderRadius: 9999,
+                    border: 'none',
+                    cursor: generating ? 'default' : 'pointer',
+                    fontFamily: 'inherit',
+                    fontSize: 11,
+                    fontWeight: 600,
+                    background: active ? 'var(--text-1)' : 'transparent',
+                    color: active ? '#FAF6EE' : 'var(--text-2)',
+                    transition: 'background 120ms, color 120ms',
+                  }}
+                >
+                  {label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
         <AiDraftCard
           isDraft={true}
           aiSource={planAiSource}

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -597,10 +597,14 @@ export interface FirstPlanResponse {
 }
 
 // POST /plans/generate 요청 본문 (모두 선택 — 서버가 인터뷰 결과로 보완).
+// 계획 분량(밀도) 프리셋 — 재생성 시 사용자가 조절. light≈주3 / standard≈주5 / intense≈주8 세션.
+export type PlanDensity = 'light' | 'standard' | 'intense';
+
 export interface FirstPlanGenerateRequest {
   interviewSessionId?: string | null;
   targetDate?: string | null; // YYYY-MM-DD
   outcome?: Record<string, unknown> | null; // InterviewOutcome (보통 서버 파생)
+  density?: PlanDensity; // 생략 시 서버 기본값 'standard'
 }
 
 // POST /plans/{planId}/approve

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -712,6 +712,43 @@ export interface UserSettings {
   timezone: string;
 }
 
+// ── 지속형 프로필 메모리 (GET/PATCH /settings/profile) — #A-1·A-2 ──
+export type EnergyCycle = 'morning' | 'afternoon' | 'evening' | 'night' | 'varies';
+export type RecoveryTone = 'gentle' | 'normal' | 'encouraging';
+export type ReminderFrequency = 'minimal' | 'standard' | 'active';
+
+export interface BehavioralProfileView {
+  energyCycle: EnergyCycle;
+  attentionSpan: number;
+  timeChunkPreference: string;
+  preferredStartTime: string | null;
+  preferredEndTime: string | null;
+}
+
+export interface InteractionStyleView {
+  recoveryTone: RecoveryTone;
+  suggestionStyle: string;
+  explanationDepth: string;
+  reminderFrequency: ReminderFrequency;
+}
+
+export interface ProfileSettings {
+  behavioral: BehavioralProfileView | null;
+  interaction: InteractionStyleView | null;
+  downscopeUnitMin: number | null; // 회복 시 최소 단위(분)
+  restOk: boolean | null; // 회복 시 휴식 제안 수용
+}
+
+export interface ProfileUpdate {
+  energyCycle?: EnergyCycle;
+  attentionSpan?: number;
+  timeChunkPreference?: string;
+  recoveryTone?: RecoveryTone;
+  reminderFrequency?: ReminderFrequency;
+  downscopeUnitMin?: number;
+  restOk?: boolean;
+}
+
 export interface ToneModeUpdateRequest {
   toneMode: ToneMode;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -30,7 +30,8 @@ export type ScreenId =
   | 'inbox'
   | 'review'
   | 'goals'
-  | 'settings';
+  | 'settings'
+  | 'my-info';
 
 export type TabId = 'today' | 'weekly' | 'inbox' | 'review';
 


### PR DESCRIPTION
이번 이니셔티브의 프론트 작업 묶음(FE origin 에 main 만 있어 한 PR로).

- **계획 분량 셀렉터** — 재생성 시 가볍게/표준/촘촘(density).
- **프로필 편집(A-2)** — 리듬·회복 선호 편집 화면.
- **목표 심화 진행바(B)** — 초기 슬롯 추정치 반영.
- **내 정보 탭** — 설정에서 프로필(사용자 메모리)을 별도 `MyInfoScreen` 으로 분리, 거기서 조회·편집.

슬롯 카탈로그를 API 로 렌더하므로 주당시간·세션길이 등 신규 슬롯은 FE 코드 변경 없이 자동 노출.

🤖 Generated with [Claude Code](https://claude.com/claude-code)