### PR TITLE
feat(planning): 마일스톤 확인·편집 화면 (Phase 2 FE)

### DIFF
--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -7,7 +7,7 @@ import { ToastProvider } from '../contexts/ToastContext';
 import { IosInstallCard } from '../components/IosInstallCard';
 import { ApiError, authApi, friendlyError, onboardingApi, setAccessToken } from '../lib/api';
 import type { ScreenId, TabId } from '../types';
-import type { OnboardingState, UserProfile } from '../types/api';
+import type { Milestone, OnboardingState, UserProfile } from '../types/api';
 
 // stub 로그인 idToken 결정 (백엔드 AUTH_STUB 모드).
 //  - 기본: 브라우저별 전용 계정 `demo:<deviceId>` — 여러 테스터/탭이 같은 데모 계정을
@@ -54,6 +54,7 @@ export function AppShell() {
   const [isBootstrapping, setIsBootstrapping] = useState(true);
   const [weekOffset, setWeekOffset] = useState(0);
   const [interviewSessionId, setInterviewSessionId] = useState<string | null>(null);
+  const [plannedMilestones, setPlannedMilestones] = useState<Milestone[] | null>(null);
   // 실제 로그인 화면(구글/데모)을 보여줘야 하는지 — stub 자동 로그인이 꺼졌거나(?login=1) 401 뒤 재로그인 필요할 때.
   const [needsLogin, setNeedsLogin] = useState(false);
   const [authBusy, setAuthBusy] = useState(false);
@@ -212,7 +213,7 @@ export function AppShell() {
 
   return (
     <NavigationContext.Provider
-      value={{ screen, tab, setScreen, setTab, user, onboardingState, isBootstrapping, weekOffset, setWeekOffset, interviewSessionId, setInterviewSessionId }}
+      value={{ screen, tab, setScreen, setTab, user, onboardingState, isBootstrapping, weekOffset, setWeekOffset, interviewSessionId, setInterviewSessionId, plannedMilestones, setPlannedMilestones }}
     >
       <ToastProvider>
         {/* 뷰포트에 맞는 트리 하나만 마운트(둘 다 마운트 후 CSS 로만 숨기면 데이터 페칭이 2배로 나감). */}

--- a/src/app/ReActionMerged.tsx
+++ b/src/app/ReActionMerged.tsx
@@ -5,6 +5,7 @@ import { SystemIntroScreen } from '../screens/SystemIntroScreen';
 import { GoalIntakeScreen } from '../screens/GoalIntakeScreen';
 import { GoalClassificationScreen } from '../screens/GoalClassificationScreen';
 import { SetupScreen } from '../screens/SetupScreen';
+import { MilestoneConfirmScreen } from '../screens/MilestoneConfirmScreen';
 import { WeeklyPlanGenerationScreen } from '../screens/WeeklyPlanGenerationScreen';
 import { MorningBriefScreen } from '../screens/MorningBriefScreen';
 import { InboxScreen } from '../screens/InboxScreen';
@@ -33,7 +34,8 @@ const NAV_META: Record<ScreenId, { label: string; back: ScreenId | null }> = {
   'goal-intake':            { label: '목표 파악',      back: 'intro' },
   'goal-classify':          { label: '목표 분류',      back: 'goal-intake' },
   'setup':                  { label: '마무리 확인',    back: 'goal-classify' },
-  'weekly-plan':            { label: '주간 계획 생성', back: 'setup' },
+  'milestone-confirm':      { label: '계획의 큰 그림', back: 'setup' },
+  'weekly-plan':            { label: '주간 계획 생성', back: 'milestone-confirm' },
   'morning-brief':          { label: '모닝 브리프',    back: 'weekly-plan' },
   'today':                  { label: '오늘의 실행',    back: null },
   'focus':                  { label: '집중 모드',      back: 'today' },
@@ -224,8 +226,9 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
           <GoalClassificationScreen onNext={() => setScreen('setup')} outcome={interviewOutcome} />
         )}
         {screen === 'setup' && (
-          <SetupScreen onDone={() => setScreen('weekly-plan')} />
+          <SetupScreen onDone={() => setScreen('milestone-confirm')} />
         )}
+        {screen === 'milestone-confirm' && <MilestoneConfirmScreen />}
         {screen === 'weekly-plan' && (
           <WeeklyPlanGenerationScreen onContinue={() => setScreen('morning-brief')} />
         )}

--- a/src/contexts/NavigationContext.tsx
+++ b/src/contexts/NavigationContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext } from 'react';
 import type { ScreenId, TabId } from '../types';
-import type { OnboardingState, UserProfile } from '../types/api';
+import type { Milestone, OnboardingState, UserProfile } from '../types/api';
 
 export interface NavigationContextType {
   screen: ScreenId;
@@ -21,6 +21,10 @@ export interface NavigationContextType {
   // interviewSessionId 로 실제 계획을 생성할 때 사용한다. 인터뷰 전이면 null.
   interviewSessionId: string | null;
   setInterviewSessionId: (id: string | null) => void;
+  // 사용자가 확인·편집해 확정한 마일스톤(Phase 2). weekly-plan 의 /plans/generate 가
+  // milestones 로 넘겨 그 구조대로 계획을 세운다. 마일스톤 없이 자동 생성이면 null.
+  plannedMilestones: Milestone[] | null;
+  setPlannedMilestones: (m: Milestone[] | null) => void;
 }
 
 export const NavigationContext = createContext<NavigationContextType>({
@@ -35,6 +39,8 @@ export const NavigationContext = createContext<NavigationContextType>({
   setWeekOffset: () => {},
   interviewSessionId: null,
   setInterviewSessionId: () => {},
+  plannedMilestones: null,
+  setPlannedMilestones: () => {},
 });
 
 export const useNavigation = () => useContext(NavigationContext);

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -20,6 +20,7 @@ import type {
   FirstPlanApproveResponse,
   FirstPlanGenerateRequest,
   FirstPlanResponse,
+  MilestoneListResponse,
   FixedSchedule,
   FixedScheduleCreateRequest,
   FixedScheduleUpdateRequest,
@@ -448,6 +449,10 @@ export const plansApi = {
   // Idempotency-Key 동봉 시 같은 키 재요청은 동일 planId 를 돌려준다(재시도 안전, #6).
   generate: (body: FirstPlanGenerateRequest = {}, idempotencyKey?: string) =>
     request<FirstPlanResponse>('/plans/generate', { method: 'POST', body, idempotencyKey }),
+
+  // Stage A(#milestones) — 목표를 중간 목표 3~5개로. 사용자 확인·편집 후 generate 에 넘긴다.
+  milestones: (body: FirstPlanGenerateRequest = {}) =>
+    request<MilestoneListResponse>('/plans/milestones', { method: 'POST', body }),
 
   get: (planId: string) => request<FirstPlanResponse>(`/plans/${planId}`),
 

--- a/src/screens/MilestoneConfirmScreen.tsx
+++ b/src/screens/MilestoneConfirmScreen.tsx
@@ -1,0 +1,165 @@
+import { useEffect, useState } from 'react';
+import { CaretLeft, CaretUp, CaretDown, Plus, X, Sparkle, ArrowRight, Path } from '@phosphor-icons/react';
+import { ApiError, plansApi } from '../lib/api';
+import { useNavigation } from '../contexts/NavigationContext';
+import type { Milestone } from '../types/api';
+
+// 인터뷰 후, 계획을 세우기 전에 '중간 목표(마일스톤)' 뼈대를 사용자가 확인·편집하는 화면(Phase 2).
+// 확정하면 그 구조대로 계획이 생성되고, 건너뛰면 마일스톤 없이 자동 분해된다.
+export function MilestoneConfirmScreen() {
+  const { interviewSessionId, setScreen, setPlannedMilestones } = useNavigation();
+  const [milestones, setMilestones] = useState<Milestone[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setFailed(false);
+    plansApi
+      .milestones(interviewSessionId ? { interviewSessionId } : {})
+      .then(
+        (res) => {
+          if (!cancelled) {
+            setMilestones(res.milestones ?? []);
+            setLoading(false);
+          }
+        },
+        (err) => {
+          if (!cancelled) {
+            setFailed(!(err instanceof ApiError) || err.status !== 401);
+            setLoading(false);
+          }
+        },
+      );
+    return () => { cancelled = true; };
+  }, [interviewSessionId]);
+
+  const update = (i: number, patch: Partial<Milestone>) =>
+    setMilestones((ms) => ms.map((m, idx) => (idx === i ? { ...m, ...patch } : m)));
+  const remove = (i: number) => setMilestones((ms) => ms.filter((_, idx) => idx !== i));
+  const move = (i: number, dir: -1 | 1) =>
+    setMilestones((ms) => {
+      const j = i + dir;
+      if (j < 0 || j >= ms.length) return ms;
+      const next = [...ms];
+      [next[i], next[j]] = [next[j], next[i]];
+      return next;
+    });
+  const add = () => setMilestones((ms) => [...ms, { title: '', summary: '' }]);
+
+  const confirmAndPlan = () => {
+    const cleaned = milestones.map((m) => ({ title: m.title.trim(), summary: m.summary.trim() })).filter((m) => m.title);
+    setPlannedMilestones(cleaned.length > 0 ? cleaned : null);
+    setScreen('weekly-plan');
+  };
+  const skip = () => {
+    setPlannedMilestones(null);
+    setScreen('weekly-plan');
+  };
+
+  const canConfirm = milestones.some((m) => m.title.trim());
+
+  return (
+    <div style={{ height: '100%', display: 'flex', flexDirection: 'column', background: 'var(--surface-ground)' }}>
+      <div style={{ flex: 1, overflowY: 'auto', padding: '14px 18px 24px', display: 'flex', flexDirection: 'column', gap: 16 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <button
+            onClick={() => setScreen('setup')}
+            style={{ width: 36, height: 36, borderRadius: 9999, border: 'none', background: 'var(--surface-raised)', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer' }}
+            aria-label="뒤로"
+          >
+            <CaretLeft size={16} />
+          </button>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 7 }}>
+            <Path size={20} weight="fill" color="var(--brand)" />
+            <h1 style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 22, letterSpacing: '-0.02em', margin: 0 }}>계획의 큰 그림</h1>
+          </div>
+        </div>
+
+        <p style={{ fontSize: 13, color: 'var(--text-2)', lineHeight: 1.6, margin: 0 }}>
+          목표를 이 <b style={{ color: 'var(--text-1)' }}>중간 단계</b>들로 나눠 계획을 세울게요.
+          순서를 바꾸거나 고치고 더하고 빼도 돼요 — 확정하면 이 구조 그대로 계획이 만들어져요.
+        </p>
+
+        {loading ? (
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '30px 0', justifyContent: 'center', color: 'var(--text-3)', fontSize: 13 }}>
+            <Sparkle size={16} weight="fill" className="pulse" /> 중간 목표를 그리는 중…
+          </div>
+        ) : failed ? (
+          <div style={{ background: 'var(--surface-raised)', border: '1px dashed var(--sand-300)', borderRadius: 14, padding: '20px 14px', textAlign: 'center', display: 'flex', flexDirection: 'column', gap: 10 }}>
+            <div style={{ fontSize: 13, color: 'var(--text-3)', lineHeight: 1.5 }}>중간 목표를 불러오지 못했어요. 마일스톤 없이 바로 계획을 세울 수 있어요.</div>
+            <button onClick={skip} style={{ alignSelf: 'center', padding: '9px 16px', borderRadius: 10, border: 'none', background: 'var(--brand)', color: '#FFFCF6', fontWeight: 700, fontSize: 13, cursor: 'pointer', fontFamily: 'inherit' }}>바로 계획 세우기</button>
+          </div>
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+            {milestones.map((m, i) => (
+              <div key={i} style={{ background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', borderRadius: 14, padding: 12, display: 'flex', gap: 10 }}>
+                <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 2, paddingTop: 2 }}>
+                  <div style={{ width: 22, height: 22, borderRadius: 7, background: 'var(--brand-soft)', color: 'var(--brand)', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 12, fontWeight: 700, fontFamily: 'var(--font-mono)' }}>{i + 1}</div>
+                  <button onClick={() => move(i, -1)} disabled={i === 0} style={iconBtn(i === 0)} aria-label="위로"><CaretUp size={13} /></button>
+                  <button onClick={() => move(i, 1)} disabled={i === milestones.length - 1} style={iconBtn(i === milestones.length - 1)} aria-label="아래로"><CaretDown size={13} /></button>
+                </div>
+                <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 6, minWidth: 0 }}>
+                  <input
+                    value={m.title}
+                    onChange={(e) => update(i, { title: e.target.value })}
+                    placeholder="중간 목표 (예: 기초 문법 익히기)"
+                    style={{ border: 'none', background: 'transparent', color: 'var(--text-1)', fontSize: 14, fontWeight: 700, fontFamily: 'inherit', outline: 'none', padding: 0 }}
+                  />
+                  <input
+                    value={m.summary}
+                    onChange={(e) => update(i, { summary: e.target.value })}
+                    placeholder="한 줄 설명 (선택)"
+                    style={{ border: 'none', background: 'transparent', color: 'var(--text-3)', fontSize: 12, fontFamily: 'inherit', outline: 'none', padding: 0 }}
+                  />
+                </div>
+                <button onClick={() => remove(i)} style={{ ...iconBtn(false), color: 'var(--text-3)' }} aria-label="삭제"><X size={14} /></button>
+              </div>
+            ))}
+            <button
+              onClick={add}
+              style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6, padding: '11px 0', borderRadius: 12, border: '1.5px dashed var(--sand-300)', background: 'transparent', color: 'var(--text-2)', fontSize: 13, fontWeight: 600, cursor: 'pointer', fontFamily: 'inherit' }}
+            >
+              <Plus size={14} weight="bold" /> 중간 목표 추가
+            </button>
+          </div>
+        )}
+      </div>
+
+      {!loading && !failed && (
+        <div style={{ padding: '12px 18px calc(12px + env(safe-area-inset-bottom, 0px))', borderTop: '1px solid var(--sand-200)', background: 'var(--surface-ground)', display: 'flex', flexDirection: 'column', gap: 8 }}>
+          <button
+            onClick={confirmAndPlan}
+            disabled={!canConfirm}
+            style={{ width: '100%', height: 'var(--ctrl-lg)', borderRadius: 12, border: 'none', background: 'var(--brand)', color: '#FFFCF6', fontWeight: 700, fontSize: 15, fontFamily: 'inherit', cursor: canConfirm ? 'pointer' : 'not-allowed', opacity: canConfirm ? 1 : 0.5, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8 }}
+          >
+            이대로 계획 세우기 <ArrowRight size={16} weight="bold" />
+          </button>
+          <button
+            onClick={skip}
+            style={{ width: '100%', height: 40, borderRadius: 12, border: 'none', background: 'transparent', color: 'var(--text-3)', fontWeight: 600, fontSize: 12.5, fontFamily: 'inherit', cursor: 'pointer' }}
+          >
+            그냥 자동으로 세워줘 (마일스톤 없이)
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function iconBtn(disabled: boolean): React.CSSProperties {
+  return {
+    width: 24,
+    height: 20,
+    borderRadius: 6,
+    border: 'none',
+    background: 'transparent',
+    color: disabled ? 'var(--sand-300)' : 'var(--text-2)',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    cursor: disabled ? 'default' : 'pointer',
+    padding: 0,
+  };
+}

--- a/src/screens/WeeklyPlanGenerationScreen.tsx
+++ b/src/screens/WeeklyPlanGenerationScreen.tsx
@@ -166,7 +166,10 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
   // POST /plans/generate 가 빈 본문이면 "최근 정상 종료 인터뷰"로 자동 복구하므로
   // (api-contract v1.16) 항상 호출한다 — sessionId 가 있으면 그 세션을 명시.
   // 완료된 인터뷰가 아예 없으면 422 → genFailed 배너로 정직하게 안내.
-  const { interviewSessionId, setScreen } = useNavigation();
+  const { interviewSessionId, setScreen, plannedMilestones } = useNavigation();
+  // 확정 마일스톤을 ref 로 잡아 generatePlan 콜백 deps 를 흔들지 않는다(#milestones Stage B).
+  const milestonesRef = React.useRef(plannedMilestones);
+  milestonesRef.current = plannedMilestones;
   const generateInput: FirstPlanGenerateRequest = interviewSessionId
     ? { interviewSessionId }
     : {};
@@ -189,7 +192,10 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
     const attempt = async (): Promise<void> => {
       for (let i = 0; i < 3; i++) {
         try {
-          const plan = await plansApi.generate({ ...generateInput, density: densityRef.current }, key);
+          const plan = await plansApi.generate(
+            { ...generateInput, density: densityRef.current, milestones: milestonesRef.current ?? undefined },
+            key,
+          );
           planIdRef.current = plan.planId;
           // 200 응답 = 연동 성공. 블록이 0개여도 '예시'가 아니라 '아직 계획 없음'인
           // 실데이터다 — 더미로 가리지 않고 그대로 반영한다.

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -600,11 +600,24 @@ export interface FirstPlanResponse {
 // 계획 분량(밀도) 프리셋 — 재생성 시 사용자가 조절. light≈주3 / standard≈주5 / intense≈주8 세션.
 export type PlanDensity = 'light' | 'standard' | 'intense';
 
+// 중간 목표(마일스톤) — 사용자가 확인·편집하는 계획 뼈대 (Phase 2).
+export interface Milestone {
+  title: string;
+  summary: string;
+}
+
+// POST /plans/milestones 응답 (Stage A).
+export interface MilestoneListResponse {
+  milestones: Milestone[];
+  aiSource: 'llm' | 'rule';
+}
+
 export interface FirstPlanGenerateRequest {
   interviewSessionId?: string | null;
   targetDate?: string | null; // YYYY-MM-DD
   outcome?: Record<string, unknown> | null; // InterviewOutcome (보통 서버 파생)
   density?: PlanDensity; // 생략 시 서버 기본값 'standard'
+  milestones?: Milestone[]; // 사용자가 확정한 마일스톤 (있으면 분해가 branch 로 고정, Stage B)
 }
 
 // POST /plans/{planId}/approve

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -19,6 +19,7 @@ export type ScreenId =
   | 'goal-intake'
   | 'goal-classify'
   | 'setup'
+  | 'milestone-confirm'
   | 'weekly-plan'
   | 'morning-brief'
   | 'today'


### PR DESCRIPTION
백엔드 Stage A/B 의 FE. 인터뷰 후 계획 생성 직전에 사용자가 계획 뼈대를 확인·편집.

- MilestoneConfirmScreen: /plans/milestones → 편집 카드(제목·요약 수정, 순서 ↑↓, 추가/삭제). [이대로 계획 세우기](확정→generate) / [그냥 자동으로](스킵).
- 흐름: setup → milestone-confirm → weekly-plan. plannedMilestones 를 generate 로 전달.

tsc clean. 스택 base: `feat/materials-paste-ui`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)