### PR TITLE
chore(api): 백엔드 API 동기화 (routine)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -426,9 +426,80 @@
         "title": "AvailabilityProfile",
         "type": "object"
       },
-      "BlockEditRequest": {
-        "description": "PATCH /plans/{planId}/blocks/{blockId} — 15분 snap 이동.\n\n`endAt` 생략 시 기존 길이를 보존한 채 시작만 옮긴다. 시각은 KST ISO 8601.",
+      "BehavioralProfileView": {
+        "description": "behavioral_profiles 의 사용자 편집 대상 필드.",
         "properties": {
+          "attentionSpan": {
+            "title": "Attentionspan",
+            "type": "integer"
+          },
+          "energyCycle": {
+            "enum": [
+              "morning",
+              "afternoon",
+              "evening",
+              "night",
+              "varies"
+            ],
+            "title": "Energycycle",
+            "type": "string"
+          },
+          "preferredEndTime": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Preferredendtime"
+          },
+          "preferredStartTime": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Preferredstarttime"
+          },
+          "timeChunkPreference": {
+            "enum": [
+              "10",
+              "20",
+              "30",
+              "60",
+              "90"
+            ],
+            "title": "Timechunkpreference",
+            "type": "string"
+          }
+        },
+        "required": [
+          "energyCycle",
+          "attentionSpan",
+          "timeChunkPreference"
+        ],
+        "title": "BehavioralProfileView",
+        "type": "object"
+      },
+      "BlockEditRequest": {
+        "description": "PATCH /plans/{planId}/blocks/{blockId} — 15분 snap 이동 + 목표(category)/제목 수정.\n\n`endAt` 생략 시 기존 길이를 보존한 채 시작만 옮긴다. 시각은 KST ISO 8601.\n`category`/`title` 을 주면 블록이 매달린 action_item 을 갱신한다 — 같은 액션의 모든\n세션 블록에 반영되며, 미지원 category 는 'other' 로 정규화한다. 미지정 필드는 유지.",
+        "properties": {
+          "category": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Category"
+          },
           "endAt": {
             "anyOf": [
               {
@@ -443,6 +514,17 @@
           "startAt": {
             "title": "Startat",
             "type": "string"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
           }
         },
         "required": [
@@ -1025,6 +1107,16 @@
       "FirstPlanGenerateRequest": {
         "description": "POST /plans/generate (첫 계획) 요청.\n\n`interview_session_id` 로 확정된 `InterviewOutcome` 을 참조하거나(서버가 로드),\n온보딩 흐름에서 outcome 을 인라인 전달할 수 있다(`outcome`). 둘 중 하나는 필수 —\n검증은 라우터/오케스트레이터 VALIDATING 단계에서 수행.",
         "properties": {
+          "density": {
+            "default": "standard",
+            "enum": [
+              "light",
+              "standard",
+              "intense"
+            ],
+            "title": "Density",
+            "type": "string"
+          },
           "interviewSessionId": {
             "anyOf": [
               {
@@ -1045,6 +1137,15 @@
                 "type": "null"
               }
             ]
+          },
+          "scope": {
+            "default": "horizon",
+            "enum": [
+              "week",
+              "horizon"
+            ],
+            "title": "Scope",
+            "type": "string"
           },
           "targetDate": {
             "anyOf": [
@@ -1367,6 +1468,17 @@
             "minimum": 0.0,
             "title": "Confidence",
             "type": "number"
+          },
+          "currentLevel": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Currentlevel"
           },
           "deadline": {
             "anyOf": [
@@ -2099,6 +2211,21 @@
             ],
             "title": "Promotedgoalid"
           },
+          "promotedTo": {
+            "anyOf": [
+              {
+                "enum": [
+                  "goal",
+                  "action"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Promotedto"
+          },
           "rawText": {
             "title": "Rawtext",
             "type": "string"
@@ -2171,6 +2298,55 @@
           }
         },
         "title": "InboxUpdateRequest",
+        "type": "object"
+      },
+      "InteractionStyleView": {
+        "description": "interaction_styles 의 사용자 편집 대상 필드.",
+        "properties": {
+          "explanationDepth": {
+            "enum": [
+              "brief",
+              "normal",
+              "detailed"
+            ],
+            "title": "Explanationdepth",
+            "type": "string"
+          },
+          "recoveryTone": {
+            "enum": [
+              "gentle",
+              "normal",
+              "encouraging"
+            ],
+            "title": "Recoverytone",
+            "type": "string"
+          },
+          "reminderFrequency": {
+            "enum": [
+              "minimal",
+              "standard",
+              "active"
+            ],
+            "title": "Reminderfrequency",
+            "type": "string"
+          },
+          "suggestionStyle": {
+            "enum": [
+              "soft",
+              "neutral",
+              "firm"
+            ],
+            "title": "Suggestionstyle",
+            "type": "string"
+          }
+        },
+        "required": [
+          "recoveryTone",
+          "suggestionStyle",
+          "explanationDepth",
+          "reminderFrequency"
+        ],
+        "title": "InteractionStyleView",
         "type": "object"
       },
       "InterviewOutcome": {
@@ -2705,8 +2881,205 @@
         "title": "PreferenceProfile",
         "type": "object"
       },
+      "ProfileResponse": {
+        "description": "GET/PATCH /settings/profile — 지속형 프로필 메모리.\n\n인터뷰가 아직 안 채웠으면 각 항목 null (행 없음).\n`downscopeUnitMin`/`restOk` 는 회복 선호 — `users.focus_mode_preferences`(JSONB) 출처.",
+        "properties": {
+          "behavioral": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BehavioralProfileView"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "downscopeUnitMin": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Downscopeunitmin"
+          },
+          "interaction": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/InteractionStyleView"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "restOk": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Restok"
+          }
+        },
+        "required": [
+          "behavioral",
+          "interaction"
+        ],
+        "title": "ProfileResponse",
+        "type": "object"
+      },
+      "ProfileUpdateRequest": {
+        "description": "PATCH /settings/profile — 지정 필드만 부분 갱신. 미지정(None)은 유지.\n\nenum 외 값은 Pydantic Literal → 422 `COMMON_VALIDATION_ERROR`.",
+        "properties": {
+          "attentionSpan": {
+            "anyOf": [
+              {
+                "maximum": 240.0,
+                "minimum": 5.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Attentionspan"
+          },
+          "downscopeUnitMin": {
+            "anyOf": [
+              {
+                "maximum": 120.0,
+                "minimum": 1.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Downscopeunitmin"
+          },
+          "energyCycle": {
+            "anyOf": [
+              {
+                "enum": [
+                  "morning",
+                  "afternoon",
+                  "evening",
+                  "night",
+                  "varies"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Energycycle"
+          },
+          "explanationDepth": {
+            "anyOf": [
+              {
+                "enum": [
+                  "brief",
+                  "normal",
+                  "detailed"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Explanationdepth"
+          },
+          "recoveryTone": {
+            "anyOf": [
+              {
+                "enum": [
+                  "gentle",
+                  "normal",
+                  "encouraging"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recoverytone"
+          },
+          "reminderFrequency": {
+            "anyOf": [
+              {
+                "enum": [
+                  "minimal",
+                  "standard",
+                  "active"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reminderfrequency"
+          },
+          "restOk": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Restok"
+          },
+          "suggestionStyle": {
+            "anyOf": [
+              {
+                "enum": [
+                  "soft",
+                  "neutral",
+                  "firm"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Suggestionstyle"
+          },
+          "timeChunkPreference": {
+            "anyOf": [
+              {
+                "enum": [
+                  "10",
+                  "20",
+                  "30",
+                  "60",
+                  "90"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Timechunkpreference"
+          }
+        },
+        "title": "ProfileUpdateRequest",
+        "type": "object"
+      },
       "PushSubscribeRequest": {
-        "description": "POST /notifications/subscribe 요청 — Web Push subscription 객체.",
+        "description": "POST /notifications/subscribe 요청 — Web Push subscription 객체.\n\n브라우저 `PushSubscription.toJSON()` 의 `{endpoint, keys: {p256dh, auth}}`.\np256dh/auth 는 pywebpush 발송(payload 암호화)에 필수라 스키마에서 강제한다 —\n빠진 채 저장되면 **발송 시점**에야 터져서, 구독은 됐다고 믿는 사용자가 조용히\n알림을 못 받는다.",
         "properties": {
           "endpoint": {
             "minLength": 1,
@@ -2830,7 +3203,7 @@
         "type": "object"
       },
       "RecoveryDecisionRequest": {
-        "description": "POST /recovery/decisions 요청 (Idempotency-Key 필수, §1.7).\n\n- `decision=\"accepted\"` → `accepted_attempt_id` 필수, 나머지 pending 카드는 rejected.\n- `decision=\"skipped\"` → 모든 pending 카드 skipped (\"오늘은 쉬기\").",
+        "description": "POST /recovery/decisions 요청 (Idempotency-Key 필수, §1.7).\n\n- `decision=\"accepted\"` → `accepted_attempt_id` 필수, 나머지 pending 카드는 rejected.\n- `decision=\"edited\"` → `accepted_attempt_id` + `edited_action_text` 필수. 부수효과는\n  accepted 와 같고(형제 rejected, 새 카드 생성) **새 카드 title 만 사용자 문구**가 된다.\n  AI 원문(`suggested_action_text`)은 보존한다 — \"얼마나 고쳐 썼나\"가 AI 품질 지표다.\n  새 카드를 만들지 않는 그룹(RESCHEDULE/PARK)은 문구를 담을 곳이 없어 422.\n- `decision=\"skipped\"` → 모든 pending 카드 skipped (\"오늘은 쉬기\").",
         "properties": {
           "acceptedAttemptId": {
             "anyOf": [
@@ -2846,6 +3219,7 @@
           "decision": {
             "enum": [
               "accepted",
+              "edited",
               "skipped"
             ],
             "title": "Decision",
@@ -2862,6 +3236,18 @@
               }
             ],
             "title": "Decisionreason"
+          },
+          "editedActionText": {
+            "anyOf": [
+              {
+                "maxLength": 300,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Editedactiontext"
           },
           "executionId": {
             "title": "Executionid",
@@ -3223,6 +3609,53 @@
         "title": "ReplanBlock",
         "type": "object"
       },
+      "ReplanBlockPreview": {
+        "description": "재계획 미리보기 블록 — 기존 ActionItem 에 연결(actionId). 시각은 KST.\n\n`replacesBlockId` 는 이 새 블록이 교체하는 옛 미래 블록의 **대표 id**(미리보기용, 없으면\n백로그라 null). 실제 승인 재조정은 payload 의 `oldBlocks`(액션당 옛 블록 **전부**)를 권위로\n삼아 액션 단위로 취소·생성한다 — 한 액션이 여러 세션으로 쪼개진 경우까지 정확히(#117).",
+        "properties": {
+          "actionId": {
+            "title": "Actionid",
+            "type": "string"
+          },
+          "category": {
+            "title": "Category",
+            "type": "string"
+          },
+          "end": {
+            "format": "date-time",
+            "title": "End",
+            "type": "string"
+          },
+          "replacesBlockId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Replacesblockid"
+          },
+          "start": {
+            "format": "date-time",
+            "title": "Start",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "actionId",
+          "title",
+          "category",
+          "start",
+          "end"
+        ],
+        "title": "ReplanBlockPreview",
+        "type": "object"
+      },
       "ReplanDiffResponse": {
         "description": "GET /replan/{executionId} — S20 before/after 프리뷰 (Draft Layer).\n\n승인 전까지 `is_draft=True`. `already_approved=True` 면 이미 approve 로 블록이\n배치된 상태(멱등 재조회).",
         "properties": {
@@ -3273,6 +3706,72 @@
           "after"
         ],
         "title": "ReplanDiffResponse",
+        "type": "object"
+      },
+      "ReplanResponse": {
+        "description": "주간 재계획 미리보기 — 항상 Draft. 승인은 `/plans/replan/{planId}/approve`.",
+        "properties": {
+          "aiSource": {
+            "default": "llm",
+            "enum": [
+              "llm",
+              "rule"
+            ],
+            "title": "Aisource",
+            "type": "string"
+          },
+          "blocks": {
+            "items": {
+              "$ref": "#/components/schemas/ReplanBlockPreview"
+            },
+            "title": "Blocks",
+            "type": "array"
+          },
+          "generatedAt": {
+            "format": "date-time",
+            "title": "Generatedat",
+            "type": "string"
+          },
+          "horizon": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Horizon"
+          },
+          "isDraft": {
+            "default": true,
+            "title": "Isdraft",
+            "type": "boolean"
+          },
+          "planId": {
+            "title": "Planid",
+            "type": "string"
+          },
+          "warnings": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Warnings",
+            "type": "array"
+          },
+          "windowStart": {
+            "title": "Windowstart",
+            "type": "string"
+          }
+        },
+        "required": [
+          "planId",
+          "windowStart",
+          "horizon",
+          "blocks",
+          "generatedAt"
+        ],
+        "title": "ReplanResponse",
         "type": "object"
       },
       "ScheduledBlockPreview": {
@@ -3723,6 +4222,27 @@
         "title": "ValidationError",
         "type": "object"
       },
+      "VapidPublicKeyResponse": {
+        "description": "GET /notifications/vapid-public-key 응답 — FE `applicationServerKey` 용 공개값.\n\n`publicKey` 가 null 이면 서버에 VAPID 미설정 → FE 는 **구독을 만들지 말고** '알림 미지원'\n을 표시해야 한다. 서버가 발송할 수 없는데 구독만 만들면, 브라우저 subscribe 는 성공해도\n발송 시 push 서비스가 키 불일치로 403 을 던져 도달 못 하는 구독이 조용히 쌓인다.",
+        "properties": {
+          "publicKey": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Publickey"
+          }
+        },
+        "required": [
+          "publicKey"
+        ],
+        "title": "VapidPublicKeyResponse",
+        "type": "object"
+      },
       "WeeklyBlock": {
         "description": "주간 그리드의 스케줄 블록 한 칸.",
         "properties": {
@@ -3863,6 +4383,47 @@
           "days"
         ],
         "title": "WeeklyPlanResponse",
+        "type": "object"
+      },
+      "WeeklyReplanApproveResponse": {
+        "description": "주간 forward 재계획 승인 결과 — 재조정 카운트. `is_draft=False`.\n\nstarted/finished 로 바뀐 옛 블록·다른 계획 승인분은 건드리지 않으므로(재조정),\n`skipped` 는 그렇게 보존된 항목 수다.\n\n⚠️ 이름 주의: `schemas/recovery.py` 의 `ReplanApproveResponse`(S20 실행단위 replan,\n`POST /replan/{executionId}/approve`)와 **다른 것**이다. 같은 이름을 쓰면 FastAPI 가\n중복 모델명을 양쪽 다 full-qualify 로 바꿔(`reaction_backend__schemas__recovery__...`)\n이 PR 이 건드리지도 않은 회복 endpoint 의 OpenAPI 컴포넌트명이 변하고 FE 생성\n클라이언트가 깨진다. 'Weekly' 접두사는 그 충돌을 피하기 위한 것 — 지우지 말 것.",
+        "properties": {
+          "activatedAt": {
+            "format": "date-time",
+            "title": "Activatedat",
+            "type": "string"
+          },
+          "cancelledBlocks": {
+            "title": "Cancelledblocks",
+            "type": "integer"
+          },
+          "createdBlocks": {
+            "title": "Createdblocks",
+            "type": "integer"
+          },
+          "isDraft": {
+            "const": false,
+            "default": false,
+            "title": "Isdraft",
+            "type": "boolean"
+          },
+          "planId": {
+            "title": "Planid",
+            "type": "string"
+          },
+          "skippedBlocks": {
+            "title": "Skippedblocks",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "planId",
+          "cancelledBlocks",
+          "createdBlocks",
+          "skippedBlocks",
+          "activatedAt"
+        ],
+        "title": "WeeklyReplanApproveResponse",
         "type": "object"
       },
       "WeeklyReviewResponse": {
@@ -5428,7 +5989,7 @@
     },
     "/inbox": {
       "get": {
-        "description": "내 inbox 항목. `?status=captured|classified|promoted` 필터.",
+        "description": "내 inbox 항목. `?status=captured|classified|promoted|archived` 필터.\n\n`status` 미지정 시 활성 항목(archived 제외)만. `status=archived` 는 보관함(soft-deleted)\n조회 — `POST /inbox/{id}/restore` 로 되살릴 수 있다.",
         "operationId": "list_inbox_inbox_get",
         "parameters": [
           {
@@ -5788,6 +6349,65 @@
           }
         },
         "summary": "Convert To Goal",
+        "tags": [
+          "inbox"
+        ]
+      }
+    },
+    "/inbox/{inbox_id}/restore": {
+      "post": {
+        "description": "보관 취소 — `archived_at` 클리어 + status 를 활성(classified/captured)으로 복원.\n\n보관함(`status=archived`)에서만 의미. 이미 활성이면 멱등(현재 상태 그대로 반환).\n존재하지 않으면 404 `INBOX_NOT_FOUND`. hard delete 는 없으므로 언제든 되살릴 수 있다.",
+        "operationId": "restore_inbox_inbox__inbox_id__restore_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "inbox_id",
+            "required": true,
+            "schema": {
+              "title": "Inbox Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InboxItem"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Restore Inbox",
         "tags": [
           "inbox"
         ]
@@ -6253,7 +6873,7 @@
     },
     "/notifications/subscribe": {
       "delete": {
-        "description": "[mock] Web Push 구독 해제 — Issue #25 (PWA) 에서 실 구현.",
+        "description": "Web Push 구독 해제 — 멱등 (구독이 없어도 204).",
         "operationId": "unsubscribe_notifications_subscribe_delete",
         "parameters": [
           {
@@ -6294,7 +6914,7 @@
         ]
       },
       "post": {
-        "description": "[mock] Web Push 구독 등록 — Issue #25 (PWA) 에서 실 구현.",
+        "description": "Web Push 구독 등록 — `push_subscription` JSONB 저장 (재구독은 덮어쓰기).\n\n저장 형태는 pywebpush 가 그대로 받는 `{endpoint, keys: {p256dh, auth}}`.\n응답은 실 설정 행 기준 — pushSubscribed 는 저장 결과에서 파생된다.",
         "operationId": "subscribe_notifications_subscribe_post",
         "parameters": [
           {
@@ -6347,6 +6967,56 @@
           }
         },
         "summary": "Subscribe",
+        "tags": [
+          "notifications"
+        ]
+      }
+    },
+    "/notifications/vapid-public-key": {
+      "get": {
+        "description": "FE 가 `pushManager.subscribe(applicationServerKey)` 에 쓸 VAPID public key.\n\n서버가 **자기 private key 의 짝**을 직접 알려줘 키 불일치를 원천 차단한다. FE 가\npublic key 를 하드코딩·빌드타임 주입하면, 서버가 키를 rotate 하는 순간 구독은 옛 키에\n묶인 채 발송이 전부 push 서비스 403 으로 실패한다(조용히 — 구독 자체는 성공하므로).\n런타임에 받아가면 진실 소스가 서버 하나로 모여 rotate 에도 자동으로 따라온다.\n\n미설정이면 `publicKey=null` — FE 는 구독을 만들지 않는다(스키마 docstring 참조).\n이 경로는 notifications 라우터에 속해 인증 필수(#16 DoD) — 구독 흐름 자체가 로그인 후다.",
+        "operationId": "get_vapid_public_key_notifications_vapid_public_key_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VapidPublicKeyResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Vapid Public Key",
         "tags": [
           "notifications"
         ]
@@ -6462,6 +7132,115 @@
         ]
       }
     },
+    "/plans/replan": {
+      "post": {
+        "description": "주간 리포트를 작성하고, 남은 작업 + 수락한 회복을 **다음 주부터 마감까지** 다시 배치.\n\n- 대상: 다음 주 이후 미착수 블록의 액션 + 활성 블록 없는 planned 백로그(수락한 회복 포함).\n  과거·시작/완료·user_edit 블록은 불변. 실패 원본은 미래 블록이 없어 자동 제외.\n- busy = 확정(시작/완료·user_edit) 블록 + DB 시간정책 + **고정일정(#112 정합)**.\n- 각 새 블록에 '교체할 옛 블록 id'(replacesBlockId)를 실어, 승인이 blanket-cancel 없이\n  그 블록만 현재 상태로 재조정 취소하게 한다(#117). 산출물은 Draft — 자동 적용 금지.",
+        "operationId": "generate_replan_plans_replan_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReplanResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Generate Replan",
+        "tags": [
+          "planning"
+        ]
+      }
+    },
+    "/plans/replan/{plan_id}/approve": {
+      "post": {
+        "description": "재계획 Draft 승인 → **action 단위 재조정**으로 미래 블록 교체(#117 재작업).\n\n#115 스케줄러가 긴 액션을 **여러 세션 블록**으로 쪼개므로, 재조정은 개별 블록이 아니라\n**액션당 '옛 블록 집합'(payload `oldBlocks`)** 을 통째 다룬다 — 옛 블록 1개만 취소하면\n나머지가 유령으로 남거나 새 세션이 드롭되던 문제 방지(리뷰 대응). 액션마다 현재 DB 상태로:\n- 옛 블록 집합 중 하나라도 `started/finished`(사용자 착수) → 이 액션 **전체 보존**(skip).\n- 활성(`scheduled`) 옛 블록이 하나도 없음(그새 전부 취소·삭제) → 중복 방지 skip.\n- 그 외 → 활성 옛 블록 **전부 취소** + 새 세션 블록 **전부 생성**.\n- 백로그(옛 블록 없음): 그새 그 action 이 활성 블록을 얻었으면 생성 skip.\n- action 이 그새 아카이브/삭제됐으면(예: #113 First Plan 교체) 전체 skip(좀비 블록 방지).\n\nDraft 로드·검사~쓰기를 `user_agent_lock`(xact-scoped) 안에서 단일 commit 으로 원자화한다\n(동시 더블 승인 봉합, #113 패턴). 과거·시작/완료·user_edit 블록은 불변. 항상 Draft→HITL.",
+        "operationId": "approve_replan_plans_replan__plan_id__approve_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "plan_id",
+            "required": true,
+            "schema": {
+              "title": "Plan Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WeeklyReplanApproveResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Approve Replan",
+        "tags": [
+          "planning"
+        ]
+      }
+    },
     "/plans/weekly": {
       "get": {
         "description": "주간 블록 그리드 (S14). weekStart 생략 시 이번 주 월요일 기준.",
@@ -6530,7 +7309,7 @@
     },
     "/plans/{plan_id}": {
       "get": {
-        "description": "저장된 First Plan Draft 미리보기 — LLM 재호출 없이 스냅샷 재구성.",
+        "description": "저장된 First Plan Draft 미리보기 — LLM 재호출 없이 스냅샷 재구성.\n\n재계획(`kind='replan'`) Draft 는 payload 모양이 달라(goal_nodes 가 없다) 여기서 다루지\n않는다 — 가드가 없으면 `_draft_to_response` 가 `KeyError: 'goal_nodes'` 로 500 을 낸다.\n승인 endpoint 의 반대편 가드(approve_replan 의 `kind != \"replan\"` 검사)와 대칭.",
         "operationId": "get_plan_plans__plan_id__get",
         "parameters": [
           {
@@ -6589,7 +7368,7 @@
     },
     "/plans/{plan_id}/approve": {
       "post": {
-        "description": "First Plan Draft 승인 → SAVING (goal 트리 단일 가드 트랜잭션 영속화, ADR-0005 §2.5.1).\n\n`plan_id` 로 저장된 Draft 를 로드해 goals/goal_nodes/action_items/scheduled_blocks 를\n단일 트랜잭션으로 영속화(+최대 3회 재시도). `policy_guarded_transaction`(PR #30 재사용)이\n절대 시간 정책 위반 시 롤백 → 422 `PLAN_POLICY_VIOLATION`, 그 외 실패는 롤백 후 500\n`PLAN_SAVE_FAILED`. 만료된 Draft 는 410 `PLAN_DRAFT_EXPIRED`. 이미 승인된 Draft 는 멱등.\n\n부수 효과: 첫 계획 승인 = 온보딩 완료 → onboarding_state 를 `ACTIVE` 로 전이(멱등,\n어느 온보딩 단계에서든). 원설계(FIRST_PLAN → NOTIFICATIONS)는 실제 FE 흐름에서 상태가\nWELCOME 에 고정돼 새로고침 시 재-온보딩되던 문제가 있어 승인에서 ACTIVE 로 마감\n(api-contract §3).\n응답은 명시 승인이므로 `is_draft=false` (ADR-0005 §7.2).",
+        "description": "First Plan Draft 승인 → SAVING (goal 트리 단일 가드 트랜잭션 영속화, ADR-0005 §2.5.1).\n\n`plan_id` 로 저장된 Draft 를 로드해 goals/goal_nodes/action_items/scheduled_blocks 를\n단일 트랜잭션으로 영속화(+최대 3회 재시도). `policy_guarded_transaction`(PR #30 재사용)이\n절대 시간 정책 위반 시 롤백 → 422 `PLAN_POLICY_VIOLATION`, 그 외 실패는 롤백 후 500\n`PLAN_SAVE_FAILED`. 만료된 Draft 는 410 `PLAN_DRAFT_EXPIRED`. 이미 승인된 Draft 는 멱등.\n\n승인 = 교체: 같은 target_date 의 이전 AI 계획 산출물 중 사용자가 손대지 않은\n카드(source=goal·status=planned, user_edit 블록 없는 것)와 그 블록을 soft 정리\n(archived/cancelled)하고, heaviest goal 의 기존 분해 트리도 보관한 뒤 새 계획을\n영속화한다 — 재생성→재승인 반복으로 같은 날짜에 카드/블록/노드가 겹겹이 누적되던\n문제 방지 (`first_plan_adapter.supersede_previous_plan`).\n\n동시성(더블클릭·다중 디바이스 동시 승인): advisory lock 은 **트랜잭션 스코프**\n(`pg_advisory_xact_lock`) 라 commit/rollback 마다 풀린다. 그래서 시도(attempt)마다\nlock 을 새로 잡고, Draft 로드·만료·멱등 검사 → 영속화 → Draft 승인 마킹·온보딩\n전이(`on_success` — 가드 트랜잭션 내부)까지를 **한 트랜잭션 단일 commit** 으로 묶는다.\nlock 이 풀리는 순간엔 항상 status=approved 가 이미 커밋돼 있어, 대기하던 요청은\n멱등 응답으로 빠진다. 재시도(ADR-0005 §2.5.1, 3회)는 이 라우터 루프가 담당한다\n(adapter 내부 재시도는 rollback 으로 lock 을 잃은 채 돌게 되므로 `max_retries=1`).\n\n부수 효과: 첫 계획 승인 = 온보딩 완료 → onboarding_state 를 `ACTIVE` 로 전이(멱등,\n어느 온보딩 단계에서든). 원설계(FIRST_PLAN → NOTIFICATIONS)는 실제 FE 흐름에서 상태가\nWELCOME 에 고정돼 새로고침 시 재-온보딩되던 문제가 있어 승인에서 ACTIVE 로 마감\n(api-contract §3).\n응답은 명시 승인이므로 `is_draft=false` (ADR-0005 §7.2).",
         "operationId": "approve_plan_plans__plan_id__approve_post",
         "parameters": [
           {
@@ -6648,7 +7427,7 @@
     },
     "/plans/{plan_id}/blocks/{block_id}": {
       "patch": {
-        "description": "블록 15분 snap 이동 (S15). 충돌 422 `PLAN_BLOCK_CONFLICT` / 정책 422 `POLICY_VIOLATION`.",
+        "description": "블록 15분 snap 이동 + 목표(category)/제목 수정 (S15).\n\n충돌 422 `PLAN_BLOCK_CONFLICT` / 정책 422 `POLICY_VIOLATION`. `category`/`title` 을 주면\n블록이 매달린 action_item 을 갱신한다(같은 액션의 모든 세션 블록 공유). 정책 검사는\n**변경된 category** 로 수행하고, 변경 반영은 성공 commit 시에만 영속된다(422 면 롤백).",
         "operationId": "edit_block_plans__plan_id__blocks__block_id__patch",
         "parameters": [
           {
@@ -6944,7 +7723,7 @@
     },
     "/recovery/proposals/generate": {
       "post": {
-        "description": "실패 컨텍스트 기반 회복 옵션 2~4개 생성 (LLM ≤ 8s + heuristic fallback).\n\n이미 pending 카드가 있으면 재생성하지 않고 그대로 반환한다 (중복 INSERT 방지).",
+        "description": "실패 컨텍스트 기반 회복 옵션 2~4개 생성 (LLM thinking 0 + ≤ 12s, 룰 fallback — ADR-0003 addendum).\n\n이미 pending 카드가 있으면 재생성하지 않고 그대로 반환한다 (중복 INSERT 방지).",
         "operationId": "generate_recovery_proposals_recovery_proposals_generate_post",
         "parameters": [
           {
@@ -7697,6 +8476,114 @@
           }
         },
         "summary": "Anonymize",
+        "tags": [
+          "settings"
+        ]
+      }
+    },
+    "/settings/profile": {
+      "get": {
+        "description": "지속형 프로필 메모리 — 에너지/시간(behavioral) + 톤/빈도(interaction) + 회복 선호.\n\n인터뷰가 아직 안 채웠으면 해당 항목 null (행/키를 생성하지 않는다).",
+        "operationId": "get_profile_settings_profile_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProfileResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Profile",
+        "tags": [
+          "settings"
+        ]
+      },
+      "patch": {
+        "description": "프로필 메모리 부분 수정 — 지정 필드만 갱신(미지정 유지). 행/키 없으면 생성.\n\nenum 검증은 스키마 Literal (그 외 값 → 422 `COMMON_VALIDATION_ERROR`).\n회복 선호(downscopeUnitMin·restOk)는 `users.focus_mode_preferences`(JSONB)에 병합 저장.",
+        "operationId": "update_profile_settings_profile_patch",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProfileUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProfileResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update Profile",
         "tags": [
           "settings"
         ]

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -420,7 +420,7 @@ export const habitsApi = {
 };
 
 // ── Today / Execution (S10-S13) ───────────────────────────────
-// start·check-ins 는 백엔드 #13 구현됨. agenda/action 상세·pause/resume 은 미구현.
+// start·check-ins·agenda·pause/resume 모두 백엔드 구현됨(#13·#66).
 export const todayApi = {
   agenda: () => request<TodayAgenda>('/today/agenda'),
 

--- a/src/screens/MorningBriefScreen.tsx
+++ b/src/screens/MorningBriefScreen.tsx
@@ -51,7 +51,7 @@ function cardToBlock(c: AgendaCard): BriefBlock {
 export function MorningBriefScreen({ onStart }: MorningBriefScreenProps) {
   const { user } = useNavigation();
   const userName = user?.name ?? '친구';
-  const greeting = `좋은 아침이에요, ${userName}.`;
+  const fallbackGreeting = `좋은 아침이에요, ${userName}.`;
   const date = todayKo();
 
   // mock-and-replace: /today/agenda 로 오늘 실행 카드, /goals·/reviews 로 헤더 지표.
@@ -60,6 +60,10 @@ export function MorningBriefScreen({ onStart }: MorningBriefScreenProps) {
   const [blocks, setBlocks] = useState<BriefBlock[]>([]);
   const [goalName, setGoalName] = useState<string>('');
   const [weekProgress, setWeekProgress] = useState<number | null>(null);
+  // /today/agenda 의 brief(MorningBrief) — headline 은 히어로 인사말을, adjustmentHints
+  // 는 조정 안내를 실데이터로 덮는다. 없으면 각각 기본 인사말·미표시로 fallback.
+  const [briefHeadline, setBriefHeadline] = useState<string | null>(null);
+  const [adjustmentHints, setAdjustmentHints] = useState<string[]>([]);
   // /today/agenda 가 응답했는지 — true 면 blocks 가 실데이터(비어있어도)라 더미 이월 안내를 숨긴다.
   const [usingReal, setUsingReal] = useState(false);
   // 초기 로드 중 — 더미/실데이터 겹침 대신 스켈레톤을 보여준다.
@@ -71,6 +75,8 @@ export function MorningBriefScreen({ onStart }: MorningBriefScreenProps) {
       (a) => {
         if (cancelled) return;
         setBlocks((a.cards ?? []).map(cardToBlock));
+        if (a.brief?.headline) setBriefHeadline(a.brief.headline);
+        setAdjustmentHints(a.brief?.adjustmentHints ?? []);
         setUsingReal(true);
         setLoading(false);
       },
@@ -125,7 +131,7 @@ export function MorningBriefScreen({ onStart }: MorningBriefScreenProps) {
         {/* Hero card — dark */}
         <div style={{ background: 'var(--sand-950)', borderRadius: 20, padding: '20px 18px' }}>
           <div style={{ fontSize: 9, fontFamily: 'var(--font-mono)', letterSpacing: '0.14em', color: 'rgba(250,246,238,.4)', marginBottom: 6, textTransform: 'uppercase' }}>{date}</div>
-          <div style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 26, letterSpacing: '-0.02em', lineHeight: 1.1, color: '#FAF6EE', marginBottom: 14 }}>{greeting}</div>
+          <div style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 26, letterSpacing: '-0.02em', lineHeight: 1.1, color: '#FAF6EE', marginBottom: 14 }}>{briefHeadline || fallbackGreeting}</div>
           <div style={{ display: 'flex', gap: 20 }}>
             <div>
               <div style={{ fontSize: 9, fontFamily: 'var(--font-mono)', color: 'rgba(250,246,238,.4)', marginBottom: 2 }}>오늘 할 일</div>
@@ -150,6 +156,18 @@ export function MorningBriefScreen({ onStart }: MorningBriefScreenProps) {
               <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--warning)', marginBottom: 1 }}>오늘 일정을 불러오지 못했어요</div>
               <div style={{ fontSize: 11, color: 'var(--warning)', opacity: 0.85 }}>네트워크 상태를 확인하고 다시 시도해 주세요.</div>
             </div>
+          </div>
+        )}
+
+        {/* /today/agenda brief 의 조정 안내(adjustmentHints) — 실데이터가 있을 때만 노출. */}
+        {!loading && adjustmentHints.length > 0 && (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+            {adjustmentHints.map((h, i) => (
+              <div key={i} style={{ display: 'flex', gap: 8, alignItems: 'flex-start', padding: '10px 12px', background: 'var(--brand-soft)', border: '1px solid var(--coral-200)', borderRadius: 12 }}>
+                <Sparkle size={13} weight="fill" color="var(--brand)" style={{ flexShrink: 0, marginTop: 1 }} />
+                <div style={{ fontSize: 12, color: 'var(--coral-700)', lineHeight: 1.4 }}>{h}</div>
+              </div>
+            ))}
           </div>
         )}
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -66,6 +66,7 @@ export interface GoalCandidate {
   successImage?: string | null;
   tentativeTier: 'focus' | 'maintain' | 'parked';
   confidence: number;
+  currentLevel?: string | null; // 현재 수준/진척 서술(있을 때만)
 }
 
 // 종료 턴(S03 확인 카드용) 요약 — 표현 계층일 뿐, First Plan 시드는 outcome 쪽.
@@ -111,6 +112,7 @@ export interface SlotCatalogEntry {
   answerType: SlotAnswerType;
   isRequired: boolean;
   category: string;
+  options?: string[]; // 선택형(single/multi) 슬롯의 후보 값
 }
 
 // ── Goals (S03·S26) ───────────────────────────────────────────
@@ -304,8 +306,8 @@ export interface HabitCreateRequest {
 }
 
 // ── Today / Execution (S10-S13) ───────────────────────────────
-// start·check-ins 는 백엔드 #13 으로 구현됨. agenda/action 상세·pause/resume 은
-// 아직 contract 추정(미구현) 이며 백엔드가 채워질 때 조정.
+// start·check-ins·agenda·pause/resume 모두 백엔드 구현됨(#13·#66). action 상세는
+// 실 응답에 맞춰 조정.
 
 export type ActionItemStatus =
   | 'pending'
@@ -315,11 +317,14 @@ export type ActionItemStatus =
   | 'failed'
   | 'recovery_pending';
 
-export interface DailyBrief {
-  date: string; // YYYY-MM-DD
-  greeting: string;
-  bigRock: string | null;
+// GET /today/agenda 의 brief (백엔드 MorningBrief 스키마와 정렬, #66).
+// bigRockActionId 로 오늘의 핵심 액션을 가리키고, fallbackUsed 는 규칙 기반 fallback
+// 여부, headline 은 상단 한 줄 요약이다.
+export interface MorningBrief {
+  headline: string;
+  bigRockActionId: string | null;
   adjustmentHints: string[];
+  fallbackUsed: boolean;
 }
 
 export interface ActionItem {
@@ -347,23 +352,43 @@ export interface AgendaCard {
   firstStep: string | null;
 }
 
+// GET /today/agenda 의 습관 1건 (백엔드 AgendaHabit 스키마와 정렬). 주간 진행률
+// (doneCount/targetCount)만 담는 경량 뷰로, /habit-instances 의 HabitInstance 와 다르다.
+export interface AgendaHabit {
+  habitId: string;
+  instanceId: string;
+  title: string;
+  targetCount: number;
+  doneCount: number;
+}
+
+// GET /today/agenda 의 고정 일정 1건 (백엔드 AgendaFixedSchedule 스키마와 정렬).
+export interface AgendaFixedSchedule {
+  scheduleId: string;
+  title: string;
+  startTime: string; // HH:MM
+  endTime: string; // HH:MM
+}
+
 export interface TodayAgenda {
   date: string;
-  brief: DailyBrief | null;
+  brief: MorningBrief | null;
   cards: AgendaCard[];
-  habits: HabitInstance[];
-  fixedSchedules: FixedSchedule[];
+  habits: AgendaHabit[];
+  fixedSchedules: AgendaFixedSchedule[];
 }
 
 export type CompletionStatus = 'done' | 'partial_done' | 'failed' | 'over_done';
 
-// /today/focus/{executionId}/pause·resume 는 아직 contract 추정(미구현).
+// POST /today/focus/{executionId}/pause·resume 응답 (백엔드 ExecutionEventResponse, 구현됨).
+// pauseTotalMinutes 는 누적 일시정지 시간(분).
 export interface ExecutionEvent {
   executionId: string;
   actionItemId: string;
   startedAt: string; // KST ISO
   endedAt: string | null;
   status: CompletionStatus | 'started' | string;
+  pauseTotalMinutes: number;
 }
 
 // POST /today/actions/{actionId}/start (#13)
@@ -490,6 +515,7 @@ export interface RecoveryDecisionRequest {
   decision: string; // accept / reject / skip 등
   acceptedAttemptId?: string | null;
   decisionReason?: string | null;
+  editedActionText?: string | null; // accept 시 사용자가 회복 액션 문구를 손봤다면 그 값
 }
 
 export interface RecoveryDecisionResponse {
@@ -601,6 +627,8 @@ export interface FirstPlanGenerateRequest {
   interviewSessionId?: string | null;
   targetDate?: string | null; // YYYY-MM-DD
   outcome?: Record<string, unknown> | null; // InterviewOutcome (보통 서버 파생)
+  density?: string | null; // 일정 밀도 힌트(서버 기본값 있음)
+  scope?: string | null; // 계획 범위 힌트(서버 기본값 있음)
 }
 
 // POST /plans/{planId}/approve
@@ -649,11 +677,13 @@ export interface BlockEditRequest {
 }
 export interface BlockEditResponse {
   blockId: string;
+  actionId: string;
+  source: string; // goal / habit / fixed 등
   startAt: string;
-  endAt: string | null;
-  blockStatus?: string;
-  category?: string | null;
-  title?: string | null;
+  endAt: string;
+  blockStatus: string;
+  category: string;
+  title: string;
   goalId?: string | null;
 }
 
@@ -679,7 +709,6 @@ export interface WeeklyGenerateRequest {
   weekStart?: string;
 }
 export interface HabitWeekStat {
-  weekStart: string;
   doneCount: number;
   targetCount: number;
 }
@@ -696,7 +725,9 @@ export interface HabitPenaltyListResponse {
 }
 export interface HabitPenaltyAcceptResponse {
   habitId: string;
-  newFrequency?: number;
+  message: string;
+  previousFrequency: number;
+  newFrequency: number;
 }
 
 // ── Settings / Privacy (S23·S28) — 백엔드 501. api-contract §16 ──

--- a/src/types/openapi.d.ts
+++ b/src/types/openapi.d.ts
@@ -427,7 +427,10 @@ export interface paths {
         };
         /**
          * List Inbox
-         * @description 내 inbox 항목. `?status=captured|classified|promoted` 필터.
+         * @description 내 inbox 항목. `?status=captured|classified|promoted|archived` 필터.
+         *
+         *     `status` 미지정 시 활성 항목(archived 제외)만. `status=archived` 는 보관함(soft-deleted)
+         *     조회 — `POST /inbox/{id}/restore` 로 되살릴 수 있다.
          */
         get: operations["list_inbox_inbox_get"];
         put?: never;
@@ -516,6 +519,29 @@ export interface paths {
          * @description Inbox → Goal 변환 (tier=maintain default, 한도 enforce). inbox.status=promoted.
          */
         post: operations["convert_to_goal_inbox__inbox_id__convert_to_goal_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/inbox/{inbox_id}/restore": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Restore Inbox
+         * @description 보관 취소 — `archived_at` 클리어 + status 를 활성(classified/captured)으로 복원.
+         *
+         *     보관함(`status=archived`)에서만 의미. 이미 활성이면 멱등(현재 상태 그대로 반환).
+         *     존재하지 않으면 404 `INBOX_NOT_FOUND`. hard delete 는 없으므로 언제든 되살릴 수 있다.
+         */
+        post: operations["restore_inbox_inbox__inbox_id__restore_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -690,14 +716,45 @@ export interface paths {
         put?: never;
         /**
          * Subscribe
-         * @description [mock] Web Push 구독 등록 — Issue #25 (PWA) 에서 실 구현.
+         * @description Web Push 구독 등록 — `push_subscription` JSONB 저장 (재구독은 덮어쓰기).
+         *
+         *     저장 형태는 pywebpush 가 그대로 받는 `{endpoint, keys: {p256dh, auth}}`.
+         *     응답은 실 설정 행 기준 — pushSubscribed 는 저장 결과에서 파생된다.
          */
         post: operations["subscribe_notifications_subscribe_post"];
         /**
          * Unsubscribe
-         * @description [mock] Web Push 구독 해제 — Issue #25 (PWA) 에서 실 구현.
+         * @description Web Push 구독 해제 — 멱등 (구독이 없어도 204).
          */
         delete: operations["unsubscribe_notifications_subscribe_delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/notifications/vapid-public-key": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Vapid Public Key
+         * @description FE 가 `pushManager.subscribe(applicationServerKey)` 에 쓸 VAPID public key.
+         *
+         *     서버가 **자기 private key 의 짝**을 직접 알려줘 키 불일치를 원천 차단한다. FE 가
+         *     public key 를 하드코딩·빌드타임 주입하면, 서버가 키를 rotate 하는 순간 구독은 옛 키에
+         *     묶인 채 발송이 전부 push 서비스 403 으로 실패한다(조용히 — 구독 자체는 성공하므로).
+         *     런타임에 받아가면 진실 소스가 서버 하나로 모여 rotate 에도 자동으로 따라온다.
+         *
+         *     미설정이면 `publicKey=null` — FE 는 구독을 만들지 않는다(스키마 docstring 참조).
+         *     이 경로는 notifications 라우터에 속해 인증 필수(#16 DoD) — 구독 흐름 자체가 로그인 후다.
+         */
+        get: operations["get_vapid_public_key_notifications_vapid_public_key_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
         options?: never;
         head?: never;
         patch?: never;
@@ -749,6 +806,64 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/plans/replan": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Generate Replan
+         * @description 주간 리포트를 작성하고, 남은 작업 + 수락한 회복을 **다음 주부터 마감까지** 다시 배치.
+         *
+         *     - 대상: 다음 주 이후 미착수 블록의 액션 + 활성 블록 없는 planned 백로그(수락한 회복 포함).
+         *       과거·시작/완료·user_edit 블록은 불변. 실패 원본은 미래 블록이 없어 자동 제외.
+         *     - busy = 확정(시작/완료·user_edit) 블록 + DB 시간정책 + **고정일정(#112 정합)**.
+         *     - 각 새 블록에 '교체할 옛 블록 id'(replacesBlockId)를 실어, 승인이 blanket-cancel 없이
+         *       그 블록만 현재 상태로 재조정 취소하게 한다(#117). 산출물은 Draft — 자동 적용 금지.
+         */
+        post: operations["generate_replan_plans_replan_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/plans/replan/{plan_id}/approve": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Approve Replan
+         * @description 재계획 Draft 승인 → **action 단위 재조정**으로 미래 블록 교체(#117 재작업).
+         *
+         *     #115 스케줄러가 긴 액션을 **여러 세션 블록**으로 쪼개므로, 재조정은 개별 블록이 아니라
+         *     **액션당 '옛 블록 집합'(payload `oldBlocks`)** 을 통째 다룬다 — 옛 블록 1개만 취소하면
+         *     나머지가 유령으로 남거나 새 세션이 드롭되던 문제 방지(리뷰 대응). 액션마다 현재 DB 상태로:
+         *     - 옛 블록 집합 중 하나라도 `started/finished`(사용자 착수) → 이 액션 **전체 보존**(skip).
+         *     - 활성(`scheduled`) 옛 블록이 하나도 없음(그새 전부 취소·삭제) → 중복 방지 skip.
+         *     - 그 외 → 활성 옛 블록 **전부 취소** + 새 세션 블록 **전부 생성**.
+         *     - 백로그(옛 블록 없음): 그새 그 action 이 활성 블록을 얻었으면 생성 skip.
+         *     - action 이 그새 아카이브/삭제됐으면(예: #113 First Plan 교체) 전체 skip(좀비 블록 방지).
+         *
+         *     Draft 로드·검사~쓰기를 `user_agent_lock`(xact-scoped) 안에서 단일 commit 으로 원자화한다
+         *     (동시 더블 승인 봉합, #113 패턴). 과거·시작/완료·user_edit 블록은 불변. 항상 Draft→HITL.
+         */
+        post: operations["approve_replan_plans_replan__plan_id__approve_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/plans/weekly": {
         parameters: {
             query?: never;
@@ -779,6 +894,10 @@ export interface paths {
         /**
          * Get Plan
          * @description 저장된 First Plan Draft 미리보기 — LLM 재호출 없이 스냅샷 재구성.
+         *
+         *     재계획(`kind='replan'`) Draft 는 payload 모양이 달라(goal_nodes 가 없다) 여기서 다루지
+         *     않는다 — 가드가 없으면 `_draft_to_response` 가 `KeyError: 'goal_nodes'` 로 500 을 낸다.
+         *     승인 endpoint 의 반대편 가드(approve_replan 의 `kind != "replan"` 검사)와 대칭.
          */
         get: operations["get_plan_plans__plan_id__get"];
         put?: never;
@@ -806,6 +925,20 @@ export interface paths {
          *     단일 트랜잭션으로 영속화(+최대 3회 재시도). `policy_guarded_transaction`(PR #30 재사용)이
          *     절대 시간 정책 위반 시 롤백 → 422 `PLAN_POLICY_VIOLATION`, 그 외 실패는 롤백 후 500
          *     `PLAN_SAVE_FAILED`. 만료된 Draft 는 410 `PLAN_DRAFT_EXPIRED`. 이미 승인된 Draft 는 멱등.
+         *
+         *     승인 = 교체: 같은 target_date 의 이전 AI 계획 산출물 중 사용자가 손대지 않은
+         *     카드(source=goal·status=planned, user_edit 블록 없는 것)와 그 블록을 soft 정리
+         *     (archived/cancelled)하고, heaviest goal 의 기존 분해 트리도 보관한 뒤 새 계획을
+         *     영속화한다 — 재생성→재승인 반복으로 같은 날짜에 카드/블록/노드가 겹겹이 누적되던
+         *     문제 방지 (`first_plan_adapter.supersede_previous_plan`).
+         *
+         *     동시성(더블클릭·다중 디바이스 동시 승인): advisory lock 은 **트랜잭션 스코프**
+         *     (`pg_advisory_xact_lock`) 라 commit/rollback 마다 풀린다. 그래서 시도(attempt)마다
+         *     lock 을 새로 잡고, Draft 로드·만료·멱등 검사 → 영속화 → Draft 승인 마킹·온보딩
+         *     전이(`on_success` — 가드 트랜잭션 내부)까지를 **한 트랜잭션 단일 commit** 으로 묶는다.
+         *     lock 이 풀리는 순간엔 항상 status=approved 가 이미 커밋돼 있어, 대기하던 요청은
+         *     멱등 응답으로 빠진다. 재시도(ADR-0005 §2.5.1, 3회)는 이 라우터 루프가 담당한다
+         *     (adapter 내부 재시도는 rollback 으로 lock 을 잃은 채 돌게 되므로 `max_retries=1`).
          *
          *     부수 효과: 첫 계획 승인 = 온보딩 완료 → onboarding_state 를 `ACTIVE` 로 전이(멱등,
          *     어느 온보딩 단계에서든). 원설계(FIRST_PLAN → NOTIFICATIONS)는 실제 FE 흐름에서 상태가
@@ -835,7 +968,11 @@ export interface paths {
         head?: never;
         /**
          * Edit Block
-         * @description 블록 15분 snap 이동 (S15). 충돌 422 `PLAN_BLOCK_CONFLICT` / 정책 422 `POLICY_VIOLATION`.
+         * @description 블록 15분 snap 이동 + 목표(category)/제목 수정 (S15).
+         *
+         *     충돌 422 `PLAN_BLOCK_CONFLICT` / 정책 422 `POLICY_VIOLATION`. `category`/`title` 을 주면
+         *     블록이 매달린 action_item 을 갱신한다(같은 액션의 모든 세션 블록 공유). 정책 검사는
+         *     **변경된 category** 로 수행하고, 변경 반영은 성공 commit 시에만 영속된다(422 면 롤백).
          */
         patch: operations["edit_block_plans__plan_id__blocks__block_id__patch"];
         trace?: never;
@@ -922,7 +1059,7 @@ export interface paths {
         put?: never;
         /**
          * Generate Recovery Proposals
-         * @description 실패 컨텍스트 기반 회복 옵션 2~4개 생성 (LLM ≤ 8s + heuristic fallback).
+         * @description 실패 컨텍스트 기반 회복 옵션 2~4개 생성 (LLM thinking 0 + ≤ 12s, 룰 fallback — ADR-0003 addendum).
          *
          *     이미 pending 카드가 있으면 재생성하지 않고 그대로 반환한다 (중복 INSERT 방지).
          */
@@ -1195,6 +1332,35 @@ export interface paths {
         options?: never;
         head?: never;
         patch?: never;
+        trace?: never;
+    };
+    "/settings/profile": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Profile
+         * @description 지속형 프로필 메모리 — 에너지/시간(behavioral) + 톤/빈도(interaction) + 회복 선호.
+         *
+         *     인터뷰가 아직 안 채웠으면 해당 항목 null (행/키를 생성하지 않는다).
+         */
+        get: operations["get_profile_settings_profile_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Update Profile
+         * @description 프로필 메모리 부분 수정 — 지정 필드만 갱신(미지정 유지). 행/키 없으면 생성.
+         *
+         *     enum 검증은 스키마 Literal (그 외 값 → 422 `COMMON_VALIDATION_ERROR`).
+         *     회복 선호(downscopeUnitMin·restOk)는 `users.focus_mode_preferences`(JSONB)에 병합 저장.
+         */
+        patch: operations["update_profile_settings_profile_patch"];
         trace?: never;
     };
     "/settings/tone-mode": {
@@ -1603,16 +1769,44 @@ export interface components {
             peakWindow: string[];
         };
         /**
+         * BehavioralProfileView
+         * @description behavioral_profiles 의 사용자 편집 대상 필드.
+         */
+        BehavioralProfileView: {
+            /** Attentionspan */
+            attentionSpan: number;
+            /**
+             * Energycycle
+             * @enum {string}
+             */
+            energyCycle: "morning" | "afternoon" | "evening" | "night" | "varies";
+            /** Preferredendtime */
+            preferredEndTime?: string | null;
+            /** Preferredstarttime */
+            preferredStartTime?: string | null;
+            /**
+             * Timechunkpreference
+             * @enum {string}
+             */
+            timeChunkPreference: "10" | "20" | "30" | "60" | "90";
+        };
+        /**
          * BlockEditRequest
-         * @description PATCH /plans/{planId}/blocks/{blockId} — 15분 snap 이동.
+         * @description PATCH /plans/{planId}/blocks/{blockId} — 15분 snap 이동 + 목표(category)/제목 수정.
          *
          *     `endAt` 생략 시 기존 길이를 보존한 채 시작만 옮긴다. 시각은 KST ISO 8601.
+         *     `category`/`title` 을 주면 블록이 매달린 action_item 을 갱신한다 — 같은 액션의 모든
+         *     세션 블록에 반영되며, 미지원 category 는 'other' 로 정규화한다. 미지정 필드는 유지.
          */
         BlockEditRequest: {
+            /** Category */
+            category?: string | null;
             /** Endat */
             endAt?: string | null;
             /** Startat */
             startAt: string;
+            /** Title */
+            title?: string | null;
         };
         /**
          * BlockEditResponse
@@ -1901,9 +2095,21 @@ export interface components {
          *     검증은 라우터/오케스트레이터 VALIDATING 단계에서 수행.
          */
         FirstPlanGenerateRequest: {
+            /**
+             * Density
+             * @default standard
+             * @enum {string}
+             */
+            density: "light" | "standard" | "intense";
             /** Interviewsessionid */
             interviewSessionId?: string | null;
             outcome?: components["schemas"]["InterviewOutcome"] | null;
+            /**
+             * Scope
+             * @default horizon
+             * @enum {string}
+             */
+            scope: "week" | "horizon";
             /** Targetdate */
             targetDate?: string | null;
         };
@@ -2030,6 +2236,8 @@ export interface components {
             category: string;
             /** Confidence */
             confidence: number;
+            /** Currentlevel */
+            currentLevel?: string | null;
             /** Deadline */
             deadline?: string | null;
             /**
@@ -2339,6 +2547,8 @@ export interface components {
             inboxId: string;
             /** Promotedgoalid */
             promotedGoalId: string | null;
+            /** Promotedto */
+            promotedTo?: ("goal" | "action") | null;
             /** Rawtext */
             rawText: string;
             /** Status */
@@ -2355,6 +2565,32 @@ export interface components {
             status?: ("captured" | "classified" | "archived" | "promoted") | null;
             /** Usercategory */
             userCategory?: ("study" | "project" | "health" | "routine" | "schedule" | "other") | null;
+        };
+        /**
+         * InteractionStyleView
+         * @description interaction_styles 의 사용자 편집 대상 필드.
+         */
+        InteractionStyleView: {
+            /**
+             * Explanationdepth
+             * @enum {string}
+             */
+            explanationDepth: "brief" | "normal" | "detailed";
+            /**
+             * Recoverytone
+             * @enum {string}
+             */
+            recoveryTone: "gentle" | "normal" | "encouraging";
+            /**
+             * Reminderfrequency
+             * @enum {string}
+             */
+            reminderFrequency: "minimal" | "standard" | "active";
+            /**
+             * Suggestionstyle
+             * @enum {string}
+             */
+            suggestionStyle: "soft" | "neutral" | "firm";
         };
         /**
          * InterviewOutcome
@@ -2601,8 +2837,54 @@ export interface components {
             weeklyEnergy?: string | null;
         };
         /**
+         * ProfileResponse
+         * @description GET/PATCH /settings/profile — 지속형 프로필 메모리.
+         *
+         *     인터뷰가 아직 안 채웠으면 각 항목 null (행 없음).
+         *     `downscopeUnitMin`/`restOk` 는 회복 선호 — `users.focus_mode_preferences`(JSONB) 출처.
+         */
+        ProfileResponse: {
+            behavioral: components["schemas"]["BehavioralProfileView"] | null;
+            /** Downscopeunitmin */
+            downscopeUnitMin?: number | null;
+            interaction: components["schemas"]["InteractionStyleView"] | null;
+            /** Restok */
+            restOk?: boolean | null;
+        };
+        /**
+         * ProfileUpdateRequest
+         * @description PATCH /settings/profile — 지정 필드만 부분 갱신. 미지정(None)은 유지.
+         *
+         *     enum 외 값은 Pydantic Literal → 422 `COMMON_VALIDATION_ERROR`.
+         */
+        ProfileUpdateRequest: {
+            /** Attentionspan */
+            attentionSpan?: number | null;
+            /** Downscopeunitmin */
+            downscopeUnitMin?: number | null;
+            /** Energycycle */
+            energyCycle?: ("morning" | "afternoon" | "evening" | "night" | "varies") | null;
+            /** Explanationdepth */
+            explanationDepth?: ("brief" | "normal" | "detailed") | null;
+            /** Recoverytone */
+            recoveryTone?: ("gentle" | "normal" | "encouraging") | null;
+            /** Reminderfrequency */
+            reminderFrequency?: ("minimal" | "standard" | "active") | null;
+            /** Restok */
+            restOk?: boolean | null;
+            /** Suggestionstyle */
+            suggestionStyle?: ("soft" | "neutral" | "firm") | null;
+            /** Timechunkpreference */
+            timeChunkPreference?: ("10" | "20" | "30" | "60" | "90") | null;
+        };
+        /**
          * PushSubscribeRequest
          * @description POST /notifications/subscribe 요청 — Web Push subscription 객체.
+         *
+         *     브라우저 `PushSubscription.toJSON()` 의 `{endpoint, keys: {p256dh, auth}}`.
+         *     p256dh/auth 는 pywebpush 발송(payload 암호화)에 필수라 스키마에서 강제한다 —
+         *     빠진 채 저장되면 **발송 시점**에야 터져서, 구독은 됐다고 믿는 사용자가 조용히
+         *     알림을 못 받는다.
          */
         PushSubscribeRequest: {
             /** Endpoint */
@@ -2662,6 +2944,10 @@ export interface components {
          * @description POST /recovery/decisions 요청 (Idempotency-Key 필수, §1.7).
          *
          *     - `decision="accepted"` → `accepted_attempt_id` 필수, 나머지 pending 카드는 rejected.
+         *     - `decision="edited"` → `accepted_attempt_id` + `edited_action_text` 필수. 부수효과는
+         *       accepted 와 같고(형제 rejected, 새 카드 생성) **새 카드 title 만 사용자 문구**가 된다.
+         *       AI 원문(`suggested_action_text`)은 보존한다 — "얼마나 고쳐 썼나"가 AI 품질 지표다.
+         *       새 카드를 만들지 않는 그룹(RESCHEDULE/PARK)은 문구를 담을 곳이 없어 422.
          *     - `decision="skipped"` → 모든 pending 카드 skipped ("오늘은 쉬기").
          */
         RecoveryDecisionRequest: {
@@ -2671,9 +2957,11 @@ export interface components {
              * Decision
              * @enum {string}
              */
-            decision: "accepted" | "skipped";
+            decision: "accepted" | "edited" | "skipped";
             /** Decisionreason */
             decisionReason?: string | null;
+            /** Editedactiontext */
+            editedActionText?: string | null;
             /** Executionid */
             executionId: string;
         };
@@ -2863,6 +3151,34 @@ export interface components {
             title: string;
         };
         /**
+         * ReplanBlockPreview
+         * @description 재계획 미리보기 블록 — 기존 ActionItem 에 연결(actionId). 시각은 KST.
+         *
+         *     `replacesBlockId` 는 이 새 블록이 교체하는 옛 미래 블록의 **대표 id**(미리보기용, 없으면
+         *     백로그라 null). 실제 승인 재조정은 payload 의 `oldBlocks`(액션당 옛 블록 **전부**)를 권위로
+         *     삼아 액션 단위로 취소·생성한다 — 한 액션이 여러 세션으로 쪼개진 경우까지 정확히(#117).
+         */
+        ReplanBlockPreview: {
+            /** Actionid */
+            actionId: string;
+            /** Category */
+            category: string;
+            /**
+             * End
+             * Format: date-time
+             */
+            end: string;
+            /** Replacesblockid */
+            replacesBlockId?: string | null;
+            /**
+             * Start
+             * Format: date-time
+             */
+            start: string;
+            /** Title */
+            title: string;
+        };
+        /**
          * ReplanDiffResponse
          * @description GET /replan/{executionId} — S20 before/after 프리뷰 (Draft Layer).
          *
@@ -2895,6 +3211,38 @@ export interface components {
              * @enum {string}
              */
             optionGroup: "DOWNSCOPE" | "RESCHEDULE" | "CARRY_OVER" | "PARK";
+        };
+        /**
+         * ReplanResponse
+         * @description 주간 재계획 미리보기 — 항상 Draft. 승인은 `/plans/replan/{planId}/approve`.
+         */
+        ReplanResponse: {
+            /**
+             * Aisource
+             * @default llm
+             * @enum {string}
+             */
+            aiSource: "llm" | "rule";
+            /** Blocks */
+            blocks: components["schemas"]["ReplanBlockPreview"][];
+            /**
+             * Generatedat
+             * Format: date-time
+             */
+            generatedAt: string;
+            /** Horizon */
+            horizon: string | null;
+            /**
+             * Isdraft
+             * @default true
+             */
+            isDraft: boolean;
+            /** Planid */
+            planId: string;
+            /** Warnings */
+            warnings?: string[];
+            /** Windowstart */
+            windowStart: string;
         };
         /**
          * ScheduledBlockPreview
@@ -3101,6 +3449,18 @@ export interface components {
             type: string;
         };
         /**
+         * VapidPublicKeyResponse
+         * @description GET /notifications/vapid-public-key 응답 — FE `applicationServerKey` 용 공개값.
+         *
+         *     `publicKey` 가 null 이면 서버에 VAPID 미설정 → FE 는 **구독을 만들지 말고** '알림 미지원'
+         *     을 표시해야 한다. 서버가 발송할 수 없는데 구독만 만들면, 브라우저 subscribe 는 성공해도
+         *     발송 시 push 서비스가 키 불일치로 403 을 던져 도달 못 하는 구독이 조용히 쌓인다.
+         */
+        VapidPublicKeyResponse: {
+            /** Publickey */
+            publicKey: string | null;
+        };
+        /**
          * WeeklyBlock
          * @description 주간 그리드의 스케줄 블록 한 칸.
          */
@@ -3177,6 +3537,40 @@ export interface components {
              * Format: date
              */
             weekStart: string;
+        };
+        /**
+         * WeeklyReplanApproveResponse
+         * @description 주간 forward 재계획 승인 결과 — 재조정 카운트. `is_draft=False`.
+         *
+         *     started/finished 로 바뀐 옛 블록·다른 계획 승인분은 건드리지 않으므로(재조정),
+         *     `skipped` 는 그렇게 보존된 항목 수다.
+         *
+         *     ⚠️ 이름 주의: `schemas/recovery.py` 의 `ReplanApproveResponse`(S20 실행단위 replan,
+         *     `POST /replan/{executionId}/approve`)와 **다른 것**이다. 같은 이름을 쓰면 FastAPI 가
+         *     중복 모델명을 양쪽 다 full-qualify 로 바꿔(`reaction_backend__schemas__recovery__...`)
+         *     이 PR 이 건드리지도 않은 회복 endpoint 의 OpenAPI 컴포넌트명이 변하고 FE 생성
+         *     클라이언트가 깨진다. 'Weekly' 접두사는 그 충돌을 피하기 위한 것 — 지우지 말 것.
+         */
+        WeeklyReplanApproveResponse: {
+            /**
+             * Activatedat
+             * Format: date-time
+             */
+            activatedAt: string;
+            /** Cancelledblocks */
+            cancelledBlocks: number;
+            /** Createdblocks */
+            createdBlocks: number;
+            /**
+             * Isdraft
+             * @default false
+             * @constant
+             */
+            isDraft: false;
+            /** Planid */
+            planId: string;
+            /** Skippedblocks */
+            skippedBlocks: number;
         };
         /**
          * WeeklyReviewResponse
@@ -4282,6 +4676,39 @@ export interface operations {
             };
         };
     };
+    restore_inbox_inbox__inbox_id__restore_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                inbox_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InboxItem"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     start_session_interview_sessions_post: {
         parameters: {
             query?: never;
@@ -4610,6 +5037,37 @@ export interface operations {
             };
         };
     };
+    get_vapid_public_key_notifications_vapid_public_key_get: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["VapidPublicKeyResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     get_onboarding_status_onboarding_status_get: {
         parameters: {
             query?: never;
@@ -4663,6 +5121,70 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["FirstPlanResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    generate_replan_plans_replan_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ReplanResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    approve_replan_plans_replan__plan_id__approve_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                plan_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WeeklyReplanApproveResponse"];
                 };
             };
             /** @description Validation Error */
@@ -5365,6 +5887,72 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AnonymizeResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_profile_settings_profile_get: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProfileResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_profile_settings_profile_patch: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ProfileUpdateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProfileResponse"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
백엔드(`hanium-reaction/reaction-backend`) OpenAPI 를 다시 덤프해 프론트 타입·화면과 동기화했습니다. 자동 루틴 산출물입니다.

## (a) 신규/변경 엔드포인트
- **미구현→구현 전환**: `GET /today/agenda`, `POST /today/focus/{execution_id}/pause·resume`, `GET /reflection/pending`, `POST /reflection/batch` 가 모두 백엔드에 구현되어 `check:api` 에서 OK 로 잡힙니다. (이전엔 WARN)
- **스키마 필드 교정** — 수기 추정 타입을 실제 스키마에 맞춰 정정:
  - `TodayAgenda`: `brief` → `MorningBrief`, `habits` → `AgendaHabit[]`, `fixedSchedules` → `AgendaFixedSchedule[]` (전용 경량 뷰). 신규 `AgendaHabit`·`AgendaFixedSchedule`·`MorningBrief` 인터페이스 추가.
  - `ExecutionEvent`: 필수 `pauseTotalMinutes` 추가 (pause/resume 응답).
  - `BlockEditResponse`: 필수 `actionId`·`source` 추가, `blockStatus`/`category`/`title`/`endAt` 필수로 정정.
  - `HabitPenaltyAcceptResponse`: 필수 `message`·`previousFrequency` 추가.
  - `GoalCandidate.currentLevel`, `SlotCatalogEntry.options`, `RecoveryDecisionRequest.editedActionText`, `FirstPlanGenerateRequest.density`·`scope` 추가.
  - `HabitWeekStat`: 실제 스키마에 없는 `weekStart` 제거.
- **아직 래퍼 없는 신규(NEW 11)**: `calendar/events/approve-insert`, `calendar/sync-preview`, `PATCH /habits/{}`, `GET /health`, `GET /inbox`, `notifications/vapid-public-key`, `plans/replan`(+`/approve`), `policy-snapshot/current`, `GET·PATCH /settings/profile`. 이번엔 래퍼·화면 미추가(계약 실패 아님) — 필요 시 후속 연동.

## (b) 화면 실연동
- **아침 브리프(MorningBriefScreen)**: 이제 `GET /today/agenda` 의 `brief.headline` 을 히어로 인사말로, `brief.adjustmentHints` 를 조정 안내 배너로 실데이터 연동. 기존 mock-and-replace 패턴 유지 — brief 가 없거나 실패하면 기본 인사말/미표시로 fallback 되어 데모가 깨지지 않음.
- 이미 연동된 화면(Today agenda 카드, Focus pause/resume, Evening 회고 pending/batch 등)은 스키마 변화만 반영, UI 동작 그대로.

## (c) check:api 요약
```
✅ OK   73   ⚠️ WARN 0   ❌ GONE 0   🆕 NEW 11
결과: PASS
```
검증 게이트 전부 통과: `check:api`(GONE 0) · `tsc --noEmit`(0) · `npm run build`(성공).

---
_Generated by [Claude Code](https://claude.ai/code/session_01GYJRWJyZpHzLoYA9VJoR2j)_