### PR TITLE
chore(api): 백엔드 API 동기화 (routine)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -426,9 +426,80 @@
         "title": "AvailabilityProfile",
         "type": "object"
       },
-      "BlockEditRequest": {
-        "description": "PATCH /plans/{planId}/blocks/{blockId} — 15분 snap 이동.\n\n`endAt` 생략 시 기존 길이를 보존한 채 시작만 옮긴다. 시각은 KST ISO 8601.",
+      "BehavioralProfileView": {
+        "description": "behavioral_profiles 의 사용자 편집 대상 필드.",
         "properties": {
+          "attentionSpan": {
+            "title": "Attentionspan",
+            "type": "integer"
+          },
+          "energyCycle": {
+            "enum": [
+              "morning",
+              "afternoon",
+              "evening",
+              "night",
+              "varies"
+            ],
+            "title": "Energycycle",
+            "type": "string"
+          },
+          "preferredEndTime": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Preferredendtime"
+          },
+          "preferredStartTime": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Preferredstarttime"
+          },
+          "timeChunkPreference": {
+            "enum": [
+              "10",
+              "20",
+              "30",
+              "60",
+              "90"
+            ],
+            "title": "Timechunkpreference",
+            "type": "string"
+          }
+        },
+        "required": [
+          "energyCycle",
+          "attentionSpan",
+          "timeChunkPreference"
+        ],
+        "title": "BehavioralProfileView",
+        "type": "object"
+      },
+      "BlockEditRequest": {
+        "description": "PATCH /plans/{planId}/blocks/{blockId} — 15분 snap 이동 + 목표(category)/제목 수정.\n\n`endAt` 생략 시 기존 길이를 보존한 채 시작만 옮긴다. 시각은 KST ISO 8601.\n`category`/`title` 을 주면 블록이 매달린 action_item 을 갱신한다 — 같은 액션의 모든\n세션 블록에 반영되며, 미지원 category 는 'other' 로 정규화한다. 미지정 필드는 유지.",
+        "properties": {
+          "category": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Category"
+          },
           "endAt": {
             "anyOf": [
               {
@@ -443,6 +514,17 @@
           "startAt": {
             "title": "Startat",
             "type": "string"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
           }
         },
         "required": [
@@ -1025,6 +1107,16 @@
       "FirstPlanGenerateRequest": {
         "description": "POST /plans/generate (첫 계획) 요청.\n\n`interview_session_id` 로 확정된 `InterviewOutcome` 을 참조하거나(서버가 로드),\n온보딩 흐름에서 outcome 을 인라인 전달할 수 있다(`outcome`). 둘 중 하나는 필수 —\n검증은 라우터/오케스트레이터 VALIDATING 단계에서 수행.",
         "properties": {
+          "density": {
+            "default": "standard",
+            "enum": [
+              "light",
+              "standard",
+              "intense"
+            ],
+            "title": "Density",
+            "type": "string"
+          },
           "interviewSessionId": {
             "anyOf": [
               {
@@ -1045,6 +1137,15 @@
                 "type": "null"
               }
             ]
+          },
+          "scope": {
+            "default": "horizon",
+            "enum": [
+              "week",
+              "horizon"
+            ],
+            "title": "Scope",
+            "type": "string"
           },
           "targetDate": {
             "anyOf": [
@@ -1367,6 +1468,17 @@
             "minimum": 0.0,
             "title": "Confidence",
             "type": "number"
+          },
+          "currentLevel": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Currentlevel"
           },
           "deadline": {
             "anyOf": [
@@ -2099,6 +2211,21 @@
             ],
             "title": "Promotedgoalid"
           },
+          "promotedTo": {
+            "anyOf": [
+              {
+                "enum": [
+                  "goal",
+                  "action"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Promotedto"
+          },
           "rawText": {
             "title": "Rawtext",
             "type": "string"
@@ -2171,6 +2298,55 @@
           }
         },
         "title": "InboxUpdateRequest",
+        "type": "object"
+      },
+      "InteractionStyleView": {
+        "description": "interaction_styles 의 사용자 편집 대상 필드.",
+        "properties": {
+          "explanationDepth": {
+            "enum": [
+              "brief",
+              "normal",
+              "detailed"
+            ],
+            "title": "Explanationdepth",
+            "type": "string"
+          },
+          "recoveryTone": {
+            "enum": [
+              "gentle",
+              "normal",
+              "encouraging"
+            ],
+            "title": "Recoverytone",
+            "type": "string"
+          },
+          "reminderFrequency": {
+            "enum": [
+              "minimal",
+              "standard",
+              "active"
+            ],
+            "title": "Reminderfrequency",
+            "type": "string"
+          },
+          "suggestionStyle": {
+            "enum": [
+              "soft",
+              "neutral",
+              "firm"
+            ],
+            "title": "Suggestionstyle",
+            "type": "string"
+          }
+        },
+        "required": [
+          "recoveryTone",
+          "suggestionStyle",
+          "explanationDepth",
+          "reminderFrequency"
+        ],
+        "title": "InteractionStyleView",
         "type": "object"
       },
       "InterviewOutcome": {
@@ -2705,8 +2881,205 @@
         "title": "PreferenceProfile",
         "type": "object"
       },
+      "ProfileResponse": {
+        "description": "GET/PATCH /settings/profile — 지속형 프로필 메모리.\n\n인터뷰가 아직 안 채웠으면 각 항목 null (행 없음).\n`downscopeUnitMin`/`restOk` 는 회복 선호 — `users.focus_mode_preferences`(JSONB) 출처.",
+        "properties": {
+          "behavioral": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BehavioralProfileView"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "downscopeUnitMin": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Downscopeunitmin"
+          },
+          "interaction": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/InteractionStyleView"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "restOk": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Restok"
+          }
+        },
+        "required": [
+          "behavioral",
+          "interaction"
+        ],
+        "title": "ProfileResponse",
+        "type": "object"
+      },
+      "ProfileUpdateRequest": {
+        "description": "PATCH /settings/profile — 지정 필드만 부분 갱신. 미지정(None)은 유지.\n\nenum 외 값은 Pydantic Literal → 422 `COMMON_VALIDATION_ERROR`.",
+        "properties": {
+          "attentionSpan": {
+            "anyOf": [
+              {
+                "maximum": 240.0,
+                "minimum": 5.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Attentionspan"
+          },
+          "downscopeUnitMin": {
+            "anyOf": [
+              {
+                "maximum": 120.0,
+                "minimum": 1.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Downscopeunitmin"
+          },
+          "energyCycle": {
+            "anyOf": [
+              {
+                "enum": [
+                  "morning",
+                  "afternoon",
+                  "evening",
+                  "night",
+                  "varies"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Energycycle"
+          },
+          "explanationDepth": {
+            "anyOf": [
+              {
+                "enum": [
+                  "brief",
+                  "normal",
+                  "detailed"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Explanationdepth"
+          },
+          "recoveryTone": {
+            "anyOf": [
+              {
+                "enum": [
+                  "gentle",
+                  "normal",
+                  "encouraging"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recoverytone"
+          },
+          "reminderFrequency": {
+            "anyOf": [
+              {
+                "enum": [
+                  "minimal",
+                  "standard",
+                  "active"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reminderfrequency"
+          },
+          "restOk": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Restok"
+          },
+          "suggestionStyle": {
+            "anyOf": [
+              {
+                "enum": [
+                  "soft",
+                  "neutral",
+                  "firm"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Suggestionstyle"
+          },
+          "timeChunkPreference": {
+            "anyOf": [
+              {
+                "enum": [
+                  "10",
+                  "20",
+                  "30",
+                  "60",
+                  "90"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Timechunkpreference"
+          }
+        },
+        "title": "ProfileUpdateRequest",
+        "type": "object"
+      },
       "PushSubscribeRequest": {
-        "description": "POST /notifications/subscribe 요청 — Web Push subscription 객체.",
+        "description": "POST /notifications/subscribe 요청 — Web Push subscription 객체.\n\n브라우저 `PushSubscription.toJSON()` 의 `{endpoint, keys: {p256dh, auth}}`.\np256dh/auth 는 pywebpush 발송(payload 암호화)에 필수라 스키마에서 강제한다 —\n빠진 채 저장되면 **발송 시점**에야 터져서, 구독은 됐다고 믿는 사용자가 조용히\n알림을 못 받는다.",
         "properties": {
           "endpoint": {
             "minLength": 1,
@@ -2830,7 +3203,7 @@
         "type": "object"
       },
       "RecoveryDecisionRequest": {
-        "description": "POST /recovery/decisions 요청 (Idempotency-Key 필수, §1.7).\n\n- `decision=\"accepted\"` → `accepted_attempt_id` 필수, 나머지 pending 카드는 rejected.\n- `decision=\"skipped\"` → 모든 pending 카드 skipped (\"오늘은 쉬기\").",
+        "description": "POST /recovery/decisions 요청 (Idempotency-Key 필수, §1.7).\n\n- `decision=\"accepted\"` → `accepted_attempt_id` 필수, 나머지 pending 카드는 rejected.\n- `decision=\"edited\"` → `accepted_attempt_id` + `edited_action_text` 필수. 부수효과는\n  accepted 와 같고(형제 rejected, 새 카드 생성) **새 카드 title 만 사용자 문구**가 된다.\n  AI 원문(`suggested_action_text`)은 보존한다 — \"얼마나 고쳐 썼나\"가 AI 품질 지표다.\n  새 카드를 만들지 않는 그룹(RESCHEDULE/PARK)은 문구를 담을 곳이 없어 422.\n- `decision=\"skipped\"` → 모든 pending 카드 skipped (\"오늘은 쉬기\").",
         "properties": {
           "acceptedAttemptId": {
             "anyOf": [
@@ -2846,6 +3219,7 @@
           "decision": {
             "enum": [
               "accepted",
+              "edited",
               "skipped"
             ],
             "title": "Decision",
@@ -2862,6 +3236,18 @@
               }
             ],
             "title": "Decisionreason"
+          },
+          "editedActionText": {
+            "anyOf": [
+              {
+                "maxLength": 300,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Editedactiontext"
           },
           "executionId": {
             "title": "Executionid",
@@ -3223,6 +3609,53 @@
         "title": "ReplanBlock",
         "type": "object"
       },
+      "ReplanBlockPreview": {
+        "description": "재계획 미리보기 블록 — 기존 ActionItem 에 연결(actionId). 시각은 KST.\n\n`replacesBlockId` 는 이 새 블록이 교체하는 옛 미래 블록의 **대표 id**(미리보기용, 없으면\n백로그라 null). 실제 승인 재조정은 payload 의 `oldBlocks`(액션당 옛 블록 **전부**)를 권위로\n삼아 액션 단위로 취소·생성한다 — 한 액션이 여러 세션으로 쪼개진 경우까지 정확히(#117).",
+        "properties": {
+          "actionId": {
+            "title": "Actionid",
+            "type": "string"
+          },
+          "category": {
+            "title": "Category",
+            "type": "string"
+          },
+          "end": {
+            "format": "date-time",
+            "title": "End",
+            "type": "string"
+          },
+          "replacesBlockId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Replacesblockid"
+          },
+          "start": {
+            "format": "date-time",
+            "title": "Start",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "actionId",
+          "title",
+          "category",
+          "start",
+          "end"
+        ],
+        "title": "ReplanBlockPreview",
+        "type": "object"
+      },
       "ReplanDiffResponse": {
         "description": "GET /replan/{executionId} — S20 before/after 프리뷰 (Draft Layer).\n\n승인 전까지 `is_draft=True`. `already_approved=True` 면 이미 approve 로 블록이\n배치된 상태(멱등 재조회).",
         "properties": {
@@ -3273,6 +3706,72 @@
           "after"
         ],
         "title": "ReplanDiffResponse",
+        "type": "object"
+      },
+      "ReplanResponse": {
+        "description": "주간 재계획 미리보기 — 항상 Draft. 승인은 `/plans/replan/{planId}/approve`.",
+        "properties": {
+          "aiSource": {
+            "default": "llm",
+            "enum": [
+              "llm",
+              "rule"
+            ],
+            "title": "Aisource",
+            "type": "string"
+          },
+          "blocks": {
+            "items": {
+              "$ref": "#/components/schemas/ReplanBlockPreview"
+            },
+            "title": "Blocks",
+            "type": "array"
+          },
+          "generatedAt": {
+            "format": "date-time",
+            "title": "Generatedat",
+            "type": "string"
+          },
+          "horizon": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Horizon"
+          },
+          "isDraft": {
+            "default": true,
+            "title": "Isdraft",
+            "type": "boolean"
+          },
+          "planId": {
+            "title": "Planid",
+            "type": "string"
+          },
+          "warnings": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Warnings",
+            "type": "array"
+          },
+          "windowStart": {
+            "title": "Windowstart",
+            "type": "string"
+          }
+        },
+        "required": [
+          "planId",
+          "windowStart",
+          "horizon",
+          "blocks",
+          "generatedAt"
+        ],
+        "title": "ReplanResponse",
         "type": "object"
       },
       "ScheduledBlockPreview": {
@@ -3723,6 +4222,27 @@
         "title": "ValidationError",
         "type": "object"
       },
+      "VapidPublicKeyResponse": {
+        "description": "GET /notifications/vapid-public-key 응답 — FE `applicationServerKey` 용 공개값.\n\n`publicKey` 가 null 이면 서버에 VAPID 미설정 → FE 는 **구독을 만들지 말고** '알림 미지원'\n을 표시해야 한다. 서버가 발송할 수 없는데 구독만 만들면, 브라우저 subscribe 는 성공해도\n발송 시 push 서비스가 키 불일치로 403 을 던져 도달 못 하는 구독이 조용히 쌓인다.",
+        "properties": {
+          "publicKey": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Publickey"
+          }
+        },
+        "required": [
+          "publicKey"
+        ],
+        "title": "VapidPublicKeyResponse",
+        "type": "object"
+      },
       "WeeklyBlock": {
         "description": "주간 그리드의 스케줄 블록 한 칸.",
         "properties": {
@@ -3863,6 +4383,47 @@
           "days"
         ],
         "title": "WeeklyPlanResponse",
+        "type": "object"
+      },
+      "WeeklyReplanApproveResponse": {
+        "description": "주간 forward 재계획 승인 결과 — 재조정 카운트. `is_draft=False`.\n\nstarted/finished 로 바뀐 옛 블록·다른 계획 승인분은 건드리지 않으므로(재조정),\n`skipped` 는 그렇게 보존된 항목 수다.\n\n⚠️ 이름 주의: `schemas/recovery.py` 의 `ReplanApproveResponse`(S20 실행단위 replan,\n`POST /replan/{executionId}/approve`)와 **다른 것**이다. 같은 이름을 쓰면 FastAPI 가\n중복 모델명을 양쪽 다 full-qualify 로 바꿔(`reaction_backend__schemas__recovery__...`)\n이 PR 이 건드리지도 않은 회복 endpoint 의 OpenAPI 컴포넌트명이 변하고 FE 생성\n클라이언트가 깨진다. 'Weekly' 접두사는 그 충돌을 피하기 위한 것 — 지우지 말 것.",
+        "properties": {
+          "activatedAt": {
+            "format": "date-time",
+            "title": "Activatedat",
+            "type": "string"
+          },
+          "cancelledBlocks": {
+            "title": "Cancelledblocks",
+            "type": "integer"
+          },
+          "createdBlocks": {
+            "title": "Createdblocks",
+            "type": "integer"
+          },
+          "isDraft": {
+            "const": false,
+            "default": false,
+            "title": "Isdraft",
+            "type": "boolean"
+          },
+          "planId": {
+            "title": "Planid",
+            "type": "string"
+          },
+          "skippedBlocks": {
+            "title": "Skippedblocks",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "planId",
+          "cancelledBlocks",
+          "createdBlocks",
+          "skippedBlocks",
+          "activatedAt"
+        ],
+        "title": "WeeklyReplanApproveResponse",
         "type": "object"
       },
       "WeeklyReviewResponse": {
@@ -5428,7 +5989,7 @@
     },
     "/inbox": {
       "get": {
-        "description": "내 inbox 항목. `?status=captured|classified|promoted` 필터.",
+        "description": "내 inbox 항목. `?status=captured|classified|promoted|archived` 필터.\n\n`status` 미지정 시 활성 항목(archived 제외)만. `status=archived` 는 보관함(soft-deleted)\n조회 — `POST /inbox/{id}/restore` 로 되살릴 수 있다.",
         "operationId": "list_inbox_inbox_get",
         "parameters": [
           {
@@ -5788,6 +6349,65 @@
           }
         },
         "summary": "Convert To Goal",
+        "tags": [
+          "inbox"
+        ]
+      }
+    },
+    "/inbox/{inbox_id}/restore": {
+      "post": {
+        "description": "보관 취소 — `archived_at` 클리어 + status 를 활성(classified/captured)으로 복원.\n\n보관함(`status=archived`)에서만 의미. 이미 활성이면 멱등(현재 상태 그대로 반환).\n존재하지 않으면 404 `INBOX_NOT_FOUND`. hard delete 는 없으므로 언제든 되살릴 수 있다.",
+        "operationId": "restore_inbox_inbox__inbox_id__restore_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "inbox_id",
+            "required": true,
+            "schema": {
+              "title": "Inbox Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InboxItem"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Restore Inbox",
         "tags": [
           "inbox"
         ]
@@ -6253,7 +6873,7 @@
     },
     "/notifications/subscribe": {
       "delete": {
-        "description": "[mock] Web Push 구독 해제 — Issue #25 (PWA) 에서 실 구현.",
+        "description": "Web Push 구독 해제 — 멱등 (구독이 없어도 204).",
         "operationId": "unsubscribe_notifications_subscribe_delete",
         "parameters": [
           {
@@ -6294,7 +6914,7 @@
         ]
       },
       "post": {
-        "description": "[mock] Web Push 구독 등록 — Issue #25 (PWA) 에서 실 구현.",
+        "description": "Web Push 구독 등록 — `push_subscription` JSONB 저장 (재구독은 덮어쓰기).\n\n저장 형태는 pywebpush 가 그대로 받는 `{endpoint, keys: {p256dh, auth}}`.\n응답은 실 설정 행 기준 — pushSubscribed 는 저장 결과에서 파생된다.",
         "operationId": "subscribe_notifications_subscribe_post",
         "parameters": [
           {
@@ -6347,6 +6967,56 @@
           }
         },
         "summary": "Subscribe",
+        "tags": [
+          "notifications"
+        ]
+      }
+    },
+    "/notifications/vapid-public-key": {
+      "get": {
+        "description": "FE 가 `pushManager.subscribe(applicationServerKey)` 에 쓸 VAPID public key.\n\n서버가 **자기 private key 의 짝**을 직접 알려줘 키 불일치를 원천 차단한다. FE 가\npublic key 를 하드코딩·빌드타임 주입하면, 서버가 키를 rotate 하는 순간 구독은 옛 키에\n묶인 채 발송이 전부 push 서비스 403 으로 실패한다(조용히 — 구독 자체는 성공하므로).\n런타임에 받아가면 진실 소스가 서버 하나로 모여 rotate 에도 자동으로 따라온다.\n\n미설정이면 `publicKey=null` — FE 는 구독을 만들지 않는다(스키마 docstring 참조).\n이 경로는 notifications 라우터에 속해 인증 필수(#16 DoD) — 구독 흐름 자체가 로그인 후다.",
+        "operationId": "get_vapid_public_key_notifications_vapid_public_key_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VapidPublicKeyResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Vapid Public Key",
         "tags": [
           "notifications"
         ]
@@ -6462,6 +7132,115 @@
         ]
       }
     },
+    "/plans/replan": {
+      "post": {
+        "description": "주간 리포트를 작성하고, 남은 작업 + 수락한 회복을 **다음 주부터 마감까지** 다시 배치.\n\n- 대상: 다음 주 이후 미착수 블록의 액션 + 활성 블록 없는 planned 백로그(수락한 회복 포함).\n  과거·시작/완료·user_edit 블록은 불변. 실패 원본은 미래 블록이 없어 자동 제외.\n- busy = 확정(시작/완료·user_edit) 블록 + DB 시간정책 + **고정일정(#112 정합)**.\n- 각 새 블록에 '교체할 옛 블록 id'(replacesBlockId)를 실어, 승인이 blanket-cancel 없이\n  그 블록만 현재 상태로 재조정 취소하게 한다(#117). 산출물은 Draft — 자동 적용 금지.",
+        "operationId": "generate_replan_plans_replan_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReplanResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Generate Replan",
+        "tags": [
+          "planning"
+        ]
+      }
+    },
+    "/plans/replan/{plan_id}/approve": {
+      "post": {
+        "description": "재계획 Draft 승인 → **action 단위 재조정**으로 미래 블록 교체(#117 재작업).\n\n#115 스케줄러가 긴 액션을 **여러 세션 블록**으로 쪼개므로, 재조정은 개별 블록이 아니라\n**액션당 '옛 블록 집합'(payload `oldBlocks`)** 을 통째 다룬다 — 옛 블록 1개만 취소하면\n나머지가 유령으로 남거나 새 세션이 드롭되던 문제 방지(리뷰 대응). 액션마다 현재 DB 상태로:\n- 옛 블록 집합 중 하나라도 `started/finished`(사용자 착수) → 이 액션 **전체 보존**(skip).\n- 활성(`scheduled`) 옛 블록이 하나도 없음(그새 전부 취소·삭제) → 중복 방지 skip.\n- 그 외 → 활성 옛 블록 **전부 취소** + 새 세션 블록 **전부 생성**.\n- 백로그(옛 블록 없음): 그새 그 action 이 활성 블록을 얻었으면 생성 skip.\n- action 이 그새 아카이브/삭제됐으면(예: #113 First Plan 교체) 전체 skip(좀비 블록 방지).\n\nDraft 로드·검사~쓰기를 `user_agent_lock`(xact-scoped) 안에서 단일 commit 으로 원자화한다\n(동시 더블 승인 봉합, #113 패턴). 과거·시작/완료·user_edit 블록은 불변. 항상 Draft→HITL.",
+        "operationId": "approve_replan_plans_replan__plan_id__approve_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "plan_id",
+            "required": true,
+            "schema": {
+              "title": "Plan Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WeeklyReplanApproveResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Approve Replan",
+        "tags": [
+          "planning"
+        ]
+      }
+    },
     "/plans/weekly": {
       "get": {
         "description": "주간 블록 그리드 (S14). weekStart 생략 시 이번 주 월요일 기준.",
@@ -6530,7 +7309,7 @@
     },
     "/plans/{plan_id}": {
       "get": {
-        "description": "저장된 First Plan Draft 미리보기 — LLM 재호출 없이 스냅샷 재구성.",
+        "description": "저장된 First Plan Draft 미리보기 — LLM 재호출 없이 스냅샷 재구성.\n\n재계획(`kind='replan'`) Draft 는 payload 모양이 달라(goal_nodes 가 없다) 여기서 다루지\n않는다 — 가드가 없으면 `_draft_to_response` 가 `KeyError: 'goal_nodes'` 로 500 을 낸다.\n승인 endpoint 의 반대편 가드(approve_replan 의 `kind != \"replan\"` 검사)와 대칭.",
         "operationId": "get_plan_plans__plan_id__get",
         "parameters": [
           {
@@ -6589,7 +7368,7 @@
     },
     "/plans/{plan_id}/approve": {
       "post": {
-        "description": "First Plan Draft 승인 → SAVING (goal 트리 단일 가드 트랜잭션 영속화, ADR-0005 §2.5.1).\n\n`plan_id` 로 저장된 Draft 를 로드해 goals/goal_nodes/action_items/scheduled_blocks 를\n단일 트랜잭션으로 영속화(+최대 3회 재시도). `policy_guarded_transaction`(PR #30 재사용)이\n절대 시간 정책 위반 시 롤백 → 422 `PLAN_POLICY_VIOLATION`, 그 외 실패는 롤백 후 500\n`PLAN_SAVE_FAILED`. 만료된 Draft 는 410 `PLAN_DRAFT_EXPIRED`. 이미 승인된 Draft 는 멱등.\n\n부수 효과: 첫 계획 승인 = 온보딩 완료 → onboarding_state 를 `ACTIVE` 로 전이(멱등,\n어느 온보딩 단계에서든). 원설계(FIRST_PLAN → NOTIFICATIONS)는 실제 FE 흐름에서 상태가\nWELCOME 에 고정돼 새로고침 시 재-온보딩되던 문제가 있어 승인에서 ACTIVE 로 마감\n(api-contract §3).\n응답은 명시 승인이므로 `is_draft=false` (ADR-0005 §7.2).",
+        "description": "First Plan Draft 승인 → SAVING (goal 트리 단일 가드 트랜잭션 영속화, ADR-0005 §2.5.1).\n\n`plan_id` 로 저장된 Draft 를 로드해 goals/goal_nodes/action_items/scheduled_blocks 를\n단일 트랜잭션으로 영속화(+최대 3회 재시도). `policy_guarded_transaction`(PR #30 재사용)이\n절대 시간 정책 위반 시 롤백 → 422 `PLAN_POLICY_VIOLATION`, 그 외 실패는 롤백 후 500\n`PLAN_SAVE_FAILED`. 만료된 Draft 는 410 `PLAN_DRAFT_EXPIRED`. 이미 승인된 Draft 는 멱등.\n\n승인 = 교체: 같은 target_date 의 이전 AI 계획 산출물 중 사용자가 손대지 않은\n카드(source=goal·status=planned, user_edit 블록 없는 것)와 그 블록을 soft 정리\n(archived/cancelled)하고, heaviest goal 의 기존 분해 트리도 보관한 뒤 새 계획을\n영속화한다 — 재생성→재승인 반복으로 같은 날짜에 카드/블록/노드가 겹겹이 누적되던\n문제 방지 (`first_plan_adapter.supersede_previous_plan`).\n\n동시성(더블클릭·다중 디바이스 동시 승인): advisory lock 은 **트랜잭션 스코프**\n(`pg_advisory_xact_lock`) 라 commit/rollback 마다 풀린다. 그래서 시도(attempt)마다\nlock 을 새로 잡고, Draft 로드·만료·멱등 검사 → 영속화 → Draft 승인 마킹·온보딩\n전이(`on_success` — 가드 트랜잭션 내부)까지를 **한 트랜잭션 단일 commit** 으로 묶는다.\nlock 이 풀리는 순간엔 항상 status=approved 가 이미 커밋돼 있어, 대기하던 요청은\n멱등 응답으로 빠진다. 재시도(ADR-0005 §2.5.1, 3회)는 이 라우터 루프가 담당한다\n(adapter 내부 재시도는 rollback 으로 lock 을 잃은 채 돌게 되므로 `max_retries=1`).\n\n부수 효과: 첫 계획 승인 = 온보딩 완료 → onboarding_state 를 `ACTIVE` 로 전이(멱등,\n어느 온보딩 단계에서든). 원설계(FIRST_PLAN → NOTIFICATIONS)는 실제 FE 흐름에서 상태가\nWELCOME 에 고정돼 새로고침 시 재-온보딩되던 문제가 있어 승인에서 ACTIVE 로 마감\n(api-contract §3).\n응답은 명시 승인이므로 `is_draft=false` (ADR-0005 §7.2).",
         "operationId": "approve_plan_plans__plan_id__approve_post",
         "parameters": [
           {
@@ -6648,7 +7427,7 @@
     },
     "/plans/{plan_id}/blocks/{block_id}": {
       "patch": {
-        "description": "블록 15분 snap 이동 (S15). 충돌 422 `PLAN_BLOCK_CONFLICT` / 정책 422 `POLICY_VIOLATION`.",
+        "description": "블록 15분 snap 이동 + 목표(category)/제목 수정 (S15).\n\n충돌 422 `PLAN_BLOCK_CONFLICT` / 정책 422 `POLICY_VIOLATION`. `category`/`title` 을 주면\n블록이 매달린 action_item 을 갱신한다(같은 액션의 모든 세션 블록 공유). 정책 검사는\n**변경된 category** 로 수행하고, 변경 반영은 성공 commit 시에만 영속된다(422 면 롤백).",
         "operationId": "edit_block_plans__plan_id__blocks__block_id__patch",
         "parameters": [
           {
@@ -6944,7 +7723,7 @@
     },
     "/recovery/proposals/generate": {
       "post": {
-        "description": "실패 컨텍스트 기반 회복 옵션 2~4개 생성 (LLM ≤ 8s + heuristic fallback).\n\n이미 pending 카드가 있으면 재생성하지 않고 그대로 반환한다 (중복 INSERT 방지).",
+        "description": "실패 컨텍스트 기반 회복 옵션 2~4개 생성 (LLM thinking 0 + ≤ 12s, 룰 fallback — ADR-0003 addendum).\n\n이미 pending 카드가 있으면 재생성하지 않고 그대로 반환한다 (중복 INSERT 방지).",
         "operationId": "generate_recovery_proposals_recovery_proposals_generate_post",
         "parameters": [
           {
@@ -7697,6 +8476,114 @@
           }
         },
         "summary": "Anonymize",
+        "tags": [
+          "settings"
+        ]
+      }
+    },
+    "/settings/profile": {
+      "get": {
+        "description": "지속형 프로필 메모리 — 에너지/시간(behavioral) + 톤/빈도(interaction) + 회복 선호.\n\n인터뷰가 아직 안 채웠으면 해당 항목 null (행/키를 생성하지 않는다).",
+        "operationId": "get_profile_settings_profile_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProfileResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Profile",
+        "tags": [
+          "settings"
+        ]
+      },
+      "patch": {
+        "description": "프로필 메모리 부분 수정 — 지정 필드만 갱신(미지정 유지). 행/키 없으면 생성.\n\nenum 검증은 스키마 Literal (그 외 값 → 422 `COMMON_VALIDATION_ERROR`).\n회복 선호(downscopeUnitMin·restOk)는 `users.focus_mode_preferences`(JSONB)에 병합 저장.",
+        "operationId": "update_profile_settings_profile_patch",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProfileUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProfileResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update Profile",
         "tags": [
           "settings"
         ]

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -43,6 +43,8 @@ import type {
   OnboardingStatus,
   BlockEditRequest,
   BlockEditResponse,
+  ProfileResponse,
+  ProfileUpdateRequest,
   PushSubscribeRequest,
   RecoveryDecisionRequest,
   RecoveryDecisionResponse,
@@ -60,10 +62,13 @@ import type {
   ToneModeUpdateRequest,
   UserProfile,
   UserSettings,
+  VapidPublicKeyResponse,
   HabitPenaltyAcceptResponse,
   HabitPenaltyListResponse,
   WeeklyGenerateRequest,
   WeeklyPlanResponse,
+  WeeklyReplanApproveResponse,
+  WeeklyReplanResponse,
   WeeklyReviewResponse,
 } from '../types/api';
 
@@ -473,6 +478,17 @@ export const plansApi = {
       method: 'PATCH',
       body,
     }),
+
+  // 주간 forward 재계획(S21 후속, #117 구현됨) — 항상 Draft.
+  replanWeekly: () =>
+    request<WeeklyReplanResponse>('/plans/replan', { method: 'POST', body: {} }),
+
+  approveWeeklyReplan: (planId: string, idempotencyKey?: string) =>
+    request<WeeklyReplanApproveResponse>(`/plans/replan/${planId}/approve`, {
+      method: 'POST',
+      body: {},
+      idempotencyKey,
+    }),
 };
 
 // ── Reviews (S21·S22) — 백엔드 #21 구현됨 ─────────────────────
@@ -556,6 +572,10 @@ export const notificationsApi = {
 
   unsubscribe: () =>
     request<void>('/notifications/subscribe', { method: 'DELETE' }),
+
+  // publicKey 가 null 이면 서버에 VAPID 미설정 — 구독을 만들지 않아야 한다.
+  vapidPublicKey: () =>
+    request<VapidPublicKeyResponse>('/notifications/vapid-public-key'),
 };
 
 // ── Settings / Privacy (S23·S28) — 백엔드 501 ─────────────────
@@ -567,6 +587,12 @@ export const settingsApi = {
 
   anonymize: (body: AnonymizeRequest) =>
     request<void>('/settings/anonymize', { method: 'POST', body }),
+
+  // 지속형 프로필 메모리(behavioral/interaction + 회복 선호) — 백엔드 구현됨.
+  getProfile: () => request<ProfileResponse>('/settings/profile'),
+
+  updateProfile: (body: ProfileUpdateRequest) =>
+    request<ProfileResponse>('/settings/profile', { method: 'PATCH', body }),
 };
 
 export const privacyApi = {

--- a/src/lib/push.ts
+++ b/src/lib/push.ts
@@ -1,15 +1,23 @@
 // Web Push 구독 헬퍼 (#25).
-// VAPID public key 는 백엔드에서 받아야 하지만 미구현이라 데모용 키 사용.
-// 실제 푸시 발송이 안 되어도 subscribe API 의 응답 모양은 확인 가능.
+// VAPID public key 는 GET /notifications/vapid-public-key 로 백엔드에서 받는다(#25 구현됨).
+// 서버가 응답하면 (null 포함) 그 값을 신뢰한다 — publicKey=null 은 서버에 VAPID 가 정말
+// 미설정이라는 뜻이라 구독을 만들면 안 된다(구독은 성공해도 발송이 전부 403 실패).
+// 네트워크 실패 등으로 서버를 아예 못 부른 경우에만 데모용 더미 키로 폴백한다.
 
+import { notificationsApi } from './api';
 import type { PushSubscribeRequest } from '../types/api';
 
-// VAPID public key — 우선 환경변수(VITE_VAPID_PUBLIC_KEY), 없으면 시연용 더미로 fallback.
-// 실제 발송에는 같은 키쌍의 private key 를 가진 백엔드(#25)가 필요하다.
 const FALLBACK_VAPID_PUBLIC_KEY =
   'BNcRdreALRFXTkOOUHK1EtK2wtaz5Ry4YfYCA_0QTpQtUbVlUls0VJXg7A8u-Ts1XbjhazAkj7I99e8QcYP7DkM';
-const VAPID_PUBLIC_KEY =
-  import.meta.env.VITE_VAPID_PUBLIC_KEY ?? FALLBACK_VAPID_PUBLIC_KEY;
+
+async function resolveVapidPublicKey(): Promise<string | null> {
+  try {
+    const { publicKey } = await notificationsApi.vapidPublicKey();
+    return publicKey;
+  } catch {
+    return import.meta.env.VITE_VAPID_PUBLIC_KEY ?? FALLBACK_VAPID_PUBLIC_KEY;
+  }
+}
 
 function urlBase64ToUint8Array(base64String: string): Uint8Array {
   const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
@@ -37,10 +45,13 @@ export async function subscribePush(): Promise<PushSubscribeRequest | null> {
   }
   if (Notification.permission !== 'granted') return null;
 
+  const publicKey = await resolveVapidPublicKey();
+  if (!publicKey) return null;
+
   const reg = await navigator.serviceWorker.ready;
   const sub = await reg.pushManager.subscribe({
     userVisibleOnly: true,
-    applicationServerKey: urlBase64ToUint8Array(VAPID_PUBLIC_KEY) as BufferSource,
+    applicationServerKey: urlBase64ToUint8Array(publicKey) as BufferSource,
   });
 
   const json = sub.toJSON();

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -74,7 +74,7 @@ export function SettingsScreen() {
           setPushEnabled(true);
           showToast('푸시 알림 켜졌어요');
         } else {
-          showToast('브라우저가 허용을 거부했어요');
+          showToast('알림을 켤 수 없어요 — 브라우저 권한이나 서버 설정을 확인해주세요');
         }
       } else {
         await unsubscribePush();

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -535,6 +535,37 @@ export interface ReplanApproveResponse {
   isDraft?: boolean;
 }
 
+// POST /plans/replan — 주간 forward 재계획(S21 후속, #117). 항상 Draft(isDraft=true).
+export interface WeeklyReplanBlock {
+  actionId: string;
+  title: string;
+  category: string;
+  start: string; // date-time
+  end: string; // date-time
+  replacesBlockId?: string | null; // 없으면 백로그 신규
+}
+
+export interface WeeklyReplanResponse {
+  planId: string;
+  windowStart: string;
+  horizon: string | null;
+  blocks: WeeklyReplanBlock[];
+  warnings?: string[];
+  generatedAt: string; // date-time
+  isDraft: boolean;
+  aiSource?: 'llm' | 'rule';
+}
+
+// POST /plans/replan/{planId}/approve — action 단위 재조정 승인(Idempotency-Key 필수).
+export interface WeeklyReplanApproveResponse {
+  planId: string;
+  isDraft: false;
+  cancelledBlocks: number;
+  createdBlocks: number;
+  skippedBlocks: number;
+  activatedAt: string; // date-time
+}
+
 // ── Plans (S16) — 주간 보기/블록 수정은 아직 contract 추정(미구현) ──
 export type WorkloadLevel = 'easy' | 'medium' | 'heavy';
 
@@ -729,10 +760,58 @@ export interface ConsentUpdateRequest {
   granted: boolean;
 }
 
+// GET/PATCH /settings/profile — 지속형 프로필 메모리(behavioral/interaction + 회복 선호).
+// 인터뷰가 아직 안 채워졌으면 behavioral/interaction 은 null.
+export type EnergyCycle = 'morning' | 'afternoon' | 'evening' | 'night' | 'varies';
+export type TimeChunkPreference = '10' | '20' | '30' | '60' | '90';
+export type ExplanationDepth = 'brief' | 'normal' | 'detailed';
+export type RecoveryTone = 'gentle' | 'normal' | 'encouraging';
+export type ReminderFrequency = 'minimal' | 'standard' | 'active';
+export type SuggestionStyle = 'soft' | 'neutral' | 'firm';
+
+export interface BehavioralProfileView {
+  attentionSpan: number;
+  energyCycle: EnergyCycle;
+  preferredStartTime?: string | null;
+  preferredEndTime?: string | null;
+  timeChunkPreference: TimeChunkPreference;
+}
+
+export interface InteractionStyleView {
+  explanationDepth: ExplanationDepth;
+  recoveryTone: RecoveryTone;
+  reminderFrequency: ReminderFrequency;
+  suggestionStyle: SuggestionStyle;
+}
+
+export interface ProfileResponse {
+  behavioral: BehavioralProfileView | null;
+  interaction: InteractionStyleView | null;
+  downscopeUnitMin?: number | null;
+  restOk?: boolean | null;
+}
+
+export interface ProfileUpdateRequest {
+  attentionSpan?: number | null;
+  energyCycle?: EnergyCycle | null;
+  timeChunkPreference?: TimeChunkPreference | null;
+  explanationDepth?: ExplanationDepth | null;
+  recoveryTone?: RecoveryTone | null;
+  reminderFrequency?: ReminderFrequency | null;
+  suggestionStyle?: SuggestionStyle | null;
+  downscopeUnitMin?: number | null;
+  restOk?: boolean | null;
+}
+
 // ── Web Push (S08·S25) ────────────────────────────────────────
 export interface PushSubscribeRequest {
   endpoint: string;
   keys: { p256dh: string; auth: string };
+}
+
+// GET /notifications/vapid-public-key — publicKey 가 null 이면 서버 미설정(구독 생성 금지).
+export interface VapidPublicKeyResponse {
+  publicKey: string | null;
 }
 
 // ── 공통 에러 ─────────────────────────────────────────────────

--- a/src/types/openapi.d.ts
+++ b/src/types/openapi.d.ts
@@ -427,7 +427,10 @@ export interface paths {
         };
         /**
          * List Inbox
-         * @description 내 inbox 항목. `?status=captured|classified|promoted` 필터.
+         * @description 내 inbox 항목. `?status=captured|classified|promoted|archived` 필터.
+         *
+         *     `status` 미지정 시 활성 항목(archived 제외)만. `status=archived` 는 보관함(soft-deleted)
+         *     조회 — `POST /inbox/{id}/restore` 로 되살릴 수 있다.
          */
         get: operations["list_inbox_inbox_get"];
         put?: never;
@@ -516,6 +519,29 @@ export interface paths {
          * @description Inbox → Goal 변환 (tier=maintain default, 한도 enforce). inbox.status=promoted.
          */
         post: operations["convert_to_goal_inbox__inbox_id__convert_to_goal_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/inbox/{inbox_id}/restore": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Restore Inbox
+         * @description 보관 취소 — `archived_at` 클리어 + status 를 활성(classified/captured)으로 복원.
+         *
+         *     보관함(`status=archived`)에서만 의미. 이미 활성이면 멱등(현재 상태 그대로 반환).
+         *     존재하지 않으면 404 `INBOX_NOT_FOUND`. hard delete 는 없으므로 언제든 되살릴 수 있다.
+         */
+        post: operations["restore_inbox_inbox__inbox_id__restore_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -690,14 +716,45 @@ export interface paths {
         put?: never;
         /**
          * Subscribe
-         * @description [mock] Web Push 구독 등록 — Issue #25 (PWA) 에서 실 구현.
+         * @description Web Push 구독 등록 — `push_subscription` JSONB 저장 (재구독은 덮어쓰기).
+         *
+         *     저장 형태는 pywebpush 가 그대로 받는 `{endpoint, keys: {p256dh, auth}}`.
+         *     응답은 실 설정 행 기준 — pushSubscribed 는 저장 결과에서 파생된다.
          */
         post: operations["subscribe_notifications_subscribe_post"];
         /**
          * Unsubscribe
-         * @description [mock] Web Push 구독 해제 — Issue #25 (PWA) 에서 실 구현.
+         * @description Web Push 구독 해제 — 멱등 (구독이 없어도 204).
          */
         delete: operations["unsubscribe_notifications_subscribe_delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/notifications/vapid-public-key": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Vapid Public Key
+         * @description FE 가 `pushManager.subscribe(applicationServerKey)` 에 쓸 VAPID public key.
+         *
+         *     서버가 **자기 private key 의 짝**을 직접 알려줘 키 불일치를 원천 차단한다. FE 가
+         *     public key 를 하드코딩·빌드타임 주입하면, 서버가 키를 rotate 하는 순간 구독은 옛 키에
+         *     묶인 채 발송이 전부 push 서비스 403 으로 실패한다(조용히 — 구독 자체는 성공하므로).
+         *     런타임에 받아가면 진실 소스가 서버 하나로 모여 rotate 에도 자동으로 따라온다.
+         *
+         *     미설정이면 `publicKey=null` — FE 는 구독을 만들지 않는다(스키마 docstring 참조).
+         *     이 경로는 notifications 라우터에 속해 인증 필수(#16 DoD) — 구독 흐름 자체가 로그인 후다.
+         */
+        get: operations["get_vapid_public_key_notifications_vapid_public_key_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
         options?: never;
         head?: never;
         patch?: never;
@@ -749,6 +806,64 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/plans/replan": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Generate Replan
+         * @description 주간 리포트를 작성하고, 남은 작업 + 수락한 회복을 **다음 주부터 마감까지** 다시 배치.
+         *
+         *     - 대상: 다음 주 이후 미착수 블록의 액션 + 활성 블록 없는 planned 백로그(수락한 회복 포함).
+         *       과거·시작/완료·user_edit 블록은 불변. 실패 원본은 미래 블록이 없어 자동 제외.
+         *     - busy = 확정(시작/완료·user_edit) 블록 + DB 시간정책 + **고정일정(#112 정합)**.
+         *     - 각 새 블록에 '교체할 옛 블록 id'(replacesBlockId)를 실어, 승인이 blanket-cancel 없이
+         *       그 블록만 현재 상태로 재조정 취소하게 한다(#117). 산출물은 Draft — 자동 적용 금지.
+         */
+        post: operations["generate_replan_plans_replan_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/plans/replan/{plan_id}/approve": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Approve Replan
+         * @description 재계획 Draft 승인 → **action 단위 재조정**으로 미래 블록 교체(#117 재작업).
+         *
+         *     #115 스케줄러가 긴 액션을 **여러 세션 블록**으로 쪼개므로, 재조정은 개별 블록이 아니라
+         *     **액션당 '옛 블록 집합'(payload `oldBlocks`)** 을 통째 다룬다 — 옛 블록 1개만 취소하면
+         *     나머지가 유령으로 남거나 새 세션이 드롭되던 문제 방지(리뷰 대응). 액션마다 현재 DB 상태로:
+         *     - 옛 블록 집합 중 하나라도 `started/finished`(사용자 착수) → 이 액션 **전체 보존**(skip).
+         *     - 활성(`scheduled`) 옛 블록이 하나도 없음(그새 전부 취소·삭제) → 중복 방지 skip.
+         *     - 그 외 → 활성 옛 블록 **전부 취소** + 새 세션 블록 **전부 생성**.
+         *     - 백로그(옛 블록 없음): 그새 그 action 이 활성 블록을 얻었으면 생성 skip.
+         *     - action 이 그새 아카이브/삭제됐으면(예: #113 First Plan 교체) 전체 skip(좀비 블록 방지).
+         *
+         *     Draft 로드·검사~쓰기를 `user_agent_lock`(xact-scoped) 안에서 단일 commit 으로 원자화한다
+         *     (동시 더블 승인 봉합, #113 패턴). 과거·시작/완료·user_edit 블록은 불변. 항상 Draft→HITL.
+         */
+        post: operations["approve_replan_plans_replan__plan_id__approve_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/plans/weekly": {
         parameters: {
             query?: never;
@@ -779,6 +894,10 @@ export interface paths {
         /**
          * Get Plan
          * @description 저장된 First Plan Draft 미리보기 — LLM 재호출 없이 스냅샷 재구성.
+         *
+         *     재계획(`kind='replan'`) Draft 는 payload 모양이 달라(goal_nodes 가 없다) 여기서 다루지
+         *     않는다 — 가드가 없으면 `_draft_to_response` 가 `KeyError: 'goal_nodes'` 로 500 을 낸다.
+         *     승인 endpoint 의 반대편 가드(approve_replan 의 `kind != "replan"` 검사)와 대칭.
          */
         get: operations["get_plan_plans__plan_id__get"];
         put?: never;
@@ -806,6 +925,20 @@ export interface paths {
          *     단일 트랜잭션으로 영속화(+최대 3회 재시도). `policy_guarded_transaction`(PR #30 재사용)이
          *     절대 시간 정책 위반 시 롤백 → 422 `PLAN_POLICY_VIOLATION`, 그 외 실패는 롤백 후 500
          *     `PLAN_SAVE_FAILED`. 만료된 Draft 는 410 `PLAN_DRAFT_EXPIRED`. 이미 승인된 Draft 는 멱등.
+         *
+         *     승인 = 교체: 같은 target_date 의 이전 AI 계획 산출물 중 사용자가 손대지 않은
+         *     카드(source=goal·status=planned, user_edit 블록 없는 것)와 그 블록을 soft 정리
+         *     (archived/cancelled)하고, heaviest goal 의 기존 분해 트리도 보관한 뒤 새 계획을
+         *     영속화한다 — 재생성→재승인 반복으로 같은 날짜에 카드/블록/노드가 겹겹이 누적되던
+         *     문제 방지 (`first_plan_adapter.supersede_previous_plan`).
+         *
+         *     동시성(더블클릭·다중 디바이스 동시 승인): advisory lock 은 **트랜잭션 스코프**
+         *     (`pg_advisory_xact_lock`) 라 commit/rollback 마다 풀린다. 그래서 시도(attempt)마다
+         *     lock 을 새로 잡고, Draft 로드·만료·멱등 검사 → 영속화 → Draft 승인 마킹·온보딩
+         *     전이(`on_success` — 가드 트랜잭션 내부)까지를 **한 트랜잭션 단일 commit** 으로 묶는다.
+         *     lock 이 풀리는 순간엔 항상 status=approved 가 이미 커밋돼 있어, 대기하던 요청은
+         *     멱등 응답으로 빠진다. 재시도(ADR-0005 §2.5.1, 3회)는 이 라우터 루프가 담당한다
+         *     (adapter 내부 재시도는 rollback 으로 lock 을 잃은 채 돌게 되므로 `max_retries=1`).
          *
          *     부수 효과: 첫 계획 승인 = 온보딩 완료 → onboarding_state 를 `ACTIVE` 로 전이(멱등,
          *     어느 온보딩 단계에서든). 원설계(FIRST_PLAN → NOTIFICATIONS)는 실제 FE 흐름에서 상태가
@@ -835,7 +968,11 @@ export interface paths {
         head?: never;
         /**
          * Edit Block
-         * @description 블록 15분 snap 이동 (S15). 충돌 422 `PLAN_BLOCK_CONFLICT` / 정책 422 `POLICY_VIOLATION`.
+         * @description 블록 15분 snap 이동 + 목표(category)/제목 수정 (S15).
+         *
+         *     충돌 422 `PLAN_BLOCK_CONFLICT` / 정책 422 `POLICY_VIOLATION`. `category`/`title` 을 주면
+         *     블록이 매달린 action_item 을 갱신한다(같은 액션의 모든 세션 블록 공유). 정책 검사는
+         *     **변경된 category** 로 수행하고, 변경 반영은 성공 commit 시에만 영속된다(422 면 롤백).
          */
         patch: operations["edit_block_plans__plan_id__blocks__block_id__patch"];
         trace?: never;
@@ -922,7 +1059,7 @@ export interface paths {
         put?: never;
         /**
          * Generate Recovery Proposals
-         * @description 실패 컨텍스트 기반 회복 옵션 2~4개 생성 (LLM ≤ 8s + heuristic fallback).
+         * @description 실패 컨텍스트 기반 회복 옵션 2~4개 생성 (LLM thinking 0 + ≤ 12s, 룰 fallback — ADR-0003 addendum).
          *
          *     이미 pending 카드가 있으면 재생성하지 않고 그대로 반환한다 (중복 INSERT 방지).
          */
@@ -1195,6 +1332,35 @@ export interface paths {
         options?: never;
         head?: never;
         patch?: never;
+        trace?: never;
+    };
+    "/settings/profile": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Profile
+         * @description 지속형 프로필 메모리 — 에너지/시간(behavioral) + 톤/빈도(interaction) + 회복 선호.
+         *
+         *     인터뷰가 아직 안 채웠으면 해당 항목 null (행/키를 생성하지 않는다).
+         */
+        get: operations["get_profile_settings_profile_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Update Profile
+         * @description 프로필 메모리 부분 수정 — 지정 필드만 갱신(미지정 유지). 행/키 없으면 생성.
+         *
+         *     enum 검증은 스키마 Literal (그 외 값 → 422 `COMMON_VALIDATION_ERROR`).
+         *     회복 선호(downscopeUnitMin·restOk)는 `users.focus_mode_preferences`(JSONB)에 병합 저장.
+         */
+        patch: operations["update_profile_settings_profile_patch"];
         trace?: never;
     };
     "/settings/tone-mode": {
@@ -1603,16 +1769,44 @@ export interface components {
             peakWindow: string[];
         };
         /**
+         * BehavioralProfileView
+         * @description behavioral_profiles 의 사용자 편집 대상 필드.
+         */
+        BehavioralProfileView: {
+            /** Attentionspan */
+            attentionSpan: number;
+            /**
+             * Energycycle
+             * @enum {string}
+             */
+            energyCycle: "morning" | "afternoon" | "evening" | "night" | "varies";
+            /** Preferredendtime */
+            preferredEndTime?: string | null;
+            /** Preferredstarttime */
+            preferredStartTime?: string | null;
+            /**
+             * Timechunkpreference
+             * @enum {string}
+             */
+            timeChunkPreference: "10" | "20" | "30" | "60" | "90";
+        };
+        /**
          * BlockEditRequest
-         * @description PATCH /plans/{planId}/blocks/{blockId} — 15분 snap 이동.
+         * @description PATCH /plans/{planId}/blocks/{blockId} — 15분 snap 이동 + 목표(category)/제목 수정.
          *
          *     `endAt` 생략 시 기존 길이를 보존한 채 시작만 옮긴다. 시각은 KST ISO 8601.
+         *     `category`/`title` 을 주면 블록이 매달린 action_item 을 갱신한다 — 같은 액션의 모든
+         *     세션 블록에 반영되며, 미지원 category 는 'other' 로 정규화한다. 미지정 필드는 유지.
          */
         BlockEditRequest: {
+            /** Category */
+            category?: string | null;
             /** Endat */
             endAt?: string | null;
             /** Startat */
             startAt: string;
+            /** Title */
+            title?: string | null;
         };
         /**
          * BlockEditResponse
@@ -1901,9 +2095,21 @@ export interface components {
          *     검증은 라우터/오케스트레이터 VALIDATING 단계에서 수행.
          */
         FirstPlanGenerateRequest: {
+            /**
+             * Density
+             * @default standard
+             * @enum {string}
+             */
+            density: "light" | "standard" | "intense";
             /** Interviewsessionid */
             interviewSessionId?: string | null;
             outcome?: components["schemas"]["InterviewOutcome"] | null;
+            /**
+             * Scope
+             * @default horizon
+             * @enum {string}
+             */
+            scope: "week" | "horizon";
             /** Targetdate */
             targetDate?: string | null;
         };
@@ -2030,6 +2236,8 @@ export interface components {
             category: string;
             /** Confidence */
             confidence: number;
+            /** Currentlevel */
+            currentLevel?: string | null;
             /** Deadline */
             deadline?: string | null;
             /**
@@ -2339,6 +2547,8 @@ export interface components {
             inboxId: string;
             /** Promotedgoalid */
             promotedGoalId: string | null;
+            /** Promotedto */
+            promotedTo?: ("goal" | "action") | null;
             /** Rawtext */
             rawText: string;
             /** Status */
@@ -2355,6 +2565,32 @@ export interface components {
             status?: ("captured" | "classified" | "archived" | "promoted") | null;
             /** Usercategory */
             userCategory?: ("study" | "project" | "health" | "routine" | "schedule" | "other") | null;
+        };
+        /**
+         * InteractionStyleView
+         * @description interaction_styles 의 사용자 편집 대상 필드.
+         */
+        InteractionStyleView: {
+            /**
+             * Explanationdepth
+             * @enum {string}
+             */
+            explanationDepth: "brief" | "normal" | "detailed";
+            /**
+             * Recoverytone
+             * @enum {string}
+             */
+            recoveryTone: "gentle" | "normal" | "encouraging";
+            /**
+             * Reminderfrequency
+             * @enum {string}
+             */
+            reminderFrequency: "minimal" | "standard" | "active";
+            /**
+             * Suggestionstyle
+             * @enum {string}
+             */
+            suggestionStyle: "soft" | "neutral" | "firm";
         };
         /**
          * InterviewOutcome
@@ -2601,8 +2837,54 @@ export interface components {
             weeklyEnergy?: string | null;
         };
         /**
+         * ProfileResponse
+         * @description GET/PATCH /settings/profile — 지속형 프로필 메모리.
+         *
+         *     인터뷰가 아직 안 채웠으면 각 항목 null (행 없음).
+         *     `downscopeUnitMin`/`restOk` 는 회복 선호 — `users.focus_mode_preferences`(JSONB) 출처.
+         */
+        ProfileResponse: {
+            behavioral: components["schemas"]["BehavioralProfileView"] | null;
+            /** Downscopeunitmin */
+            downscopeUnitMin?: number | null;
+            interaction: components["schemas"]["InteractionStyleView"] | null;
+            /** Restok */
+            restOk?: boolean | null;
+        };
+        /**
+         * ProfileUpdateRequest
+         * @description PATCH /settings/profile — 지정 필드만 부분 갱신. 미지정(None)은 유지.
+         *
+         *     enum 외 값은 Pydantic Literal → 422 `COMMON_VALIDATION_ERROR`.
+         */
+        ProfileUpdateRequest: {
+            /** Attentionspan */
+            attentionSpan?: number | null;
+            /** Downscopeunitmin */
+            downscopeUnitMin?: number | null;
+            /** Energycycle */
+            energyCycle?: ("morning" | "afternoon" | "evening" | "night" | "varies") | null;
+            /** Explanationdepth */
+            explanationDepth?: ("brief" | "normal" | "detailed") | null;
+            /** Recoverytone */
+            recoveryTone?: ("gentle" | "normal" | "encouraging") | null;
+            /** Reminderfrequency */
+            reminderFrequency?: ("minimal" | "standard" | "active") | null;
+            /** Restok */
+            restOk?: boolean | null;
+            /** Suggestionstyle */
+            suggestionStyle?: ("soft" | "neutral" | "firm") | null;
+            /** Timechunkpreference */
+            timeChunkPreference?: ("10" | "20" | "30" | "60" | "90") | null;
+        };
+        /**
          * PushSubscribeRequest
          * @description POST /notifications/subscribe 요청 — Web Push subscription 객체.
+         *
+         *     브라우저 `PushSubscription.toJSON()` 의 `{endpoint, keys: {p256dh, auth}}`.
+         *     p256dh/auth 는 pywebpush 발송(payload 암호화)에 필수라 스키마에서 강제한다 —
+         *     빠진 채 저장되면 **발송 시점**에야 터져서, 구독은 됐다고 믿는 사용자가 조용히
+         *     알림을 못 받는다.
          */
         PushSubscribeRequest: {
             /** Endpoint */
@@ -2662,6 +2944,10 @@ export interface components {
          * @description POST /recovery/decisions 요청 (Idempotency-Key 필수, §1.7).
          *
          *     - `decision="accepted"` → `accepted_attempt_id` 필수, 나머지 pending 카드는 rejected.
+         *     - `decision="edited"` → `accepted_attempt_id` + `edited_action_text` 필수. 부수효과는
+         *       accepted 와 같고(형제 rejected, 새 카드 생성) **새 카드 title 만 사용자 문구**가 된다.
+         *       AI 원문(`suggested_action_text`)은 보존한다 — "얼마나 고쳐 썼나"가 AI 품질 지표다.
+         *       새 카드를 만들지 않는 그룹(RESCHEDULE/PARK)은 문구를 담을 곳이 없어 422.
          *     - `decision="skipped"` → 모든 pending 카드 skipped ("오늘은 쉬기").
          */
         RecoveryDecisionRequest: {
@@ -2671,9 +2957,11 @@ export interface components {
              * Decision
              * @enum {string}
              */
-            decision: "accepted" | "skipped";
+            decision: "accepted" | "edited" | "skipped";
             /** Decisionreason */
             decisionReason?: string | null;
+            /** Editedactiontext */
+            editedActionText?: string | null;
             /** Executionid */
             executionId: string;
         };
@@ -2863,6 +3151,34 @@ export interface components {
             title: string;
         };
         /**
+         * ReplanBlockPreview
+         * @description 재계획 미리보기 블록 — 기존 ActionItem 에 연결(actionId). 시각은 KST.
+         *
+         *     `replacesBlockId` 는 이 새 블록이 교체하는 옛 미래 블록의 **대표 id**(미리보기용, 없으면
+         *     백로그라 null). 실제 승인 재조정은 payload 의 `oldBlocks`(액션당 옛 블록 **전부**)를 권위로
+         *     삼아 액션 단위로 취소·생성한다 — 한 액션이 여러 세션으로 쪼개진 경우까지 정확히(#117).
+         */
+        ReplanBlockPreview: {
+            /** Actionid */
+            actionId: string;
+            /** Category */
+            category: string;
+            /**
+             * End
+             * Format: date-time
+             */
+            end: string;
+            /** Replacesblockid */
+            replacesBlockId?: string | null;
+            /**
+             * Start
+             * Format: date-time
+             */
+            start: string;
+            /** Title */
+            title: string;
+        };
+        /**
          * ReplanDiffResponse
          * @description GET /replan/{executionId} — S20 before/after 프리뷰 (Draft Layer).
          *
@@ -2895,6 +3211,38 @@ export interface components {
              * @enum {string}
              */
             optionGroup: "DOWNSCOPE" | "RESCHEDULE" | "CARRY_OVER" | "PARK";
+        };
+        /**
+         * ReplanResponse
+         * @description 주간 재계획 미리보기 — 항상 Draft. 승인은 `/plans/replan/{planId}/approve`.
+         */
+        ReplanResponse: {
+            /**
+             * Aisource
+             * @default llm
+             * @enum {string}
+             */
+            aiSource: "llm" | "rule";
+            /** Blocks */
+            blocks: components["schemas"]["ReplanBlockPreview"][];
+            /**
+             * Generatedat
+             * Format: date-time
+             */
+            generatedAt: string;
+            /** Horizon */
+            horizon: string | null;
+            /**
+             * Isdraft
+             * @default true
+             */
+            isDraft: boolean;
+            /** Planid */
+            planId: string;
+            /** Warnings */
+            warnings?: string[];
+            /** Windowstart */
+            windowStart: string;
         };
         /**
          * ScheduledBlockPreview
@@ -3101,6 +3449,18 @@ export interface components {
             type: string;
         };
         /**
+         * VapidPublicKeyResponse
+         * @description GET /notifications/vapid-public-key 응답 — FE `applicationServerKey` 용 공개값.
+         *
+         *     `publicKey` 가 null 이면 서버에 VAPID 미설정 → FE 는 **구독을 만들지 말고** '알림 미지원'
+         *     을 표시해야 한다. 서버가 발송할 수 없는데 구독만 만들면, 브라우저 subscribe 는 성공해도
+         *     발송 시 push 서비스가 키 불일치로 403 을 던져 도달 못 하는 구독이 조용히 쌓인다.
+         */
+        VapidPublicKeyResponse: {
+            /** Publickey */
+            publicKey: string | null;
+        };
+        /**
          * WeeklyBlock
          * @description 주간 그리드의 스케줄 블록 한 칸.
          */
@@ -3177,6 +3537,40 @@ export interface components {
              * Format: date
              */
             weekStart: string;
+        };
+        /**
+         * WeeklyReplanApproveResponse
+         * @description 주간 forward 재계획 승인 결과 — 재조정 카운트. `is_draft=False`.
+         *
+         *     started/finished 로 바뀐 옛 블록·다른 계획 승인분은 건드리지 않으므로(재조정),
+         *     `skipped` 는 그렇게 보존된 항목 수다.
+         *
+         *     ⚠️ 이름 주의: `schemas/recovery.py` 의 `ReplanApproveResponse`(S20 실행단위 replan,
+         *     `POST /replan/{executionId}/approve`)와 **다른 것**이다. 같은 이름을 쓰면 FastAPI 가
+         *     중복 모델명을 양쪽 다 full-qualify 로 바꿔(`reaction_backend__schemas__recovery__...`)
+         *     이 PR 이 건드리지도 않은 회복 endpoint 의 OpenAPI 컴포넌트명이 변하고 FE 생성
+         *     클라이언트가 깨진다. 'Weekly' 접두사는 그 충돌을 피하기 위한 것 — 지우지 말 것.
+         */
+        WeeklyReplanApproveResponse: {
+            /**
+             * Activatedat
+             * Format: date-time
+             */
+            activatedAt: string;
+            /** Cancelledblocks */
+            cancelledBlocks: number;
+            /** Createdblocks */
+            createdBlocks: number;
+            /**
+             * Isdraft
+             * @default false
+             * @constant
+             */
+            isDraft: false;
+            /** Planid */
+            planId: string;
+            /** Skippedblocks */
+            skippedBlocks: number;
         };
         /**
          * WeeklyReviewResponse
@@ -4282,6 +4676,39 @@ export interface operations {
             };
         };
     };
+    restore_inbox_inbox__inbox_id__restore_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                inbox_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InboxItem"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     start_session_interview_sessions_post: {
         parameters: {
             query?: never;
@@ -4610,6 +5037,37 @@ export interface operations {
             };
         };
     };
+    get_vapid_public_key_notifications_vapid_public_key_get: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["VapidPublicKeyResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     get_onboarding_status_onboarding_status_get: {
         parameters: {
             query?: never;
@@ -4663,6 +5121,70 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["FirstPlanResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    generate_replan_plans_replan_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ReplanResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    approve_replan_plans_replan__plan_id__approve_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                plan_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WeeklyReplanApproveResponse"];
                 };
             };
             /** @description Validation Error */
@@ -5365,6 +5887,72 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AnonymizeResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_profile_settings_profile_get: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProfileResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_profile_settings_profile_patch: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ProfileUpdateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProfileResponse"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
## 요약

reaction-backend 최신 커밋 기준으로 OpenAPI 스펙을 다시 덤프하고, 프론트 타입/래퍼를 동기화한 정기 루틴 실행 결과입니다.

### (a) 신규/변경 엔드포인트

- `POST /plans/replan`, `POST /plans/replan/{planId}/approve` — 주간 forward 재계획(S21 후속, #117)
- `GET/PATCH /settings/profile` — 지속형 프로필 메모리(behavioral/interaction + 회복 선호)
- `GET /notifications/vapid-public-key` — Web Push 구독용 VAPID 공개키
- (참고) `today/agenda`, `today/focus/{id}/pause|resume`, `reflection/pending`, `reflection/batch` 는 지난 실행 시점엔 WARN(백엔드 미구현)이었으나 이번 체크에서 모두 OK 로 확인됨 — api.ts 래퍼는 이미 존재해 추가 작업 불필요

### (b) 화면 실연동

- **Web Push 구독 실키 전환** (`src/lib/push.ts`, `src/screens/SettingsScreen.tsx`): 하드코딩된 데모 VAPID 공개키 대신 백엔드 `GET /notifications/vapid-public-key` 응답을 사용하도록 변경. 서버가 명시적으로 `publicKey: null` 을 주면(VAPID 미설정) 구독을 만들지 않고, 네트워크 실패 등으로 서버를 아예 못 부른 경우에만 기존 데모 키로 폴백(mock-and-replace 유지, 화면 안 깨짐).
- 신규 엔드포인트(주간 재계획, 프로필 메모리) 는 기존 화면에 대응하는 mock UI가 없어 이번엔 타입 + `api.ts` 래퍼만 추가하고 화면 연동은 보류함(신규 화면 제작은 API 동기화 루틴 범위 밖으로 판단).

### (c) check:api 요약

```
openapi 경로 69개 · api.ts 호출 78개
✅ OK   78  ⚠️ WARN 0  ❌ GONE 0  🆕 NEW 6
NEW: POST /calendar/events/approve-insert, POST /calendar/sync-preview,
     PATCH /habits/{}, GET /health, GET /inbox, GET /policy-snapshot/current
```
(NEW 6개는 모두 이번 백엔드 동기화 이전부터 있던 항목이며, 대응하는 mock 화면이 없거나(`policy-snapshot`, `health`) `[stub]`만 구현된(`calendar/*`) 엔드포인트라 이번 범위에서 제외함. `GET /inbox` 는 실제로는 이미 래핑되어 있으나 체크 스크립트 정규식이 삼항연산자 경로를 못 잡는 false positive.)

### 검증 게이트

- [x] `npm run check:api` — GONE 0, PASS
- [x] `npx tsc --noEmit` — 통과
- [x] `npm run build` — 통과


---
_Generated by [Claude Code](https://claude.ai/code/session_01WoxYQpfEtikFAJV8eafG6T)_