### PR TITLE
feat(inbox): 추천 자료 카드 분기 + 뷰어 배선 — 결정 (a) (#163)

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -36,6 +36,7 @@ import type {
   HabitInstance,
   InboxCreateRequest,
   InboxItem,
+  InboxResource,
   InboxUpdateRequest,
   InterviewSession,
   NotificationSettings,
@@ -397,6 +398,10 @@ export const inboxApi = {
   // 보관 복원 → 활성(captured/classified) 로 되돌림 (#122, backend#125)
   restore: (inboxId: string) =>
     request<InboxItem>(`/inbox/${inboxId}/restore`, { method: 'POST', body: {} }),
+
+  // 추천 자료 본문(마크다운) 조회 (#163, backend#171). 미존재 slug 는 404.
+  resource: (slug: string) =>
+    request<InboxResource>(`/inbox/resources/${encodeURIComponent(slug)}`),
 };
 
 // ── Habits (S27) ──────────────────────────────────────────────

--- a/src/screens/InboxScreen.tsx
+++ b/src/screens/InboxScreen.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useRef, useState } from 'react';
-import { Sparkle, ArrowUp, Archive, TreeStructure, ListChecks, ArrowCounterClockwise, ArrowRight } from '@phosphor-icons/react';
+import { Sparkle, ArrowUp, Archive, TreeStructure, ListChecks, ArrowCounterClockwise, ArrowRight, BookOpen } from '@phosphor-icons/react';
 import { friendlyError, inboxApi } from '../lib/api';
 import { Segmented } from '../components/Segmented';
+import { ResourceViewerSheet } from '../components/ResourceViewerSheet';
 import { useNavigation } from '../contexts/NavigationContext';
 import type { InboxItem, InboxStatus } from '../types/api';
 
@@ -48,6 +49,8 @@ export function InboxScreen() {
   const [error, setError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const { setScreen, setTab } = useNavigation();
+  // 추천 자료 뷰어(#163) — markdown null = 로딩 중.
+  const [resource, setResource] = useState<{ title: string; markdown: string | null; error: string | null } | null>(null);
 
   const fetchList = (status?: string) => {
     setIsLoading(true);
@@ -148,6 +151,19 @@ export function InboxScreen() {
     }
   };
 
+  // 추천 자료 열기 — 시트를 먼저 띄우고(로딩) 본문을 받아 채운다(#163).
+  const openResource = async (it: InboxItem) => {
+    const slug = it.resourceSlug;
+    if (!slug) return;
+    setResource({ title: it.rawText, markdown: null, error: null });
+    try {
+      const res = await inboxApi.resource(slug);
+      setResource({ title: res.title || it.rawText, markdown: res.markdown, error: null });
+    } catch (err: unknown) {
+      setResource({ title: it.rawText, markdown: null, error: friendlyError(err, '자료를 불러오지 못했어요.') });
+    }
+  };
+
   // 목록에 존재하는 카테고리(사용자 지정 우선, 없으면 AI 추정) — 필터 칩 소스.
   const itemCategory = (it: InboxItem) => it.userCategory ?? it.aiCategoryGuess ?? null;
   const categories = Array.from(new Set(items.map(itemCategory).filter((c): c is string => !!c)));
@@ -213,6 +229,9 @@ export function InboxScreen() {
           const meta = STATUS_META[status];
           // 승격 배지는 대상에 따라 분기(#122): action=할 일로, goal(기본)=목표로.
           const badgeLabel = status === 'promoted' && it.promotedTo === 'action' ? '할 일로' : meta.label;
+          // 시스템이 넣은 추천 자료(#163). 결정 (a): 별도 탭·섹션 없이 '할 일' 탭 안에서
+          // 배지로만 구분한다. 승격(할 일로/목표로)은 BE 가 422 로 막으므로 버튼을 숨긴다.
+          const isResource = it.source === 'system';
           return (
             <div
               key={it.inboxId}
@@ -222,7 +241,11 @@ export function InboxScreen() {
               <div style={{ display: 'flex', gap: 5, flexWrap: 'wrap', alignItems: 'center' }}>
                 {/* classified 는 '할 일' 탭에서 자명하므로 상태 배지 생략(#129 — 내부 상태 노출 제거).
                     처리됨(목표로/할 일로)·보관 배지는 의미가 있어 유지. */}
-                {status !== 'classified' && (
+                {isResource ? (
+                  <span style={{ height: 'var(--ctrl-xs)', padding: '0 8px', borderRadius: 9999, background: 'var(--brand-soft)', border: '1px solid var(--coral-200)', fontSize: 10, fontWeight: 700, color: 'var(--coral-700)', fontFamily: 'var(--font-mono)', display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+                    <BookOpen size={10} weight="fill" /> 추천 자료
+                  </span>
+                ) : status !== 'classified' && (
                   <span style={{ height: 'var(--ctrl-xs)', padding: '0 8px', borderRadius: 9999, background: meta.bg, border: `1px solid ${meta.bd}`, fontSize: 10, fontWeight: 700, color: meta.fg, fontFamily: 'var(--font-mono)', display: 'inline-flex', alignItems: 'center' }}>
                     {badgeLabel}
                   </span>
@@ -233,7 +256,15 @@ export function InboxScreen() {
                   </span>
                 )}
                 <div style={{ flex: 1 }} />
-                {status !== 'promoted' && status !== 'archived' && (
+                {isResource && status !== 'archived' && (
+                  <button
+                    onClick={() => openResource(it)}
+                    style={{ height: 26, padding: '0 10px', borderRadius: 9999, border: '1px solid var(--coral-200)', background: 'var(--brand-soft)', color: 'var(--coral-700)', fontSize: 11, fontWeight: 600, cursor: 'pointer', fontFamily: 'inherit', display: 'inline-flex', alignItems: 'center', gap: 4 }}
+                  >
+                    <BookOpen size={11} weight="fill" /> 열기
+                  </button>
+                )}
+                {!isResource && status !== 'promoted' && status !== 'archived' && (
                   <>
                     <button
                       onClick={() => convertToAction(it.inboxId)}
@@ -301,6 +332,16 @@ export function InboxScreen() {
           <ArrowUp size={14} weight="fill" />
         </button>
       </div>
+
+      {/* 추천 자료 뷰어(#163) — 마크다운 본문. 시트가 화면을 덮으므로 최상단에 렌더. */}
+      {resource && (
+        <ResourceViewerSheet
+          title={resource.title}
+          markdown={resource.markdown}
+          error={resource.error}
+          onClose={() => setResource(null)}
+        />
+      )}
     </div>
   );
 }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -262,10 +262,22 @@ export interface InboxItem {
   promotedGoalId: string | null;
   // 승격 대상 구분(#122) — 'action'(할 일로) / 'goal'(목표로). 없으면 goal 로 간주.
   promotedTo?: 'goal' | 'action' | null;
+  // 시스템이 넣은 추천 자료 항목 구분(#163, backend#171). 필드가 없으면 사용자 캡처로
+  // 간주하므로 BE 미배포 상태에서도 기존 동작 그대로다(안전한 no-op).
+  // ⚠️ BE 배포 후 `npm run gen:api` 로 실제 계약과 대조할 것.
+  source?: 'user' | 'system' | null;
+  resourceSlug?: string | null;
 }
 
 export interface InboxCreateRequest {
   rawText: string;
+}
+
+// GET /inbox/resources/{slug} (#163, backend#171). 미존재 slug 는 404.
+export interface InboxResource {
+  slug: string;
+  title: string;
+  markdown: string;
 }
 
 export interface InboxUpdateRequest {


### PR DESCRIPTION
## 결정 반영
**PM 결정 (a)**: 별도 탭·섹션 없이 **'할 일' 탭 안에서 배지로만 구분**. (자료가 3건 넘게 쌓이는 게 확인되면 (b) 별도 섹션으로 재검토)

앞선 PR #167(뷰어 컴포넌트)에 이어, 이번엔 **카드 분기 + API 배선**입니다.

## 변경
- **타입**: `InboxItem.source?('user'|'system')` · `resourceSlug?` 추가 — **optional 이라 backend#171 미배포 상태에선 자연히 no-op**(기존 카드 동작 유지).
- **카드 분기**: `source==='system'` → **"추천 자료" 배지** + 액션을 **[열기]·[보관]** 으로 제한. `[할 일로]`/`[목표로]` 숨김(BE 가 422 로 막는 경로).
- **API**: `inboxApi.resource(slug)` → `GET /inbox/resources/{slug}`. 응답 `{slug,title,markdown}` 은 **backend#171 이슈에 명시된 계약**을 따랐습니다(추측 아님). 404 는 `friendlyError`.
- **[열기]** → `ResourceViewerSheet` 를 로딩 상태로 먼저 띄우고 본문을 채움.

## 검증 (Playwright, mock)
| 시나리오 | 결과 |
|---|---|
| **BE 미배포 회귀** (`source` 없음) | 배지·열기 **0건**, 할일로/목표로 그대로 → 안전한 no-op |
| 자료 항목 | 배지 1 · 열기 1, **자료카드 내 할일로/목표로 0**, 일반카드는 유지 |
| [열기] | slug 로 fetch → 시트에 마크다운 렌더, 헤더/본문 제목 중복 없음 |
| 404 | "자료를 불러오지 못했어요" alert |

`tsc` / `check-api-contract`(PASS) / `build` 클린.

## DoD 대조
- [x] 자료 카드에 [할 일로]/[목표로] 버튼 없음
- [x] [열기] → 마크다운이 앱 스타일로 렌더
- [x] 모바일 뷰포트 가로 스크롤 없음 (PR #167 에서 검증)
- [x] build(tsc) · check:api green
- [ ] **운동 목표 생성 → 인박스에 자료 카드 노출** — backend#171 배포 후 실환경 확인 필요
- [ ] [보관] → 보관 탭 이동 / [복원] — 기존 경로라 동작하지만 자료 항목으로는 실환경 확인 필요

## 남은 것
backend#171 배포 후 **`npm run gen:api` 로 계약 대조** 1회. 필드명이 다르면 배지가 안 뜰 뿐 기존 동작은 깨지지 않습니다(실패 모드가 안전).

Refs #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)