### PR TITLE
refactor: 화면에 인라인으로 박힌 UI 를 컴포넌트로 추출 (DS 15 → 31)

### DIFF
--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -1,7 +1,7 @@
 # design-sync 운영 노트 (Re:Action DS)
 
 프로젝트: `Re:Action DS (코드 동기화)` — https://claude.ai/design/p/ae221286-40e0-4835-93dd-234ba1046b95
-shape: `package` (Storybook 없음). 컴포넌트 15개 전부 동기화됨.
+shape: `package` (Storybook 없음). 컴포넌트 **31개** 동기화됨.
 
 ## 이 레포에서만 생기는 함정들
 
@@ -35,6 +35,36 @@ shape: `package` (Storybook 없음). 컴포넌트 15개 전부 동기화됨.
 흰 글씨 + 코랄-500 버튼도 3.14:1로 미달. 강조 텍스트는 `--coral-700`(5.74:1 / 흰 글씨 6.04:1).
 이 내용은 `conventions.md`에 들어가 있고 README 맨 위로 업로드됩니다 — 디자인 에이전트가
 읽는 규약이므로, 팔레트를 바꾸면 여기 수치도 같이 고칠 것.
+
+## 무엇을 DS 에 넣나 — 판단 기준
+
+**앱이 실제로 렌더하는 것만 넣는다.** 디자인 툴에서 조립한 화면이 코드에 없는 부품을
+쓰면 그 디자인은 그대로 구현될 수 없다. 그래서:
+
+- 화면 안에 인라인으로 박혀 있는 UI 는 **컴포넌트로 뽑아서 화면이 그걸 쓰게 만든 뒤** 등록한다.
+  뽑아만 두고 화면은 그대로 두면 곧바로 드리프트가 시작된다.
+- 안 쓰이는 컴포넌트는 등록하지 않는다. (실제로 `Ring` 이 정의만 되고 아무도 안 쓰는
+  죽은 코드였다 — `noUnusedLocals: false` 라 아무 경고도 없었음. 이런 건 지운다.)
+- 새 컴포넌트를 추가하면 **`src/design-system.ts` 배럴**과
+  **`.design-sync/config.json` 의 `componentSrcMap`** 둘 다에 넣어야 한다.
+
+## 카드가 이상하게 나올 때
+
+- `cardMode: "single"` 인데 엉뚱한 스토리가 뽑히면 → `primaryStory` 를 지정한다.
+  (`WeekGrid` 가 `Loading` 스토리를 대표로 골라서 빈 격자만 나왔었다.)
+- `[GRID_OVERFLOW]` 경고 → 해당 컴포넌트에 `cardMode: "column"`.
+- 배럴에서 export 했는데 프리뷰 파일이 없으면 빈 "floor card" 가 나온다.
+  같은 파일에서 여러 개를 export 하면(`InboxItemCard` + `InboxAction`)
+  **각각 프리뷰 파일이 필요**하다.
+
+## 빌드/검증 실행법 (스크립트는 `.ds-sync/` 에 스테이징돼 있다)
+
+```
+node .ds-sync/package-build.mjs --config .design-sync/config.json \
+  --node-modules ./node_modules --out ./ds-bundle
+node .ds-sync/package-validate.mjs ./ds-bundle
+```
+스킬 디렉터리에서 직접 실행하면 `esbuild` 를 못 찾는다 — 반드시 `.ds-sync/` 쪽을 쓸 것.
 
 ## 재동기화 방법
 

--- a/.design-sync/config.json
+++ b/.design-sync/config.json
@@ -13,14 +13,30 @@
     "Card": "src/components/Card.tsx",
     "Chip": "src/components/Chip.tsx",
     "DemoNotice": "src/components/DemoNotice.tsx",
+    "EmptyState": "src/components/EmptyState.tsx",
+    "ErrorBanner": "src/components/ErrorBanner.tsx",
+    "GoalCard": "src/components/GoalCard.tsx",
+    "HeroTaskCard": "src/components/HeroTaskCard.tsx",
+    "IconAction": "src/components/IconAction.tsx",
+    "InboxAction": "src/components/InboxItemCard.tsx",
+    "InboxItemCard": "src/components/InboxItemCard.tsx",
     "IosInstallCard": "src/components/IosInstallCard.tsx",
+    "ProgressSheet": "src/components/ProgressSheet.tsx",
     "ReButton": "src/components/ReButton.tsx",
+    "RecoveryOptionCard": "src/components/RecoveryOptionCard.tsx",
     "ResourceViewerSheet": "src/components/ResourceViewerSheet.tsx",
+    "ScoreDonut": "src/components/ScoreDonut.tsx",
     "SectionHeader": "src/components/SectionHeader.tsx",
     "Segmented": "src/components/Segmented.tsx",
     "SetupProgress": "src/components/SetupProgress.tsx",
+    "SkeletonBlock": "src/components/SkeletonBlock.tsx",
     "TabBar": "src/components/TabBar.tsx",
+    "TaskRow": "src/components/TaskRow.tsx",
+    "TextField": "src/components/TextField.tsx",
     "TimeDial": "src/components/TimeDial.tsx",
+    "Toast": "src/components/Toast.tsx",
+    "Toggle": "src/components/Toggle.tsx",
+    "WeekGrid": "src/components/WeekGrid.tsx",
     "WeeklySwitch": "src/components/WeeklySwitch.tsx",
     "Wordmark": "src/components/Wordmark.tsx"
   },
@@ -33,6 +49,36 @@
     "ResourceViewerSheet": {
       "cardMode": "column",
       "viewport": "420x580"
+    },
+    "WeekGrid": {
+      "cardMode": "single",
+      "primaryStory": "ThisWeek",
+      "viewport": "420x620"
+    },
+    "ProgressSheet": {
+      "cardMode": "single",
+      "primaryStory": "Open",
+      "viewport": "420x620"
+    },
+    "HeroTaskCard": {
+      "cardMode": "column",
+      "viewport": "400x520"
+    },
+    "RecoveryOptionCard": {
+      "cardMode": "column",
+      "viewport": "400x560"
+    },
+    "InboxItemCard": {
+      "cardMode": "column",
+      "viewport": "400x520"
+    },
+    "GoalCard": {
+      "cardMode": "column",
+      "viewport": "400x520"
+    },
+    "Toast": {
+      "cardMode": "column",
+      "viewport": "400x220"
     }
   },
   "readmeHeader": ".design-sync/conventions.md"

--- a/.design-sync/conventions.md
+++ b/.design-sync/conventions.md
@@ -71,6 +71,33 @@ AI가 만든 것은 **항상 초안으로 표시**하고 사용자가 승인해�
 
 상태 표현은 앱 전체에서 **완료 / 일부만 / 잘 안됨**으로 통일합니다.
 
+## 화면별로 뭘 쓰나
+
+앱의 실제 화면은 아래 조합이다. 새 화면을 그릴 땐 이걸 그대로 재사용한다.
+
+| 화면 | 주역 | 함께 쓰는 것 |
+|---|---|---|
+| 오늘 실행 | `HeroTaskCard` + `TaskRow` | `ProgressSheet`(일부만 기록), `EmptyState` |
+| 주간 계획 | `WeekGrid` | `BlockEditSheet`, `Toast`, `WeeklySwitch` |
+| 온보딩 계획 확인 | `WeekGrid` (+`backdrop` 으로 기존 계획) | `AiDraftCard`, `SetupProgress` |
+| 회복 제안 | `RecoveryOptionCard` | `ErrorBanner`, `EmptyState` |
+| 인박스 | `InboxItemCard` + `InboxAction` | `ResourceViewerSheet`, `SkeletonBlock` |
+| 목표 관리 | `GoalCard` + `IconAction` | `TextField`, `ReButton`, `AiDraftCard` |
+| 주간 리뷰 | `ScoreDonut` | `SectionHeader`, `EmptyState` |
+| 설정 | `Toggle` | `SectionHeader`, `Toast` |
+
+**시간표는 `WeekGrid` 하나뿐이다.** 온보딩과 메인 캘린더가 같은 걸 쓴다. 좁다고 느끼면
+`colWidth`(기본 50) 만 올리면 되고, 그러면 가로 스크롤이 생긴다 — 격자를 목록으로
+바꾸지 말 것. 빈 시간이 눈에 보이는 게 이 화면의 존재 이유다.
+
+## 로딩·빈·에러 — 더미로 채우지 않는다
+
+데이터가 없을 때 그럴듯한 가짜를 그리지 않는다. 셋 중 하나를 쓴다.
+
+- 아직 불러오는 중 → `SkeletonBlock`
+- 불러왔는데 없음 → `EmptyState` (점선 = 내용 없음)
+- 실패 → `ErrorBanner` (사라지면 안 되는 것) / `Toast` (되돌린 사실 통지)
+
 ## 진짜 소스
 
 - 토큰 원본: `_ds_bundle.css` (`styles.css`가 `@import`)

--- a/.design-sync/previews/EmptyState.tsx
+++ b/.design-sync/previews/EmptyState.tsx
@@ -1,0 +1,16 @@
+import { EmptyState } from 're-action-web';
+
+const wrap: React.CSSProperties = { maxWidth: 344, display: 'flex', flexDirection: 'column', gap: 10 };
+
+export const Quiet = () => (
+  <div style={wrap}>
+    <EmptyState>이번 주에 등록된 계획이 없어요. 온보딩에서 주간 계획을 생성하거나, 우측 하단 + 버튼으로 추가해보세요.</EmptyState>
+    <EmptyState>아직 추적 중인 습관이 없어요. 위 <b>+ 습관 추가</b>로 만들어보세요.</EmptyState>
+  </div>
+);
+
+export const Hero = () => (
+  <div style={wrap}>
+    <EmptyState tone="hero" title="오늘 할 일이 없어요">주간 계획에서 블록을 추가해보세요.</EmptyState>
+  </div>
+);

--- a/.design-sync/previews/ErrorBanner.tsx
+++ b/.design-sync/previews/ErrorBanner.tsx
@@ -1,0 +1,25 @@
+import { ErrorBanner, ReButton } from 're-action-web';
+
+const noop = () => {};
+const wrap: React.CSSProperties = { maxWidth: 344, display: 'flex', flexDirection: 'column', gap: 10 };
+
+export const Plain = () => (
+  <div style={wrap}>
+    <ErrorBanner>회복 계획을 저장하지 못했어요. 잠시 후 다시 시도해 주세요.</ErrorBanner>
+    <ErrorBanner>이 시간대는 야간 차단 정책이 있어요.</ErrorBanner>
+  </div>
+);
+
+export const WithAction = () => (
+  <div style={wrap}>
+    <ErrorBanner
+      action={
+        <div style={{ alignSelf: 'flex-start' }}>
+          <ReButton variant="ghost" size="sm" onClick={noop}>다음 단계로 넘어가기</ReButton>
+        </div>
+      }
+    >
+      인터뷰를 이어갈 수 없어요.
+    </ErrorBanner>
+  </div>
+);

--- a/.design-sync/previews/GoalCard.tsx
+++ b/.design-sync/previews/GoalCard.tsx
@@ -1,0 +1,25 @@
+import { GoalCard, IconAction, ReButton } from 're-action-web';
+
+const noop = () => {};
+const list: React.CSSProperties = { maxWidth: 344, display: 'flex', flexDirection: 'column', gap: 8 };
+
+export const Tiers = () => (
+  <div style={list}>
+    <GoalCard title="토익 900점" tier="focus" categoryLabel="학습" deadline="2026-09-30" priorityLevel={1} />
+    <GoalCard title="주 3회 운동" tier="maintain" categoryLabel="건강" priorityLevel={3} />
+    <GoalCard title="기타 배우기" tier="parked" categoryLabel="자기계발" priorityLevel={5} />
+  </div>
+);
+
+export const Expanded = () => (
+  <div style={list}>
+    <GoalCard title="정보처리기사 취득" tier="focus" categoryLabel="자기계발" deadline="2026-08-20" priorityLevel={2} expanded onToggle={noop}>
+      <div style={{ display: 'flex', gap: 6 }}>
+        <IconAction icon={<span>✎</span>} label="수정" onClick={noop} />
+        <IconAction icon={<span>⑂</span>} label="분해" onClick={noop} />
+        <IconAction icon={<span>🗑</span>} label="삭제" tone="danger" onClick={noop} />
+      </div>
+      <ReButton variant="ghost" size="sm" full onClick={noop}>이 목표로 계획 다시 세우기</ReButton>
+    </GoalCard>
+  </div>
+);

--- a/.design-sync/previews/HeroTaskCard.tsx
+++ b/.design-sync/previews/HeroTaskCard.tsx
@@ -1,0 +1,55 @@
+import { HeroTaskCard } from 're-action-web';
+
+const noop = () => {};
+const wrap: React.CSSProperties = { maxWidth: 360 };
+
+export const NextUp = () => (
+  <div style={wrap}>
+    <HeroTaskCard
+      task={{ id: '1', title: '알고리즘 2문제 풀기', status: 'todo', time: '14:00', dur: '60분', whyNow: '오전에 집중이 잘 되는 시간대예요.' }}
+      done={1}
+      total={5}
+      onComplete={noop}
+      onPartial={noop}
+      onFail={noop}
+      onStart={noop}
+      onDetail={noop}
+    />
+  </div>
+);
+
+export const InProgress = () => (
+  <div style={wrap}>
+    <HeroTaskCard
+      task={{ id: '1', title: '정보처리기사 실기 정리', status: 'in_progress', time: '10:00', dur: '120분' }}
+      done={2}
+      total={5}
+      onComplete={noop}
+      onPartial={noop}
+      onFail={noop}
+      onStart={noop}
+      onDetail={noop}
+    />
+  </div>
+);
+
+export const CarriedOver = () => (
+  <div style={wrap}>
+    <HeroTaskCard
+      task={{ id: '1', title: '포트폴리오 초안 쓰기', status: 'todo', time: '13:00', dur: '90분', carryover: true }}
+      done={0}
+      total={4}
+      onComplete={noop}
+      onPartial={noop}
+      onFail={noop}
+      onStart={noop}
+      onDetail={noop}
+    />
+  </div>
+);
+
+export const NothingToday = () => (
+  <div style={wrap}>
+    <HeroTaskCard task={null} done={0} total={0} onComplete={noop} onPartial={noop} onFail={noop} onStart={noop} onDetail={noop} />
+  </div>
+);

--- a/.design-sync/previews/IconAction.tsx
+++ b/.design-sync/previews/IconAction.tsx
@@ -1,0 +1,18 @@
+import { IconAction } from 're-action-web';
+
+const noop = () => {};
+const row: React.CSSProperties = { display: 'flex', gap: 6, maxWidth: 320 };
+
+export const Trio = () => (
+  <div style={row}>
+    <IconAction icon={<span>✎</span>} label="수정" onClick={noop} />
+    <IconAction icon={<span>⑂</span>} label="분해" onClick={noop} />
+    <IconAction icon={<span>🗑</span>} label="삭제" tone="danger" onClick={noop} />
+  </div>
+);
+
+export const Busy = () => (
+  <div style={row}>
+    <IconAction icon={<span>⑂</span>} label="분해 중…" onClick={noop} disabled />
+  </div>
+);

--- a/.design-sync/previews/InboxAction.tsx
+++ b/.design-sync/previews/InboxAction.tsx
@@ -1,0 +1,27 @@
+import { InboxAction } from 're-action-web';
+
+const noop = () => {};
+const row: React.CSSProperties = { display: 'flex', gap: 5, flexWrap: 'wrap', alignItems: 'center', maxWidth: 320 };
+
+export const Tones = () => (
+  <div style={row}>
+    <InboxAction onClick={noop}>할 일로</InboxAction>
+    <InboxAction tone="brand" onClick={noop}>목표로</InboxAction>
+  </div>
+);
+
+export const PerStatus = () => (
+  <div style={{ display: 'flex', flexDirection: 'column', gap: 8, maxWidth: 320 }}>
+    <div style={row}>
+      <InboxAction onClick={noop}>할 일로</InboxAction>
+      <InboxAction tone="brand" onClick={noop}>목표로</InboxAction>
+    </div>
+    <div style={row}>
+      <InboxAction tone="brand" onClick={noop}>열기</InboxAction>
+    </div>
+    <div style={row}>
+      <InboxAction onClick={noop}>목표 보기</InboxAction>
+      <InboxAction onClick={noop}>복원</InboxAction>
+    </div>
+  </div>
+);

--- a/.design-sync/previews/InboxItemCard.tsx
+++ b/.design-sync/previews/InboxItemCard.tsx
@@ -1,0 +1,46 @@
+import { InboxItemCard, InboxAction } from 're-action-web';
+
+const noop = () => {};
+const list: React.CSSProperties = { maxWidth: 344, display: 'flex', flexDirection: 'column', gap: 8 };
+
+export const Captured = () => (
+  <div style={list}>
+    <InboxItemCard
+      text="교수님한테 추천서 부탁드리기"
+      aiCategory="커리어"
+      actions={
+        <>
+          <InboxAction onClick={noop}>할 일로</InboxAction>
+          <InboxAction tone="brand" onClick={noop}>목표로</InboxAction>
+        </>
+      }
+    />
+    <InboxItemCard text="헬스장 6개월 등록 알아보기" aiCategory="건강" actions={<InboxAction onClick={noop}>할 일로</InboxAction>} />
+  </div>
+);
+
+export const Resource = () => (
+  <div style={list}>
+    <InboxItemCard
+      text="토익 파트3 공략법 — 대화 흐름 먼저 잡기"
+      badges={[{ label: '추천 자료', bg: 'var(--brand-soft)', bd: 'var(--coral-200)', fg: 'var(--coral-700)' }]}
+      aiCategory="학습"
+      actions={<InboxAction tone="brand" onClick={noop}>열기</InboxAction>}
+    />
+  </div>
+);
+
+export const Processed = () => (
+  <div style={list}>
+    <InboxItemCard
+      text="헬스장 6개월 등록 알아보기"
+      badges={[{ label: '목표로', bg: 'var(--brand-soft)', bd: 'var(--coral-200)', fg: 'var(--coral-700)' }]}
+      actions={<InboxAction onClick={noop}>목표 보기</InboxAction>}
+    />
+    <InboxItemCard
+      text="작년 노트 정리"
+      badges={[{ label: '보관', bg: 'var(--sand-100)', bd: 'var(--sand-200)', fg: 'var(--text-2)' }]}
+      actions={<InboxAction onClick={noop}>복원</InboxAction>}
+    />
+  </div>
+);

--- a/.design-sync/previews/ProgressSheet.tsx
+++ b/.design-sync/previews/ProgressSheet.tsx
@@ -1,0 +1,23 @@
+import { ProgressSheet } from 're-action-web';
+
+const noop = () => {};
+const stage: React.CSSProperties = {
+  position: 'relative',
+  width: 390,
+  height: 560,
+  background: 'var(--surface-ground)',
+  border: '1px solid var(--sand-200)',
+  borderRadius: 12,
+  overflow: 'hidden',
+};
+
+export const Open = () => (
+  <div style={stage}>
+    <ProgressSheet
+      taskTitle="정보처리기사 실기 기출 정리"
+      onSubmit={noop}
+      onClose={noop}
+      note={<>저장 시 <b>회복 대기</b> 상태로 넘어가요.</>}
+    />
+  </div>
+);

--- a/.design-sync/previews/RecoveryOptionCard.tsx
+++ b/.design-sync/previews/RecoveryOptionCard.tsx
@@ -1,0 +1,54 @@
+import { RecoveryOptionCard } from 're-action-web';
+
+const noop = () => {};
+const list: React.CSSProperties = { maxWidth: 344, display: 'flex', flexDirection: 'column', gap: 8 };
+
+const SMALLER = { bg: 'var(--brand-soft)', bc: 'var(--coral-200)', ac: 'var(--brand)' };
+const REST = { bg: '#E4EDF6', bc: '#B8D0E8', ac: '#3A5C7D' };
+
+export const ProposalSet = () => (
+  <div style={list}>
+    <RecoveryOptionCard
+      title="더 작게 쪼개기"
+      description="10분만 해보기"
+      trigger="다시 막히면"
+      confidence={82}
+      timeLabel="오늘 21:00"
+      recommended
+      selected
+      onSelect={noop}
+      why="지난 3번 중 2번은 시작만 하면 끝까지 갔어요."
+      colors={SMALLER}
+    />
+    <RecoveryOptionCard
+      title="오늘은 쉬기"
+      description="내일 아침으로 옮기기"
+      trigger="피곤하면"
+      confidence={64}
+      timeLabel="내일 09:00"
+      onSelect={noop}
+      why="수요일 밤은 완료율이 낮았어요."
+      colors={REST}
+    />
+    <RecoveryOptionCard title="다시 시도" description="30분 뒤 알림 받기" trigger="자리에 앉으면" timeLabel="오늘 20:30" onSelect={noop} />
+  </div>
+);
+
+export const WhyOpen = () => (
+  <div style={list}>
+    <RecoveryOptionCard
+      title="더 작게 쪼개기"
+      description="10분만 해보기"
+      trigger="다시 막히면"
+      confidence={82}
+      timeLabel="오늘 21:00"
+      recommended
+      selected
+      onSelect={noop}
+      why="지난 3번 중 2번은 시작만 하면 끝까지 갔어요. 시작 문턱을 낮추는 게 가장 잘 통했어요."
+      whyOpen
+      onToggleWhy={noop}
+      colors={SMALLER}
+    />
+  </div>
+);

--- a/.design-sync/previews/ScoreDonut.tsx
+++ b/.design-sync/previews/ScoreDonut.tsx
@@ -1,0 +1,19 @@
+import { ScoreDonut } from 're-action-web';
+
+const row: React.CSSProperties = { display: 'flex', gap: 20, alignItems: 'center', flexWrap: 'wrap' };
+
+export const Scores = () => (
+  <div style={row}>
+    <ScoreDonut score={92} />
+    <ScoreDonut score={72} />
+    <ScoreDonut score={31} />
+  </div>
+);
+
+export const Sizes = () => (
+  <div style={row}>
+    <ScoreDonut score={72} size={72} stroke={8} />
+    <ScoreDonut score={72} size={120} stroke={12} />
+    <ScoreDonut score={72} size={160} stroke={16} />
+  </div>
+);

--- a/.design-sync/previews/SkeletonBlock.tsx
+++ b/.design-sync/previews/SkeletonBlock.tsx
@@ -1,0 +1,16 @@
+import { SkeletonBlock } from 're-action-web';
+
+const wrap: React.CSSProperties = { maxWidth: 344, display: 'flex', flexDirection: 'column', gap: 18 };
+
+export const ListPlaceholder = () => (
+  <div style={wrap}>
+    <SkeletonBlock count={3} height={64} />
+  </div>
+);
+
+export const HeroPlusList = () => (
+  <div style={wrap}>
+    <SkeletonBlock count={1} height={140} radius={24} />
+    <SkeletonBlock count={3} height={64} />
+  </div>
+);

--- a/.design-sync/previews/TaskRow.tsx
+++ b/.design-sync/previews/TaskRow.tsx
@@ -1,0 +1,25 @@
+import { TaskRow } from 're-action-web';
+
+const noop = () => {};
+const list: React.CSSProperties = { maxWidth: 340, display: 'flex', flexDirection: 'column', gap: 2 };
+
+export const AllStates = () => (
+  <div style={list}>
+    <TaskRow task={{ id: '1', title: '토익 LC 파트3', status: 'done', time: '09:00' }} onSelect={noop} onFailedRecover={noop} onPartialRecover={noop} />
+    <TaskRow task={{ id: '2', title: '알고리즘 2문제', status: 'in_progress', time: '14:00' }} onSelect={noop} onFailedRecover={noop} onPartialRecover={noop} />
+    <TaskRow task={{ id: '3', title: '헬스 가기', status: 'partial_done', time: '19:00' }} onSelect={noop} onFailedRecover={noop} onPartialRecover={noop} />
+    <TaskRow task={{ id: '4', title: '정보처리기사 실기', status: 'failed', time: '10:00' }} onSelect={noop} onFailedRecover={noop} onPartialRecover={noop} />
+    <TaskRow task={{ id: '5', title: '독서 30분', status: 'todo', time: '21:00' }} onSelect={noop} onFailedRecover={noop} onPartialRecover={noop} />
+  </div>
+);
+
+export const LongTitle = () => (
+  <div style={list}>
+    <TaskRow
+      task={{ id: '1', title: '정보처리기사 실기 기출 5개년 오답 정리하고 요약본 만들기', status: 'todo', time: '15:30' }}
+      onSelect={noop}
+      onFailedRecover={noop}
+      onPartialRecover={noop}
+    />
+  </div>
+);

--- a/.design-sync/previews/TextField.tsx
+++ b/.design-sync/previews/TextField.tsx
@@ -1,0 +1,11 @@
+import { TextField } from 're-action-web';
+
+const wrap: React.CSSProperties = { maxWidth: 300, display: 'flex', flexDirection: 'column', gap: 12 };
+
+export const States = () => (
+  <div style={wrap}>
+    <TextField label="목표 제목" defaultValue="정보처리기사 필기" />
+    <TextField label="마감" placeholder="YYYY-MM-DD" hint="비워두면 마감 없이 관리해요." />
+    <TextField label="목표 제목" defaultValue="" error="제목을 한 줄 적어주세요." />
+  </div>
+);

--- a/.design-sync/previews/Toast.tsx
+++ b/.design-sync/previews/Toast.tsx
@@ -1,0 +1,25 @@
+import { Toast } from 're-action-web';
+
+const stage: React.CSSProperties = {
+  position: 'relative',
+  width: 340,
+  height: 160,
+  background: 'var(--surface-ground)',
+  border: '1px solid var(--sand-200)',
+  borderRadius: 12,
+  overflow: 'hidden',
+};
+
+const dot = (bg: string) => <span style={{ width: 6, height: 6, background: bg, borderRadius: 9999, flexShrink: 0 }} />;
+
+export const Neutral = () => (
+  <div style={stage}>
+    <Toast icon={dot('var(--success)')}>블록 수정됨 (임시 저장)</Toast>
+  </div>
+);
+
+export const Error = () => (
+  <div style={stage}>
+    <Toast tone="error" icon={dot('#FFFCF6')}>이 시간대는 야간 차단 정책이 있어요</Toast>
+  </div>
+);

--- a/.design-sync/previews/Toggle.tsx
+++ b/.design-sync/previews/Toggle.tsx
@@ -1,0 +1,12 @@
+import { Toggle } from 're-action-web';
+
+const row: React.CSSProperties = { display: 'flex', gap: 16, alignItems: 'center' };
+const noop = () => {};
+
+export const States = () => (
+  <div style={row}>
+    <Toggle on onChange={noop} label="푸시 알림" />
+    <Toggle on={false} onChange={noop} label="푸시 알림" />
+    <Toggle on disabled onChange={noop} label="비활성" />
+  </div>
+);

--- a/.design-sync/previews/WeekGrid.tsx
+++ b/.design-sync/previews/WeekGrid.tsx
@@ -1,0 +1,81 @@
+import { WeekGrid } from 're-action-web';
+
+const shell: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  height: 560,
+  width: 390,
+  background: 'var(--surface-ground)',
+  border: '1px solid var(--sand-200)',
+  borderRadius: 12,
+  overflow: 'hidden',
+};
+
+const study = { bg: '#E4EDF6', bd: '#B8D0E8', fg: '#3A5C7D' };
+const health = { bg: '#E5EFE3', bd: '#B4DFC8', fg: 'var(--success)' };
+const done = { bg: '#E5EFE3', bd: '#B4DFC8', fg: 'var(--success)' };
+const failed = { bg: '#FAE2D8', bd: 'var(--coral-200)', fg: 'var(--danger)' };
+const fixed = { bg: 'var(--sand-100)', bd: 'var(--sand-300)', fg: 'var(--text-3)' };
+
+const WEEK = [
+  { id: '1', col: 0, startMin: 9 * 60, durMin: 90, title: '토익 LC 파트3', subLabel: '09:00·90분', glyph: '✓ ', colors: done },
+  { id: '2', col: 0, startMin: 14 * 60, durMin: 60, title: '알고리즘 2문제', subLabel: '14:00·60분', colors: study },
+  { id: '3', col: 1, startMin: 10 * 60, durMin: 120, title: '정보처리기사 실기', subLabel: '10:00·120분', glyph: '✗ ', colors: failed },
+  { id: '4', col: 2, startMin: 11 * 60, durMin: 90, title: '전공 수업', subLabel: '11:00·90분', colors: fixed, fixed: true },
+  { id: '5', col: 2, startMin: 19 * 60, durMin: 60, title: '헬스', subLabel: '19:00·60분', colors: health },
+  { id: '6', col: 3, startMin: 9 * 60, durMin: 45, title: '토익 RC 파트5', subLabel: '09:00·45분', colors: study },
+  { id: '7', col: 4, startMin: 13 * 60, durMin: 90, title: '포트폴리오 정리', subLabel: '13:00·90분', colors: study },
+];
+
+export const ThisWeek = () => (
+  <div style={shell}>
+    <WeekGrid
+      blocks={WEEK}
+      dayNumbers={[27, 28, 29, 30, 31, 1, 2]}
+      todayCol={2}
+      nowMin={15 * 60 + 30}
+      startHour={8}
+      endHour={22}
+    />
+  </div>
+);
+
+export const WithDraftBackdrop = () => (
+  <div style={shell}>
+    <WeekGrid
+      blocks={[
+        { id: 'd1', col: 1, startMin: 10 * 60, durMin: 60, title: '토익 LC', subLabel: '10:00·60분', colors: study },
+        { id: 'd2', col: 3, startMin: 14 * 60, durMin: 90, title: '실기 대비', subLabel: '14:00·90분', colors: study },
+      ]}
+      backdrop={[
+        { id: 'o1', col: 1, startMin: 11 * 60, durMin: 90, title: '지난 계획', colors: fixed, muted: true },
+        { id: 'o2', col: 4, startMin: 13 * 60, durMin: 60, title: '지난 계획', colors: fixed, muted: true },
+      ]}
+      dayNumbers={[3, 4, 5, 6, 7, 8, 9]}
+      startHour={8}
+      endHour={20}
+    />
+  </div>
+);
+
+export const Wider = () => (
+  <div style={{ ...shell, width: 480 }}>
+    <WeekGrid
+      blocks={WEEK}
+      dayNumbers={[27, 28, 29, 30, 31, 1, 2]}
+      todayCol={2}
+      nowMin={15 * 60 + 30}
+      startHour={8}
+      endHour={20}
+      colWidth={62}
+      hourPx={64}
+      timeWidth={34}
+    />
+  </div>
+);
+
+export const Loading = () => (
+  <div style={shell}>
+    <WeekGrid blocks={[]} dayNumbers={[27, 28, 29, 30, 31, 1, 2]} todayCol={2} startHour={12} endHour={22} loading />
+  </div>
+);

--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+
+export type EmptyStateTone = 'quiet' | 'hero';
+
+export interface EmptyStateProps {
+  /** 한 줄 제목. hero 톤에서만 크게 표시된다. */
+  title?: string;
+  /** 본문. 문자열 대신 노드를 넘겨 <b>·<br/> 을 섞어도 된다. */
+  children: React.ReactNode;
+  /**
+   * quiet — 목록 사이에 끼는 점선 안내 박스(기본).
+   * hero  — 화면 주역 자리가 통째로 비었을 때 쓰는 큰 카드.
+   */
+  tone?: EmptyStateTone;
+  /** 아이콘 등 본문 위에 얹을 것. hero 에서만 의미 있다. */
+  icon?: React.ReactNode;
+}
+
+/**
+ * 정직한 빈 상태. 더미 데이터로 채우지 않고 "지금 없다"를 그대로 말한다.
+ *
+ * 점선 테두리는 "아직 내용이 없다"는 신호로 앱 전체에서 일관되게 쓴다
+ * (AiDraftCard 의 점선 = 미확정 초안과 같은 계열의 의미).
+ */
+export function EmptyState({ title, children, tone = 'quiet', icon }: EmptyStateProps) {
+  if (tone === 'hero') {
+    return (
+      <div
+        style={{
+          background: 'var(--surface-raised)',
+          border: '1px dashed var(--sand-300)',
+          borderRadius: 24,
+          padding: '36px 20px',
+          textAlign: 'center',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: 10,
+        }}
+      >
+        {icon}
+        {title && (
+          <div
+            style={{
+              fontFamily: 'var(--font-display)',
+              fontWeight: 700,
+              fontSize: 22,
+              color: 'var(--text-2)',
+            }}
+          >
+            {title}
+          </div>
+        )}
+        <p style={{ fontSize: 13, color: 'var(--text-3)', margin: 0, lineHeight: 1.55 }}>{children}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      style={{
+        padding: '14px 16px',
+        borderRadius: 12,
+        background: 'var(--surface-raised)',
+        border: '1px dashed var(--sand-200)',
+        fontSize: 12,
+        color: 'var(--text-2)',
+        lineHeight: 1.5,
+      }}
+    >
+      {title && <div style={{ fontWeight: 700, color: 'var(--text-1)', marginBottom: 4 }}>{title}</div>}
+      {children}
+    </div>
+  );
+}

--- a/src/components/ErrorBanner.tsx
+++ b/src/components/ErrorBanner.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+export interface ErrorBannerProps {
+  /** 사용자에게 보여줄 문구. friendlyError() 로 한국어 변환한 값을 넣는다. */
+  children: React.ReactNode;
+  /** 재시도 버튼 등 문구 아래 붙일 액션. */
+  action?: React.ReactNode;
+  /**
+   * 스크린리더에 즉시 알릴지. 사용자 조작 결과로 뜬 에러는 true(기본),
+   * 첫 로드 실패처럼 이미 화면에 있던 것은 false 로 낮춘다.
+   */
+  live?: boolean;
+}
+
+/**
+ * 실패를 숨기지 않고 그대로 보여주는 배너. 조용히 삼키거나 더미로 대체하지 않는다.
+ *
+ * 톤 주의: 문구는 무엇이 안 됐는지 + 다음에 뭘 하면 되는지까지만 쓴다.
+ * 사용자를 탓하는 표현은 쓰지 않는다("잘못 입력하셨어요" ✗).
+ */
+export function ErrorBanner({ children, action, live = true }: ErrorBannerProps) {
+  return (
+    <div
+      role={live ? 'alert' : undefined}
+      style={{
+        background: '#FAE2D8',
+        border: '1px solid var(--coral-200)',
+        color: 'var(--coral-700)',
+        borderRadius: 10,
+        padding: '10px 12px',
+        fontSize: 12,
+        lineHeight: 1.5,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 6,
+      }}
+    >
+      <span>{children}</span>
+      {action}
+    </div>
+  );
+}

--- a/src/components/GoalCard.tsx
+++ b/src/components/GoalCard.tsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import { GOAL_STATUS_META } from '../data';
+import type { GoalStatus } from '../types';
+
+export interface GoalCardProps {
+  title: string;
+  /** focus(집중) / maintain(유지) / parked(보류). 배지 색·라벨이 여기서 정해진다. */
+  tier: GoalStatus;
+  /** "자격증" 같은 사람이 읽는 카테고리 라벨. 내부 enum 값을 그대로 넣지 않는다. */
+  categoryLabel?: string;
+  /** YYYY-MM-DD. 있으면 "~2026-08-30" 으로 붙는다. */
+  deadline?: string | null;
+  priorityLevel?: number | null;
+  /** 펼침 상태 — 테두리가 tier 색으로 바뀐다. */
+  expanded?: boolean;
+  onToggle?: () => void;
+  /** 펼쳤을 때 카드 아래에 붙는 것(수정 폼·액션 버튼 등). */
+  children?: React.ReactNode;
+}
+
+const chip: React.CSSProperties = {
+  height: 'var(--ctrl-xs)',
+  padding: '0 7px',
+  background: 'var(--sand-100)',
+  border: '1px solid var(--sand-200)',
+  borderRadius: 9999,
+  fontSize: 10,
+  color: 'var(--text-2)',
+  display: 'inline-flex',
+  alignItems: 'center',
+};
+
+/**
+ * 목표 하나. 목표 관리 화면에서 tier 별로 묶여 나온다.
+ *
+ * tier 가 이 제품의 핵심 제약이다 — 집중은 최대 3개, 유지는 5개. 한 번에
+ * 좇을 수 있는 목표 수를 강제로 좁혀야 계획이 지켜지기 때문이고, 그래서
+ * tier 배지가 제목보다 먼저 온다.
+ *
+ * 펼치기 전에는 읽을 것만 보여주고, 수정·분해·삭제 같은 건 children 으로
+ * 넘겨 펼쳤을 때만 나오게 한다.
+ */
+export function GoalCard({
+  title,
+  tier,
+  categoryLabel,
+  deadline,
+  priorityLevel,
+  expanded = false,
+  onToggle,
+  children,
+}: GoalCardProps) {
+  const m = GOAL_STATUS_META[tier];
+  return (
+    <div
+      style={{
+        background: 'var(--surface-raised)',
+        border: `1.5px solid ${expanded ? m.border : 'var(--sand-200)'}`,
+        borderRadius: 14,
+        padding: 12,
+      }}
+    >
+      <div
+        onClick={onToggle}
+        style={{ display: 'flex', alignItems: 'flex-start', gap: 10, cursor: onToggle ? 'pointer' : 'default' }}
+      >
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 5, flexWrap: 'wrap' }}>
+            <span
+              style={{
+                height: 'var(--ctrl-xs)',
+                padding: '0 8px',
+                borderRadius: 9999,
+                background: m.bg,
+                border: `1px solid ${m.border}`,
+                fontSize: 10,
+                fontWeight: 700,
+                color: m.color,
+                fontFamily: 'var(--font-mono)',
+                display: 'inline-flex',
+                alignItems: 'center',
+              }}
+            >
+              {m.label}
+            </span>
+            {categoryLabel && <span style={chip}>{categoryLabel}</span>}
+          </div>
+          <div style={{ fontWeight: 700, fontSize: 14, color: 'var(--text-1)', letterSpacing: '-0.01em' }}>{title}</div>
+          <div style={{ display: 'flex', gap: 5, flexWrap: 'wrap', marginTop: 4 }}>
+            {deadline && (
+              <span className="tnum" style={chip}>
+                ~{deadline}
+              </span>
+            )}
+            {priorityLevel != null && (
+              <span className="tnum" style={{ ...chip, color: 'var(--text-3)' }}>
+                우선순위 {priorityLevel}
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {expanded && children && (
+        <div
+          onClick={(e) => e.stopPropagation()}
+          style={{
+            marginTop: 10,
+            paddingTop: 10,
+            borderTop: '1px solid var(--sand-200)',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 8,
+          }}
+        >
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/HeroTaskCard.tsx
+++ b/src/components/HeroTaskCard.tsx
@@ -1,0 +1,227 @@
+import React from 'react';
+import { CaretRight, Check } from '@phosphor-icons/react';
+import type { Task } from '../types';
+import { EmptyState } from './EmptyState';
+
+export interface HeroTaskCardProps {
+  /** null 이면 "오늘 할 일이 없어요" 빈 상태로 대체된다. */
+  task: Task | null;
+  /** 오늘 완료 개수 / 전체 개수 — 카드 우상단 진척 표시용. */
+  done: number;
+  total: number;
+  onComplete: () => void;
+  onPartial: () => void;
+  onFail: () => void;
+  onStart: (id: string) => void;
+  /** whyNow·firstStep 이 있을 때만 노출되는 "왜 지금?" 링크. */
+  onDetail: () => void;
+}
+
+/**
+ * 오늘 화면의 주인공 카드. 지금 할 일 딱 하나만 크게 보여준다.
+ *
+ * 설계 의도: 목록을 훑게 하지 않고 "다음 한 개"로 시선을 좁힌다. 그래서
+ * 화면에 이 카드가 하나뿐이고, 진행 전에는 CTA 도 [시작하기] 하나뿐이다.
+ *
+ * 진행 중으로 바뀌면 버튼이 셋으로 갈라진다 — 완료 / ◑ 일부만 / ✗ 잘 안됨.
+ * 이 세 갈래가 앱 전체의 상태 어휘이고, 어느 쪽을 눌러도 실패로 끝나지 않고
+ * 회복 흐름으로 이어진다.
+ */
+export function HeroTaskCard({
+  task,
+  done,
+  total,
+  onComplete,
+  onPartial,
+  onFail,
+  onStart,
+  onDetail,
+}: HeroTaskCardProps) {
+  if (!task) {
+    return (
+      <EmptyState tone="hero" title="오늘 할 일이 없어요">
+        주간 계획에서 블록을 추가해보세요.
+      </EmptyState>
+    );
+  }
+
+  const isActive = task.status === 'in_progress';
+  const pct = total > 0 ? Math.round((done / total) * 100) : 0;
+
+  return (
+    <div
+      style={{
+        background: 'var(--surface-raised)',
+        border: '1.5px solid var(--coral-200)',
+        borderRadius: 24,
+        padding: '24px 22px',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 18,
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between' }}>
+        <span
+          style={{
+            fontSize: 10,
+            fontWeight: 700,
+            letterSpacing: '0.1em',
+            color: 'var(--coral-700)',
+            fontFamily: 'var(--font-mono)',
+          }}
+        >
+          {isActive ? '진행 중' : '다음 할 일'}
+        </span>
+        <span className="tnum" style={{ fontSize: 11, color: 'var(--text-3)', fontFamily: 'var(--font-mono)' }}>
+          {done} / {total} · {pct}%
+        </span>
+      </div>
+
+      <div>
+        <h2
+          style={{
+            fontFamily: 'var(--font-display)',
+            fontWeight: 800,
+            fontSize: 26,
+            letterSpacing: '-0.02em',
+            lineHeight: 1.2,
+            margin: 0,
+            color: 'var(--text-1)',
+          }}
+        >
+          {task.title}
+        </h2>
+        <div style={{ display: 'flex', gap: 6, marginTop: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+          {task.carryover && (
+            <span
+              style={{
+                height: 'var(--ctrl-xs)',
+                padding: '0 6px',
+                background: '#FBEEDA',
+                border: '1px solid #F2D29A',
+                borderRadius: 9999,
+                fontSize: 10,
+                color: 'var(--warning)',
+                fontWeight: 600,
+                display: 'inline-flex',
+                alignItems: 'center',
+              }}
+            >
+              ↩ 이월
+            </span>
+          )}
+          {task.time && (
+            <span className="tnum" style={{ fontSize: 12, color: 'var(--text-2)' }}>
+              {task.time}
+              {task.dur ? ` · ${task.dur}` : ''}
+            </span>
+          )}
+        </div>
+        {(task.whyNow || task.firstStep) && (
+          <button
+            onClick={onDetail}
+            style={{
+              marginTop: 10,
+              alignSelf: 'flex-start',
+              background: 'transparent',
+              border: 'none',
+              padding: 0,
+              color: 'var(--coral-700)',
+              fontSize: 12,
+              fontWeight: 600,
+              cursor: 'pointer',
+              fontFamily: 'inherit',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 3,
+            }}
+          >
+            왜 지금? · 자세히 <CaretRight size={11} />
+          </button>
+        )}
+      </div>
+
+      {isActive ? (
+        <div style={{ display: 'flex', gap: 8 }}>
+          <button
+            onClick={onComplete}
+            style={{
+              flex: 2,
+              height: 52,
+              borderRadius: 14,
+              border: 'none',
+              background: 'var(--brand)',
+              color: '#FFFCF6',
+              fontWeight: 700,
+              fontSize: 15,
+              fontFamily: 'inherit',
+              cursor: 'pointer',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 6,
+            }}
+          >
+            <Check size={16} weight="bold" /> 완료
+          </button>
+          <button
+            onClick={onPartial}
+            aria-label="일부만 함"
+            style={{
+              width: 52,
+              height: 52,
+              borderRadius: 14,
+              border: '1px solid var(--sand-200)',
+              background: 'var(--surface-ground)',
+              color: 'var(--text-2)',
+              fontSize: 16,
+              fontFamily: 'inherit',
+              cursor: 'pointer',
+            }}
+          >
+            ◑
+          </button>
+          <button
+            onClick={onFail}
+            aria-label="잘 안됨"
+            style={{
+              width: 52,
+              height: 52,
+              borderRadius: 14,
+              border: '1px solid var(--coral-200)',
+              background: '#FAE2D8',
+              color: 'var(--danger)',
+              fontSize: 16,
+              fontFamily: 'inherit',
+              cursor: 'pointer',
+            }}
+          >
+            ✗
+          </button>
+        </div>
+      ) : (
+        <button
+          onClick={() => onStart(task.id)}
+          style={{
+            width: '100%',
+            height: 52,
+            borderRadius: 14,
+            border: 'none',
+            background: 'var(--text-1)',
+            color: '#FAF6EE',
+            fontWeight: 700,
+            fontSize: 15,
+            fontFamily: 'inherit',
+            cursor: 'pointer',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 6,
+          }}
+        >
+          시작하기 <CaretRight size={14} />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/IconAction.tsx
+++ b/src/components/IconAction.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+export interface IconActionProps {
+  icon: React.ReactNode;
+  label: string;
+  onClick: () => void;
+  /** danger 는 삭제처럼 되돌리기 어려운 것에만. */
+  tone?: 'default' | 'danger';
+  disabled?: boolean;
+}
+
+/**
+ * 카드 안에 가로로 늘어놓는 작은 액션 버튼. 셋 정도까지가 한계다.
+ *
+ * danger 를 줘도 곧바로 실행하지 말고, 한 번 더 확인받는 단계를 호출하는 쪽에서 둔다.
+ */
+export function IconAction({ icon, label, onClick, tone = 'default', disabled = false }: IconActionProps) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      style={{
+        flex: 1,
+        height: 34,
+        borderRadius: 10,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 5,
+        border: `1px solid ${tone === 'danger' ? 'var(--coral-200)' : 'var(--sand-200)'}`,
+        background: 'var(--surface-ground)',
+        color: tone === 'danger' ? 'var(--danger)' : 'var(--text-2)',
+        fontWeight: 600,
+        fontSize: 11,
+        cursor: disabled ? 'wait' : 'pointer',
+        fontFamily: 'inherit',
+        opacity: disabled ? 0.6 : 1,
+      }}
+    >
+      {icon} {label}
+    </button>
+  );
+}

--- a/src/components/InboxItemCard.tsx
+++ b/src/components/InboxItemCard.tsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import { Sparkle } from '@phosphor-icons/react';
+
+export interface InboxBadge {
+  label: string;
+  icon?: React.ReactNode;
+  bg: string;
+  bd: string;
+  fg: string;
+}
+
+export interface InboxItemCardProps {
+  /** 사용자가 적은 원문 한 줄. 요약하거나 다듬지 않고 그대로 보여준다. */
+  text: string;
+  /** 상태·종류 배지. 자명한 상태(할 일 탭의 '분류됨')는 넘기지 않는다. */
+  badges?: InboxBadge[];
+  /** AI 가 추측한 카테고리 라벨. 있으면 ✨ 배지로 붙는다. */
+  aiCategory?: string;
+  /** 우측 정렬 액션 버튼들. */
+  actions?: React.ReactNode;
+}
+
+/**
+ * 인박스 한 항목. 머리에 떠오른 걸 일단 던져놓는 곳이라, 카드가 판단을 강요하지 않는다.
+ *
+ * 원문은 손대지 않고 그대로 보여준다 — AI 가 추측한 분류는 배지로만 옆에 붙여서,
+ * 사용자가 그 추측을 그냥 받아들일지 무시할지 고르게 한다.
+ */
+export function InboxItemCard({ text, badges = [], aiCategory, actions }: InboxItemCardProps) {
+  return (
+    <div
+      style={{
+        background: 'var(--surface-raised)',
+        border: '1px solid var(--sand-200)',
+        borderRadius: 14,
+        padding: 12,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 8,
+      }}
+    >
+      <div style={{ fontSize: 13, color: 'var(--text-1)', lineHeight: 1.5 }}>{text}</div>
+      <div style={{ display: 'flex', gap: 5, flexWrap: 'wrap', alignItems: 'center' }}>
+        {badges.map((b, i) => (
+          <span
+            key={i}
+            style={{
+              height: 'var(--ctrl-xs)',
+              padding: '0 8px',
+              borderRadius: 9999,
+              background: b.bg,
+              border: `1px solid ${b.bd}`,
+              fontSize: 10,
+              fontWeight: 700,
+              color: b.fg,
+              fontFamily: 'var(--font-mono)',
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 4,
+            }}
+          >
+            {b.icon}
+            {b.label}
+          </span>
+        ))}
+        {aiCategory && (
+          <span
+            style={{
+              height: 'var(--ctrl-xs)',
+              padding: '0 8px',
+              borderRadius: 9999,
+              background: 'var(--sand-100)',
+              border: '1px solid var(--sand-200)',
+              fontSize: 10,
+              color: 'var(--text-2)',
+              fontWeight: 500,
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 4,
+            }}
+          >
+            <Sparkle size={9} weight="fill" /> {aiCategory}
+          </span>
+        )}
+        <div style={{ flex: 1 }} />
+        {actions}
+      </div>
+    </div>
+  );
+}
+
+export interface InboxActionProps {
+  children: React.ReactNode;
+  onClick: () => void;
+  icon?: React.ReactNode;
+  /** brand 는 주 행동(목표로·열기) 하나에만. 나머지는 quiet. */
+  tone?: 'quiet' | 'brand';
+}
+
+/** 인박스 카드 안의 작은 액션 버튼. 카드마다 강조는 최대 하나만 준다. */
+export function InboxAction({ children, onClick, icon, tone = 'quiet' }: InboxActionProps) {
+  const brand = tone === 'brand';
+  return (
+    <button
+      onClick={onClick}
+      style={{
+        height: 26,
+        padding: '0 10px',
+        borderRadius: 9999,
+        border: `1px solid ${brand ? 'var(--coral-200)' : 'var(--sand-200)'}`,
+        background: brand ? 'var(--brand-soft)' : 'var(--surface-raised)',
+        color: brand ? 'var(--coral-700)' : 'var(--text-2)',
+        fontSize: 11,
+        fontWeight: 600,
+        cursor: 'pointer',
+        fontFamily: 'inherit',
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 4,
+      }}
+    >
+      {icon}
+      {children}
+    </button>
+  );
+}

--- a/src/components/ProgressSheet.tsx
+++ b/src/components/ProgressSheet.tsx
@@ -1,0 +1,162 @@
+import React, { useState } from 'react';
+
+export interface ProgressSheetProps {
+  /** 어떤 할 일에 대한 건지 — 시트 안에서 다시 확인시켜 준다. */
+  taskTitle: string;
+  /** 처음 잡아줄 값(0~100). 기본 50. */
+  initial?: number;
+  onSubmit: (pct: number) => void;
+  onClose: () => void;
+  /** 저장하면 무슨 일이 생기는지 미리 알려주는 안내. */
+  note?: React.ReactNode;
+  submitLabel?: string;
+}
+
+const PRESETS = [0, 25, 50, 75, 100];
+
+/**
+ * "일부만 했어요"를 숫자로 받는 바텀시트.
+ *
+ * 이 시트가 존재하는 이유가 제품의 핵심이다 — 완료/실패 이분법이면 80%를 한 날도
+ * 실패로 기록되고, 사용자는 자기가 계속 실패한다고 믿게 된다. 중간을 기록할 수
+ * 있어야 다음 회복 제안도 "남은 20%"에서 시작할 수 있다.
+ *
+ * 그래서 기본값을 0 이 아니라 50 에 둔다. 0 에서 올리게 하면 아무것도 안 한 것에서
+ * 출발하는 셈이라 심리적으로 다르다.
+ */
+export function ProgressSheet({
+  taskTitle,
+  initial = 50,
+  onSubmit,
+  onClose,
+  note,
+  submitLabel = '저장하기',
+}: ProgressSheetProps) {
+  const [pct, setPct] = useState(initial);
+
+  return (
+    <div
+      onClick={onClose}
+      style={{
+        position: 'absolute',
+        inset: 0,
+        background: 'rgba(26,23,20,.45)',
+        zIndex: 40,
+        display: 'flex',
+        alignItems: 'flex-end',
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          background: 'var(--surface-raised)',
+          width: '100%',
+          borderRadius: '22px 22px 0 0',
+          padding: '10px 20px 44px',
+          boxShadow: 'var(--shadow-xl)',
+        }}
+      >
+        <div style={{ width: 36, height: 4, borderRadius: 9999, background: 'var(--sand-300)', margin: '0 auto 18px' }} />
+        <div style={{ fontSize: 17, fontWeight: 600, marginBottom: 4 }}>오늘은 얼마나 했어요?</div>
+        <p style={{ fontSize: 12, color: 'var(--text-3)', marginBottom: 18 }}>{taskTitle}</p>
+
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 12 }}>
+          <span
+            style={{
+              fontSize: 11,
+              color: 'var(--text-3)',
+              letterSpacing: '0.08em',
+              textTransform: 'uppercase',
+              fontFamily: 'var(--font-mono)',
+            }}
+          >
+            진척
+          </span>
+          <span
+            className="tnum"
+            style={{ fontSize: 30, fontWeight: 800, color: 'var(--coral-700)', letterSpacing: '-0.02em' }}
+          >
+            {pct}
+            <span style={{ fontSize: 16, fontWeight: 600 }}>%</span>
+          </span>
+        </div>
+
+        <div style={{ position: 'relative', height: 8, background: 'var(--sand-200)', borderRadius: 9999, marginBottom: 8 }}>
+          <div
+            style={{ position: 'absolute', left: 0, top: 0, bottom: 0, width: `${pct}%`, background: 'var(--brand)', borderRadius: 9999 }}
+          />
+          <div
+            style={{
+              position: 'absolute',
+              left: `${pct}%`,
+              top: '50%',
+              transform: 'translate(-50%,-50%)',
+              width: 24,
+              height: 24,
+              borderRadius: 9999,
+              background: '#FFFCF6',
+              border: '2px solid var(--brand)',
+              boxShadow: 'var(--shadow-md)',
+            }}
+          />
+        </div>
+
+        <div style={{ display: 'flex', justifyContent: 'space-between', padding: '0 2px', marginBottom: 18 }}>
+          {PRESETS.map((t) => (
+            <button
+              key={t}
+              onClick={() => setPct(t)}
+              className="tnum"
+              style={{
+                background: 'transparent',
+                border: 'none',
+                fontSize: 12,
+                cursor: 'pointer',
+                padding: '2px 4px',
+                fontFamily: 'inherit',
+                color: pct === t ? 'var(--coral-700)' : 'var(--text-3)',
+                fontWeight: pct === t ? 600 : 500,
+              }}
+            >
+              {t}
+            </button>
+          ))}
+        </div>
+
+        {note && (
+          <div
+            style={{
+              background: 'var(--coral-50)',
+              borderRadius: 10,
+              padding: '8px 10px',
+              fontSize: 11,
+              color: 'var(--coral-700)',
+              marginBottom: 14,
+              lineHeight: 1.5,
+            }}
+          >
+            {note}
+          </div>
+        )}
+
+        <button
+          onClick={() => onSubmit(pct)}
+          style={{
+            width: '100%',
+            height: 44,
+            borderRadius: 12,
+            border: 'none',
+            background: 'var(--brand)',
+            color: '#FFFCF6',
+            fontWeight: 700,
+            fontSize: 14,
+            fontFamily: 'inherit',
+            cursor: 'pointer',
+          }}
+        >
+          {submitLabel}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/RecoveryOptionCard.tsx
+++ b/src/components/RecoveryOptionCard.tsx
@@ -1,0 +1,174 @@
+import React from 'react';
+import { Check, Info } from '@phosphor-icons/react';
+
+export interface RecoveryOptionCardProps {
+  title: string;
+  /** if-then 의 then 쪽. "10분만 해보기" 처럼 행동으로 쓴다. */
+  description?: string;
+  /** if-then 의 if 쪽. "다시 막히면" 처럼 조건으로 쓴다. 앞에 "만약"이 자동으로 붙는다. */
+  trigger?: string;
+  /** 예상 성공률(0~100). 0 이면 표시하지 않는다 — 근거 없는 숫자를 지어내지 않는다. */
+  confidence?: number;
+  /** "오늘 21:00 · 20분" 같은 시점 요약. */
+  timeLabel?: string;
+  /** 첫 번째(=추천) 항목에만 준다. */
+  recommended?: boolean;
+  selected?: boolean;
+  onSelect: () => void;
+  /** 이 제안을 왜 골랐는지. 있으면 [왜?] 버튼이 생긴다. */
+  why?: string;
+  whyOpen?: boolean;
+  onToggleWhy?: () => void;
+  /** 선택 시 쓰는 강조색. 제안 묶음(더 작게/쉬기/다시)별로 다르다. */
+  colors?: { bg: string; bc: string; ac: string };
+}
+
+const DEFAULT_COLORS = { bg: 'var(--brand-soft)', bc: 'var(--coral-200)', ac: 'var(--brand)' };
+
+/**
+ * 막혔을 때 내미는 회복 제안 하나.
+ *
+ * 전부 점선 테두리다 — AI 초안이고 사용자가 고르기 전엔 아무것도 확정되지 않는다.
+ * 고른 것만 실선처럼 굵어진다.
+ *
+ * if-then 형식을 쓰는 이유: "만약 [막히면], [10분만]" 처럼 조건과 행동을 미리 묶어두면
+ * 그 순간 판단할 필요가 없어진다. 그래서 trigger 는 가능하면 채워서 넘긴다.
+ *
+ * 성공률은 없으면 없는 대로 둔다. 0 을 넘기면 아예 렌더하지 않는다.
+ */
+export function RecoveryOptionCard({
+  title,
+  description,
+  trigger,
+  confidence = 0,
+  timeLabel,
+  recommended = false,
+  selected = false,
+  onSelect,
+  why,
+  whyOpen = false,
+  onToggleWhy,
+  colors = DEFAULT_COLORS,
+}: RecoveryOptionCardProps) {
+  return (
+    <div
+      onClick={onSelect}
+      style={{
+        borderRadius: 14,
+        border: `${selected ? '1.5px' : '1px'} dashed ${selected ? colors.bc : 'var(--sand-300)'}`,
+        background: selected ? colors.bg : 'var(--surface-raised)',
+        cursor: 'pointer',
+        transition: 'all 160ms',
+        padding: '12px 14px',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: whyOpen ? 8 : 0 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, flex: 1, minWidth: 0 }}>
+          <div
+            style={{
+              width: 20,
+              height: 20,
+              borderRadius: 9999,
+              flexShrink: 0,
+              border: `1.5px solid ${selected ? colors.ac : 'var(--sand-300)'}`,
+              background: selected ? colors.ac : 'transparent',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            {selected && <Check size={10} color="#FFFCF6" />}
+          </div>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ fontSize: 13, fontWeight: 700, color: 'var(--text-1)', letterSpacing: '-0.01em' }}>{title}</div>
+            {description && (
+              <div style={{ fontSize: 11, color: 'var(--text-2)', marginTop: 3, lineHeight: 1.45 }}>
+                {trigger && (
+                  <>
+                    <span style={{ color: 'var(--coral-700)', fontWeight: 600 }}>만약 {trigger},</span>{' '}
+                  </>
+                )}
+                {description}
+              </div>
+            )}
+            <div style={{ display: 'flex', gap: 8, marginTop: 5, alignItems: 'center', flexWrap: 'wrap' }}>
+              {recommended && (
+                <span
+                  style={{
+                    height: 'var(--ctrl-xs)',
+                    padding: '0 6px',
+                    background: colors.bg,
+                    border: `1px solid ${colors.bc}`,
+                    borderRadius: 9999,
+                    fontSize: 9,
+                    fontWeight: 700,
+                    color: 'var(--coral-700)',
+                    fontFamily: 'var(--font-mono)',
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    letterSpacing: '0.04em',
+                  }}
+                >
+                  추천 ✓
+                </span>
+              )}
+              {confidence > 0 && (
+                <span
+                  className="tnum"
+                  style={{
+                    fontSize: 10,
+                    fontFamily: 'var(--font-mono)',
+                    fontWeight: 600,
+                    color: confidence > 80 ? 'var(--success)' : confidence > 65 ? 'var(--warning)' : 'var(--text-3)',
+                  }}
+                >
+                  성공률 {confidence}%
+                </span>
+              )}
+              {timeLabel && <span style={{ fontSize: 11, color: 'var(--text-3)' }}>{timeLabel}</span>}
+            </div>
+          </div>
+        </div>
+        {why && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onToggleWhy?.();
+            }}
+            style={{
+              flexShrink: 0,
+              background: 'transparent',
+              border: 'none',
+              fontSize: 11,
+              color: 'var(--coral-700)',
+              fontWeight: 600,
+              cursor: 'pointer',
+              fontFamily: 'inherit',
+              padding: '0 0 0 8px',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 3,
+            }}
+          >
+            <Info size={12} /> 왜?
+          </button>
+        )}
+      </div>
+      {whyOpen && why && (
+        <div
+          style={{
+            marginTop: 6,
+            padding: '8px 10px',
+            background: 'var(--brand-soft)',
+            borderRadius: 8,
+            fontSize: 11,
+            color: 'var(--coral-700)',
+            lineHeight: 1.5,
+          }}
+        >
+          {why}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ScoreDonut.tsx
+++ b/src/components/ScoreDonut.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+
+export interface ScoreDonutProps {
+  /** 0~100. 주간 실행 점수. */
+  score: number;
+  size?: number;
+  stroke?: number;
+  /** 숫자 아래 단위 문구. */
+  caption?: string;
+}
+
+/**
+ * 주간 리뷰 상단의 점수 도넛.
+ *
+ * 점수는 등급이 아니라 이번 주가 어땠는지의 요약이다. 그래서 색을 점수에 따라
+ * 바꾸지 않는다 — 낮은 점수를 빨갛게 칠하면 리뷰 화면이 성적표가 되고,
+ * 그 순간 사용자는 앱을 안 열게 된다. 늘 같은 코랄로 채운다.
+ */
+export function ScoreDonut({ score, size = 120, stroke = 12, caption = '/ 100' }: ScoreDonutProps) {
+  const r = (size - stroke) / 2;
+  const c = 2 * Math.PI * r;
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox={`0 0 ${size} ${size}`}
+      style={{ flexShrink: 0 }}
+      role="img"
+      aria-label={`이번 주 점수 ${score}점`}
+    >
+      <circle cx={size / 2} cy={size / 2} r={r} stroke="var(--sand-200)" strokeWidth={stroke} fill="none" />
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={r}
+        stroke="var(--brand)"
+        strokeWidth={stroke}
+        fill="none"
+        strokeLinecap="round"
+        strokeDasharray={c}
+        strokeDashoffset={c * (1 - score / 100)}
+        transform={`rotate(-90 ${size / 2} ${size / 2})`}
+        style={{ transition: 'stroke-dashoffset 800ms ease-out' }}
+      />
+      <text
+        x={size / 2}
+        y={size / 2 - 3}
+        textAnchor="middle"
+        fontSize={size * 0.25}
+        fontWeight="800"
+        fill="var(--text-1)"
+        fontFamily="Pretendard Variable"
+        style={{ letterSpacing: '-0.04em', fontVariantNumeric: 'tabular-nums' }}
+      >
+        {score}
+      </text>
+      <text
+        x={size / 2}
+        y={size / 2 + 15}
+        textAnchor="middle"
+        fontSize="10"
+        fill="var(--text-3)"
+        fontFamily="Pretendard Variable"
+        letterSpacing="0.06em"
+      >
+        {caption}
+      </text>
+    </svg>
+  );
+}

--- a/src/components/SectionHeader.tsx
+++ b/src/components/SectionHeader.tsx
@@ -1,30 +1,46 @@
 import React from 'react';
 
-interface SectionHeaderProps {
+export interface SectionHeaderProps {
   children: React.ReactNode;
+  /** 우측 끝에 붙는 것 — "전체 보기" 링크나 개수 배지. */
   action?: React.ReactNode;
+  /** 라벨 앞 아이콘. */
+  icon?: React.ReactNode;
+  /** danger 는 계정 삭제처럼 되돌릴 수 없는 구역에만. */
+  tone?: 'default' | 'danger';
 }
 
-export function SectionHeader({ children, action }: SectionHeaderProps) {
+/**
+ * 목록·구역 위에 붙는 작은 라벨. 화면 안에서 위계를 나누는 가장 약한 단계다.
+ *
+ * 크고 굵은 제목 대신 작고 넓은 자간의 대문자를 쓴다 — 구역 이름이 내용보다
+ * 눈에 띄면 안 되기 때문. 강조가 필요하면 여기가 아니라 내용 쪽을 키운다.
+ */
+export function SectionHeader({ children, action, icon, tone = 'default' }: SectionHeaderProps) {
   return (
     <div
       style={{
         display: 'flex',
-        alignItems: 'baseline',
+        alignItems: 'center',
         justifyContent: 'space-between',
+        gap: 5,
         padding: '0 4px',
         marginBottom: 10,
       }}
     >
       <span
         style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 5,
           fontSize: 12,
           fontWeight: 600,
           letterSpacing: '0.08em',
           textTransform: 'uppercase',
-          color: 'var(--text-3)',
+          color: tone === 'danger' ? 'var(--danger)' : 'var(--text-3)',
         }}
       >
+        {icon}
         {children}
       </span>
       {action}

--- a/src/components/SkeletonBlock.tsx
+++ b/src/components/SkeletonBlock.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+export interface SkeletonBlockProps {
+  /** 자리 개수. */
+  count?: number;
+  /** 각 자리의 높이(px). */
+  height?: number;
+  /** 모서리 반경(px). */
+  radius?: number;
+  /** 자리 사이 간격(px). */
+  gap?: number;
+}
+
+/**
+ * 첫 fetch 가 끝날 때까지 자리를 잡아두는 placeholder.
+ *
+ * 이게 있어야 "더미 → 실데이터" 깜빡임 없이 빈 화면을 정직하게 넘길 수 있다.
+ * 애니메이션은 쓰지 않는다 — 전역 @keyframes 를 추가하지 않기로 한 결정에 따라
+ * 정적 muted 박스로만 표현한다.
+ */
+export function SkeletonBlock({ count = 3, height = 64, radius = 12, gap = 8 }: SkeletonBlockProps) {
+  return (
+    <div aria-hidden style={{ display: 'flex', flexDirection: 'column', gap }}>
+      {Array.from({ length: count }, (_, i) => (
+        <div
+          key={i}
+          style={{
+            height,
+            borderRadius: radius,
+            border: '1px solid var(--sand-200)',
+            background: i % 2 === 0 ? 'var(--surface-raised)' : 'var(--sand-100)',
+            opacity: 0.6,
+          }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/TaskRow.tsx
+++ b/src/components/TaskRow.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { Check } from '@phosphor-icons/react';
+import type { Task } from '../types';
+
+export interface TaskRowProps {
+  task: Task;
+  /** todo 를 눌렀을 때 — 주역 카드로 올린다(시작은 그쪽 CTA 에서). */
+  onSelect: () => void;
+  /** failed 를 눌렀을 때 — 회복 제안으로 보낸다. */
+  onFailedRecover: () => void;
+  /** partial_done / recovery_pending 을 눌렀을 때 — 회복 제안으로 보낸다. */
+  onPartialRecover: () => void;
+}
+
+/**
+ * 오늘 목록의 한 줄. 주역 카드 아래에 나머지 할 일을 얇게 늘어놓는다.
+ *
+ * 상태에 따라 누를 때 가는 곳이 다르다:
+ *   done       → 아무 일도 없음(이미 끝난 것을 되돌리게 만들지 않는다)
+ *   failed     → 회복 제안
+ *   일부만      → 회복 제안
+ *   todo       → 주역 카드로 승격
+ *
+ * 막힌 항목을 눌렀을 때 회복으로 가는 게 핵심이다. 실패한 줄이 그냥
+ * 붉게 남아 있기만 하면 사용자는 그걸 자기 실패 기록으로 읽는다.
+ */
+export function TaskRow({ task, onSelect, onFailedRecover, onPartialRecover }: TaskRowProps) {
+  const done = task.status === 'done';
+  const failed = task.status === 'failed';
+  const partial = task.status === 'partial_done' || task.status === 'recovery_pending';
+  const inProgress = task.status === 'in_progress';
+  const onClick = done ? undefined : failed ? onFailedRecover : partial ? onPartialRecover : onSelect;
+
+  return (
+    <button
+      onClick={onClick}
+      disabled={done}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        width: '100%',
+        padding: '10px 14px',
+        borderRadius: 12,
+        border: 'none',
+        background: 'transparent',
+        cursor: done ? 'default' : 'pointer',
+        fontFamily: 'inherit',
+        textAlign: 'left',
+      }}
+    >
+      <span
+        style={{
+          width: 18,
+          height: 18,
+          borderRadius: 9999,
+          flexShrink: 0,
+          border: done
+            ? 'none'
+            : `1.5px solid ${failed ? 'var(--danger)' : inProgress || partial ? 'var(--brand)' : 'var(--sand-300)'}`,
+          background: done ? 'var(--success)' : 'transparent',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        {done && <Check size={11} weight="bold" color="#FFFCF6" />}
+        {failed && <span style={{ fontSize: 11, color: 'var(--danger)', fontWeight: 700 }}>✗</span>}
+        {(partial || inProgress) && (
+          <span style={{ width: 8, height: 8, borderRadius: 9999, background: 'var(--brand)' }} />
+        )}
+      </span>
+      <span
+        style={{
+          flex: 1,
+          fontSize: 14,
+          color: done ? 'var(--text-3)' : failed ? 'var(--danger)' : 'var(--text-1)',
+          textDecoration: done ? 'line-through' : 'none',
+          whiteSpace: 'nowrap',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          fontWeight: partial ? 600 : 500,
+        }}
+      >
+        {task.title}
+      </span>
+      {task.time && (
+        <span className="tnum" style={{ fontSize: 11, color: 'var(--text-4)', flexShrink: 0 }}>
+          {task.time}
+        </span>
+      )}
+    </button>
+  );
+}

--- a/src/components/TextField.tsx
+++ b/src/components/TextField.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+
+export interface TextFieldProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'> {
+  /** 입력 위에 붙는 작은 라벨. */
+  label?: string;
+  /** 입력 아래 안내. error 가 있으면 그쪽이 우선한다. */
+  hint?: string;
+  /** 있으면 테두리가 danger 색으로 바뀌고 문구가 아래에 붙는다. */
+  error?: string | null;
+  /** 가로를 꽉 채울지. 기본 true. */
+  full?: boolean;
+}
+
+/** 폼 요소 공통 면 — TextField 와 select 가 같은 모양이 되도록 공유한다. */
+export const fieldSurface: React.CSSProperties = {
+  padding: '9px 11px',
+  borderRadius: 9,
+  border: '1px solid var(--sand-200)',
+  background: 'var(--surface-raised)',
+  fontSize: 12,
+  fontFamily: 'inherit',
+  outline: 'none',
+  color: 'var(--text-1)',
+};
+
+/**
+ * 한 줄 텍스트 입력. 목표 제목·마감일처럼 짧은 값에 쓴다.
+ *
+ * select 를 나란히 둘 땐 style={fieldSurface} 를 그대로 얹으면 높이·테두리가 맞는다.
+ */
+export function TextField({ label, hint, error, full = true, style, ...rest }: TextFieldProps) {
+  return (
+    <label style={{ display: 'flex', flexDirection: 'column', gap: 5, width: full ? '100%' : undefined }}>
+      {label && (
+        <span style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-2)' }}>{label}</span>
+      )}
+      <input
+        {...rest}
+        aria-invalid={error ? true : undefined}
+        style={{
+          ...fieldSurface,
+          width: full ? '100%' : undefined,
+          borderColor: error ? 'var(--danger)' : 'var(--sand-200)',
+          ...style,
+        }}
+      />
+      {(error || hint) && (
+        <span style={{ fontSize: 10, color: error ? 'var(--danger)' : 'var(--text-3)', lineHeight: 1.4 }}>
+          {error || hint}
+        </span>
+      )}
+    </label>
+  );
+}

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+
+export type ToastTone = 'neutral' | 'error';
+
+export interface ToastProps {
+  children: React.ReactNode;
+  /** error 면 붉은 배경. 저장 실패·되돌림처럼 결과가 뒤집힌 경우에 쓴다. */
+  tone?: ToastTone;
+  /** 탭바 위로 띄울 때의 아래 여백(px). 기본은 safe-area 를 존중하는 하단 고정. */
+  bottom?: number;
+  /** 문구 앞 아이콘. */
+  icon?: React.ReactNode;
+}
+
+/**
+ * 짧게 떴다 사라지는 결과 알림. 위치 고정(absolute)이라 화면 루트가
+ * position: relative | absolute 여야 한다.
+ *
+ * 쓰는 자리: 되돌릴 수 있는 작은 결과("임시로 저장했어요"), 또는 실패해서
+ * 화면 상태를 원래대로 돌렸다는 사실 통지. 사용자가 반드시 읽어야 하는
+ * 에러라면 토스트가 아니라 ErrorBanner 를 쓴다 — 토스트는 사라지기 때문.
+ */
+export function Toast({ children, tone = 'neutral', bottom, icon }: ToastProps) {
+  return (
+    <div
+      role="status"
+      style={{
+        position: 'absolute',
+        left: 0,
+        right: 0,
+        bottom: bottom ?? 'max(16px, env(safe-area-inset-bottom, 16px))',
+        display: 'flex',
+        justifyContent: 'center',
+        zIndex: 80,
+        pointerEvents: 'none',
+        padding: '0 16px',
+      }}
+    >
+      <div
+        style={{
+          background: tone === 'error' ? 'var(--danger)' : 'var(--text-1)',
+          color: '#FAF6EE',
+          borderRadius: 12,
+          padding: '10px 18px',
+          fontSize: 13,
+          fontWeight: 500,
+          boxShadow: 'var(--shadow-md)',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 6,
+          maxWidth: '100%',
+        }}
+      >
+        {icon}
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Toggle.tsx
+++ b/src/components/Toggle.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+
+export interface ToggleProps {
+  on: boolean;
+  /** 없으면 표시 전용(부모 행 전체가 클릭 대상인 경우). */
+  onChange?: (next: boolean) => void;
+  /** 스크린리더용 이름. onChange 를 줄 땐 반드시 함께 준다. */
+  label?: string;
+  disabled?: boolean;
+}
+
+/** 설정 화면의 on/off 스위치. 켜짐만 브랜드 색으로 채운다. */
+export function Toggle({ on, onChange, label, disabled = false }: ToggleProps) {
+  const visual = (
+    <div
+      style={{
+        width: 36,
+        height: 20,
+        borderRadius: 9999,
+        background: on ? 'var(--brand)' : 'var(--sand-300)',
+        position: 'relative',
+        flexShrink: 0,
+        opacity: disabled ? 0.5 : 1,
+      }}
+    >
+      <div
+        style={{
+          position: 'absolute',
+          top: 2,
+          left: on ? 18 : 2,
+          width: 16,
+          height: 16,
+          borderRadius: 9999,
+          background: '#fff',
+          transition: 'left 160ms',
+        }}
+      />
+    </div>
+  );
+
+  if (!onChange) return visual;
+
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={on}
+      aria-label={label}
+      disabled={disabled}
+      onClick={() => onChange(!on)}
+      style={{
+        background: 'transparent',
+        border: 'none',
+        padding: 0,
+        cursor: disabled ? 'not-allowed' : 'pointer',
+        display: 'flex',
+      }}
+    >
+      {visual}
+    </button>
+  );
+}

--- a/src/components/WeekGrid.tsx
+++ b/src/components/WeekGrid.tsx
@@ -1,0 +1,332 @@
+import React from 'react';
+import { DAYS_KO } from '../data';
+
+export interface WeekGridBlock {
+  id: string;
+  /** 0=월 … 6=일. 표시 중인 주 바깥이면 아예 넘기지 않는다. */
+  col: number;
+  /** 자정 기준 분. 09:30 이면 570. */
+  startMin: number;
+  durMin: number;
+  title: string;
+  /** 제목 앞 글리프 — 완료 '✓ ' / 잘 안됨 '✗ ' / 이월 '↩ '. */
+  glyph?: string;
+  /** 블록이 충분히 높을 때만 보이는 두 번째 줄(보통 "14:00·60분"). */
+  subLabel?: string;
+  /** 목표 카테고리 색. 없으면 중립 sand 색. */
+  colors?: { bg: string; bd: string; fg: string };
+  /** 점선 + 반투명. 확정 전 초안이나 이전 계획 잔상에 쓴다. */
+  muted?: boolean;
+  /** 드래그 중 — 점선 + 그림자로 들린 느낌을 준다. */
+  dragging?: boolean;
+  /** 고정 일정(수업·알바 등). 옮길 수 없으니 grab 커서를 주지 않는다. */
+  fixed?: boolean;
+}
+
+export interface WeekGridProps {
+  blocks: WeekGridBlock[];
+  /** 뒤에 흐리게 깔리는 층. 클릭 불가 — 비교용 잔상이다. */
+  backdrop?: WeekGridBlock[];
+  /** 요일 아래 날짜 숫자(길이 7). 없으면 요일 글자만 나온다. */
+  dayNumbers?: (number | string)[];
+  /** 오늘 칸(0~6). 이번 주가 아니면 null 을 줘서 강조를 끈다. */
+  todayCol?: number | null;
+  /** 현재 시각(자정 기준 분). todayCol 이 있고 표시 구간 안일 때만 선이 그려진다. */
+  nowMin?: number | null;
+  startHour?: number;
+  endHour?: number;
+  /** 시간 한 칸 높이(px). */
+  hourPx?: number;
+  /** 요일 한 칸 너비(px). 넓게 쓰고 싶으면 이 값만 올리면 된다. */
+  colWidth?: number;
+  /** 좌측 시간 눈금 너비(px). */
+  timeWidth?: number;
+  /** true 면 블록 대신 자리표시만 그린다. */
+  loading?: boolean;
+  /** 블록을 누르거나 끌기 시작할 때. 드래그/탭 분기는 호출한 쪽에서 판단한다. */
+  onBlockPointerDown?: (e: React.PointerEvent, block: WeekGridBlock) => void;
+  /** 스크롤 위치를 밖에서 제어할 때(첫 블록으로 스크롤 등). */
+  scrollRef?: React.Ref<HTMLDivElement>;
+}
+
+/** 로딩 중 자리표시 — 실제 계획처럼 보이지 않게 색만 있는 박스로 둔다. */
+const LOADING_SLOTS = [
+  { col: 0, startMin: 14 * 60, durMin: 60 },
+  { col: 1, startMin: 16 * 60, durMin: 90 },
+  { col: 2, startMin: 15 * 60, durMin: 45 },
+  { col: 3, startMin: 18 * 60, durMin: 60 },
+  { col: 4, startMin: 14 * 60 + 30, durMin: 75 },
+  { col: 5, startMin: 20 * 60, durMin: 60 },
+];
+
+const NEUTRAL = { bg: 'var(--sand-100)', bd: 'var(--sand-300)', fg: 'var(--text-3)' };
+
+/**
+ * 주간 시간표. 온보딩의 계획 확인 화면과 메인 주간 캘린더가 이걸 공유한다.
+ *
+ * 이 앱에서 시간표는 장식이 아니라 "계획이 실제 시간에 놓였다"는 증거다.
+ * 그래서 목록형으로 대체하지 않고 격자를 유지한다 — 빈 시간이 눈에 보여야
+ * 사용자가 자기 일주일에 여유가 있는지 없는지 판단할 수 있다.
+ *
+ * 배치는 전부 절대좌표다. 세로 = 시각(hourPx/60 × 분), 가로 = 요일(colWidth × col).
+ * 좁다고 느끼면 colWidth 만 올리면 되고, 그러면 가로 스크롤이 생긴다.
+ */
+export function WeekGrid({
+  blocks,
+  backdrop = [],
+  dayNumbers,
+  todayCol = null,
+  nowMin = null,
+  startHour = 0,
+  endHour = 24,
+  hourPx = 56,
+  colWidth = 50,
+  timeWidth = 30,
+  loading = false,
+  onBlockPointerDown,
+  scrollRef,
+}: WeekGridProps) {
+  const hours = Array.from({ length: endHour - startHour }, (_, i) => startHour + i);
+  const toY = (m: number) => ((m - startHour * 60) * hourPx) / 60;
+  const bodyWidth = colWidth * 7;
+
+  const renderBlock = (b: WeekGridBlock, interactive: boolean) => {
+    const y = toY(b.startMin);
+    if (y < 0) return null;
+    const h = Math.max((b.durMin * hourPx) / 60 - 2, 20);
+    const c = b.colors ?? NEUTRAL;
+    const dashed = b.muted || b.dragging;
+    const common: React.CSSProperties = {
+      position: 'absolute',
+      left: b.col * colWidth + 2,
+      top: y + 1,
+      width: colWidth - 4,
+      height: h,
+      background: c.bg,
+      border: `1.5px ${dashed ? 'dashed' : 'solid'} ${c.bd}`,
+      borderRadius: 6,
+      padding: '3px 4px',
+      overflow: 'hidden',
+    };
+
+    const label = (
+      <>
+        <div
+          style={{
+            fontSize: 8,
+            fontWeight: 700,
+            color: c.fg,
+            lineHeight: 1.3,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: h > 36 ? 'normal' : 'nowrap',
+          }}
+        >
+          {b.glyph ?? ''}
+          {b.title}
+        </div>
+        {h > 36 && b.subLabel && (
+          <div
+            className="tnum"
+            style={{ fontSize: 7, color: c.fg, opacity: 0.7, marginTop: 1, fontFamily: 'var(--font-mono)' }}
+          >
+            {b.subLabel}
+          </div>
+        )}
+      </>
+    );
+
+    if (!interactive) {
+      return (
+        <div key={b.id} aria-hidden style={{ ...common, opacity: 0.38, pointerEvents: 'none' }}>
+          {label}
+        </div>
+      );
+    }
+
+    return (
+      <button
+        key={b.id}
+        onPointerDown={(e) => onBlockPointerDown?.(e, b)}
+        style={{
+          ...common,
+          cursor: b.fixed ? 'pointer' : b.dragging ? 'grabbing' : 'grab',
+          textAlign: 'left',
+          fontFamily: 'inherit',
+          opacity: b.dragging ? 0.85 : 1,
+          boxShadow: b.dragging ? 'var(--shadow-lg)' : 'none',
+          zIndex: b.dragging ? 10 : 1,
+          // 모바일에서 세로 스크롤과 드래그가 싸우지 않게 한다.
+          touchAction: 'none',
+          transition: b.dragging ? 'none' : 'box-shadow 120ms',
+        }}
+      >
+        {label}
+      </button>
+    );
+  };
+
+  return (
+    <>
+      {/* 요일 헤더 */}
+      <div style={{ flexShrink: 0, display: 'flex', borderBottom: '1px solid var(--sand-200)' }}>
+        <div style={{ width: timeWidth, flexShrink: 0 }} />
+        {DAYS_KO.map((d, i) => {
+          const isToday = todayCol === i;
+          return (
+            <div
+              key={d}
+              style={{
+                width: colWidth,
+                flexShrink: 0,
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                padding: '6px 0',
+                background: isToday ? 'rgba(226,109,78,0.04)' : 'transparent',
+              }}
+            >
+              <div
+                style={{
+                  fontSize: 8,
+                  fontFamily: 'var(--font-mono)',
+                  letterSpacing: '0.08em',
+                  color: isToday ? 'var(--coral-700)' : 'var(--text-3)',
+                  marginBottom: 3,
+                }}
+              >
+                {d}
+              </div>
+              {dayNumbers && (
+                <div
+                  className="tnum"
+                  style={{
+                    width: 22,
+                    height: 22,
+                    borderRadius: 9999,
+                    background: isToday ? 'var(--brand)' : 'transparent',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    fontWeight: 700,
+                    fontSize: 11,
+                    color: isToday ? '#FFFCF6' : 'var(--text-1)',
+                  }}
+                >
+                  {dayNumbers[i]}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* 격자 본문 */}
+      <div ref={scrollRef} style={{ flex: 1, overflowY: 'auto' }}>
+        <div style={{ display: 'flex', minWidth: timeWidth + bodyWidth }}>
+          <div style={{ width: timeWidth, flexShrink: 0, background: 'var(--surface-ground)' }}>
+            {hours.map((h) => (
+              <div
+                key={h}
+                style={{
+                  height: hourPx,
+                  display: 'flex',
+                  alignItems: 'flex-start',
+                  paddingTop: 4,
+                  justifyContent: 'flex-end',
+                  paddingRight: 4,
+                }}
+              >
+                <span className="tnum" style={{ fontSize: 8, color: 'var(--text-3)', fontFamily: 'var(--font-mono)' }}>
+                  {h}
+                </span>
+              </div>
+            ))}
+          </div>
+
+          <div style={{ flex: 1, position: 'relative', minWidth: bodyWidth }}>
+            {hours.map((h, i) => (
+              <div
+                key={h}
+                style={{ position: 'absolute', left: 0, right: 0, top: i * hourPx, height: 1, background: 'var(--sand-200)' }}
+              />
+            ))}
+            {DAYS_KO.map((d, i) => (
+              <div
+                key={d}
+                style={{ position: 'absolute', left: i * colWidth, top: 0, bottom: 0, width: 1, background: 'var(--sand-200)' }}
+              />
+            ))}
+            {todayCol != null && (
+              <div
+                style={{
+                  position: 'absolute',
+                  left: todayCol * colWidth,
+                  top: 0,
+                  bottom: 0,
+                  width: colWidth,
+                  background: 'rgba(226,109,78,0.03)',
+                }}
+              />
+            )}
+
+            {loading &&
+              LOADING_SLOTS.map((s, i) => (
+                <div
+                  key={`sk-${i}`}
+                  aria-hidden
+                  style={{
+                    position: 'absolute',
+                    left: s.col * colWidth + 2,
+                    top: toY(s.startMin) + 1,
+                    width: colWidth - 4,
+                    height: Math.max((s.durMin * hourPx) / 60 - 2, 20),
+                    borderRadius: 6,
+                    background: i % 2 === 0 ? 'var(--sand-100)' : 'var(--surface-raised)',
+                    border: '1px solid var(--sand-200)',
+                    opacity: 0.7,
+                    zIndex: 1,
+                  }}
+                />
+              ))}
+
+            {!loading && backdrop.map((b) => renderBlock(b, false))}
+
+            {/* 현재 시각 선 — 오늘 칸에만, 표시 구간 안일 때만. */}
+            {!loading && todayCol != null && nowMin != null && nowMin >= startHour * 60 && nowMin <= endHour * 60 && (
+              <div
+                style={{
+                  position: 'absolute',
+                  left: todayCol * colWidth,
+                  width: colWidth,
+                  top: toY(nowMin),
+                  height: 2,
+                  background: 'var(--brand)',
+                  borderRadius: 9999,
+                  zIndex: 5,
+                }}
+              >
+                <div
+                  style={{
+                    position: 'absolute',
+                    left: -3,
+                    top: -3,
+                    width: 7,
+                    height: 7,
+                    borderRadius: 9999,
+                    background: 'var(--brand)',
+                  }}
+                />
+              </div>
+            )}
+
+            {!loading && blocks.map((b) => renderBlock(b, true))}
+
+            {/* 마지막 시간대도 스크롤로 닿게 하는 여유 */}
+            <div style={{ height: hours.length * hourPx + hourPx }} />
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/design-system.ts
+++ b/src/design-system.ts
@@ -4,21 +4,49 @@
 // 이 배럴이 존재하는 이유는 디자인 시스템으로서 "무엇이 공개 컴포넌트인가"를
 // 한 곳에 명시하기 위함이다(동기화 대상 = 여기 열거된 것).
 //
+// 여기 있는 건 전부 실제 화면이 렌더하는 것들이다. 앱이 안 쓰는 컴포넌트는
+// 넣지 않는다 — 디자인 툴에서 조립한 화면이 코드에 없는 부품을 쓰면
+// 그 디자인은 그대로 구현될 수 없기 때문.
+//
 // 디자인 토큰은 src/index.css 의 CSS 변수(--sand-*, --coral-* 등)에 있고,
 // 컴포넌트는 그 변수를 참조하므로 스타일시트 없이는 렌더되지 않는다.
 
+// ── 화면 주역 ────────────────────────────────────────────────
+export { WeekGrid } from './components/WeekGrid';
+export { HeroTaskCard } from './components/HeroTaskCard';
+export { TaskRow } from './components/TaskRow';
+export { RecoveryOptionCard } from './components/RecoveryOptionCard';
+export { InboxItemCard, InboxAction } from './components/InboxItemCard';
+export { GoalCard } from './components/GoalCard';
+export { ScoreDonut } from './components/ScoreDonut';
 export { AiDraftCard } from './components/AiDraftCard';
+
+// ── 시트·오버레이 ────────────────────────────────────────────
 export { BlockEditSheet } from './components/BlockEditSheet';
-export { Card } from './components/Card';
-export { Chip } from './components/Chip';
-export { DemoNotice } from './components/DemoNotice';
-export { IosInstallCard } from './components/IosInstallCard';
-export { ReButton } from './components/ReButton';
+export { ProgressSheet } from './components/ProgressSheet';
 export { ResourceViewerSheet } from './components/ResourceViewerSheet';
-export { SectionHeader } from './components/SectionHeader';
-export { Segmented } from './components/Segmented';
-export { SetupProgress } from './components/SetupProgress';
-export { MergedTabBar as TabBar } from './components/TabBar';
+
+// ── 상태 표현 ────────────────────────────────────────────────
+export { EmptyState } from './components/EmptyState';
+export { ErrorBanner } from './components/ErrorBanner';
+export { SkeletonBlock } from './components/SkeletonBlock';
+export { Toast } from './components/Toast';
+export { DemoNotice } from './components/DemoNotice';
+
+// ── 입력·컨트롤 ──────────────────────────────────────────────
+export { ReButton } from './components/ReButton';
+export { TextField } from './components/TextField';
+export { Toggle } from './components/Toggle';
+export { IconAction } from './components/IconAction';
 export { TimeDial } from './components/TimeDial';
+export { Segmented } from './components/Segmented';
+export { Chip } from './components/Chip';
+
+// ── 구조·네비게이션 ──────────────────────────────────────────
+export { Card } from './components/Card';
+export { SectionHeader } from './components/SectionHeader';
+export { MergedTabBar as TabBar } from './components/TabBar';
 export { WeeklySwitch } from './components/WeeklySwitch';
+export { SetupProgress } from './components/SetupProgress';
 export { Wordmark } from './components/Wordmark';
+export { IosInstallCard } from './components/IosInstallCard';

--- a/src/screens/GoalClassificationScreen.tsx
+++ b/src/screens/GoalClassificationScreen.tsx
@@ -6,6 +6,7 @@ import type { ApiGoal, GoalCandidate, GoalsByTier, InterviewOutcome } from '../t
 import type { Goal, GoalStatus } from '../types';
 import { SetupProgress } from '../components/SetupProgress';
 import { AiDraftCard } from '../components/AiDraftCard';
+import { ErrorBanner } from '../components/ErrorBanner';
 
 interface GoalClassificationScreenProps {
   onNext: () => void;
@@ -135,9 +136,7 @@ export function GoalClassificationScreen({ onNext, outcome }: GoalClassification
         </div>
 
         {error && (
-          <div style={{ background: '#FAE2D8', border: '1px solid var(--coral-200)', color: 'var(--coral-700)', borderRadius: 10, padding: '10px 12px', fontSize: 11 }}>
-            {error}
-          </div>
+          <ErrorBanner>{error}</ErrorBanner>
         )}
 
         <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>

--- a/src/screens/GoalIntakeScreen.tsx
+++ b/src/screens/GoalIntakeScreen.tsx
@@ -4,6 +4,7 @@ import { ApiError, friendlyError, interviewApi } from '../lib/api';
 import type { InterviewOutcome, InterviewQuestion, InterviewSession, SlotCatalogEntry } from '../types/api';
 import { SetupProgress } from '../components/SetupProgress';
 import { useNavigation } from '../contexts/NavigationContext';
+import { ErrorBanner } from '../components/ErrorBanner';
 
 interface GoalIntakeScreenProps {
   onDone: () => void;
@@ -312,13 +313,16 @@ export function GoalIntakeScreen({ onDone, onOutcome }: GoalIntakeScreenProps) {
       {/* Chat feed */}
       <div ref={bodyRef} style={{ flex: 1, overflowY: 'auto', padding: '14px 16px', display: 'flex', flexDirection: 'column', gap: 10 }}>
         {error && (
-          <div style={{ background: '#FAE2D8', border: '1px solid var(--coral-200)', color: 'var(--coral-700)', borderRadius: 10, padding: '10px 12px', fontSize: 12, display: 'flex', flexDirection: 'column', gap: 8 }}>
-            <span>{error}</span>
-            {/* 인터뷰 시작/이어가기가 막혀도(예: 기존 세션 409) 온보딩을 진행할 수 있게 한다. */}
-            <button onClick={onDone} style={{ alignSelf: 'flex-start', height: 'var(--ctrl-sm)', padding: '0 12px', borderRadius: 9999, border: '1px solid var(--coral-200)', background: 'var(--surface-raised)', color: 'var(--coral-700)', fontSize: 12, fontWeight: 700, fontFamily: 'inherit', cursor: 'pointer', display: 'inline-flex', alignItems: 'center', gap: 4 }}>
-              다음 단계로 넘어가기 <ArrowRight size={12} />
-            </button>
-          </div>
+          <ErrorBanner
+            action={
+              /* 인터뷰 시작/이어가기가 막혀도(예: 기존 세션 409) 온보딩을 진행할 수 있게 한다. */
+              <button onClick={onDone} style={{ alignSelf: 'flex-start', height: 'var(--ctrl-sm)', padding: '0 12px', borderRadius: 9999, border: '1px solid var(--coral-200)', background: 'var(--surface-raised)', color: 'var(--coral-700)', fontSize: 12, fontWeight: 700, fontFamily: 'inherit', cursor: 'pointer', display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+                다음 단계로 넘어가기 <ArrowRight size={12} />
+              </button>
+            }
+          >
+            {error}
+          </ErrorBanner>
         )}
         {messages.map((m) => (
           <div key={m.id} style={{ display: 'flex', justifyContent: m.who === 'user' ? 'flex-end' : 'flex-start' }}>

--- a/src/screens/GoalsScreen.tsx
+++ b/src/screens/GoalsScreen.tsx
@@ -5,6 +5,11 @@ import type { ApiGoal, GoalDecomposition, GoalTier } from '../types/api';
 import { GOAL_STATUS_META, GOAL_CATEGORY_OPTIONS, categoryLabel } from '../data';
 import { ReButton } from '../components/ReButton';
 import { AiDraftCard } from '../components/AiDraftCard';
+import { GoalCard } from '../components/GoalCard';
+import { IconAction } from '../components/IconAction';
+import { EmptyState } from '../components/EmptyState';
+import { ErrorBanner } from '../components/ErrorBanner';
+import { SkeletonBlock } from '../components/SkeletonBlock';
 
 // Focus ≤ 3 / Maintain ≤ 5. Parked 는 한도 자유 (백엔드 _TIER_LIMITS 와 동일).
 const TIER_LIMIT: Record<GoalTier, number | null> = { focus: 3, maintain: 5, parked: null };
@@ -218,23 +223,17 @@ export function GoalsScreen() {
         </div>
 
         {error && (
-          <div style={{ background: '#FAE2D8', border: '1px solid var(--coral-200)', color: 'var(--coral-700)', borderRadius: 10, padding: '10px 12px', fontSize: 11 }}>
-            {error}
-          </div>
+          <ErrorBanner>{error}</ErrorBanner>
         )}
 
         {/* 첫 로드 중엔 스켈레톤, 연동 성공했는데 목표가 없으면 빈 상태 안내. */}
         {isLoading && (
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }} aria-hidden="true">
-            {[0, 1, 2].map((i) => (
-              <div key={i} style={{ height: 72, borderRadius: 14, border: '1px solid var(--sand-200)', background: 'var(--surface-raised)', opacity: 0.6 }} />
-            ))}
-          </div>
+          <SkeletonBlock count={3} height={72} radius={14} />
         )}
         {!isLoading && usingReal && goals.length === 0 && (
-          <div style={{ padding: '14px 16px', borderRadius: 14, background: 'var(--surface-raised)', border: '1px dashed var(--sand-200)', fontSize: 12, color: 'var(--text-2)', lineHeight: 1.5 }}>
+          <EmptyState>
             아직 등록된 목표가 없어요. 아래 <b>+ 목표 추가</b>로 만들어보세요.
-          </div>
+          </EmptyState>
         )}
 
         {/* tier 별 그룹 */}
@@ -251,27 +250,20 @@ export function GoalsScreen() {
                 const isExp = expandedId === g.goalId;
                 const isEditing = editId === g.goalId;
                 return (
-                  <div key={g.goalId} style={{ background: 'var(--surface-raised)', border: `1.5px solid ${isExp ? m.border : 'var(--sand-200)'}`, borderRadius: 14, padding: 12 }}>
-                    {/* 카드 본문 */}
-                    <div onClick={() => { setExpandedId(isExp ? null : g.goalId); setConfirmDeleteId(null); }} style={{ display: 'flex', alignItems: 'flex-start', gap: 10, cursor: 'pointer' }}>
-                      <div style={{ flex: 1, minWidth: 0 }}>
-                        <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 5, flexWrap: 'wrap' }}>
-                          <span style={{ height: 'var(--ctrl-xs)', padding: '0 8px', borderRadius: 9999, background: m.bg, border: `1px solid ${m.border}`, fontSize: 10, fontWeight: 700, color: m.color, fontFamily: 'var(--font-mono)', display: 'inline-flex', alignItems: 'center' }}>{m.label}</span>
-                          <span style={{ height: 'var(--ctrl-xs)', padding: '0 7px', background: 'var(--sand-100)', border: '1px solid var(--sand-200)', borderRadius: 9999, fontSize: 10, color: 'var(--text-2)', display: 'inline-flex', alignItems: 'center' }}>{categoryLabel(g.category)}</span>
-                        </div>
-                        <div style={{ fontWeight: 700, fontSize: 14, color: 'var(--text-1)', letterSpacing: '-0.01em' }}>{g.title}</div>
-                        <div style={{ display: 'flex', gap: 5, flexWrap: 'wrap', marginTop: 4 }}>
-                          {g.deadline && (
-                            <span className="tnum" style={{ height: 'var(--ctrl-xs)', padding: '0 7px', background: 'var(--sand-100)', border: '1px solid var(--sand-200)', borderRadius: 9999, fontSize: 10, color: 'var(--text-2)', display: 'inline-flex', alignItems: 'center' }}>~{g.deadline}</span>
-                          )}
-                          <span className="tnum" style={{ height: 'var(--ctrl-xs)', padding: '0 7px', background: 'var(--sand-100)', border: '1px solid var(--sand-200)', borderRadius: 9999, fontSize: 10, color: 'var(--text-3)', display: 'inline-flex', alignItems: 'center' }}>우선순위 {g.priorityLevel}</span>
-                        </div>
-                      </div>
-                    </div>
+                  <GoalCard
+                    key={g.goalId}
+                    title={g.title}
+                    tier={g.goalTier}
+                    categoryLabel={categoryLabel(g.category)}
+                    deadline={g.deadline}
+                    priorityLevel={g.priorityLevel}
+                    expanded={isExp}
+                    onToggle={() => { setExpandedId(isExp ? null : g.goalId); setConfirmDeleteId(null); }}
+                  >
 
                     {/* 인라인 수정 폼 */}
-                    {isExp && isEditing && edit && (
-                      <div onClick={(e) => e.stopPropagation()} style={{ marginTop: 10, paddingTop: 10, borderTop: '1px solid var(--sand-200)', display: 'flex', flexDirection: 'column', gap: 8 }}>
+                    {isEditing && edit && (
+                      <>
                         <input value={edit.title} onChange={(e) => setEdit({ ...edit, title: e.target.value })} placeholder="제목" style={inputStyle} />
                         <div style={{ display: 'flex', gap: 6 }}>
                           <input value={edit.deadline} onChange={(e) => setEdit({ ...edit, deadline: e.target.value })} placeholder="마감 YYYY-MM-DD" style={{ ...inputStyle, flex: 1 }} />
@@ -285,12 +277,12 @@ export function GoalsScreen() {
                             <ReButton variant="primary" size="sm" full onClick={() => saveEdit(g)} disabled={!edit.title.trim()}>저장</ReButton>
                           </div>
                         </div>
-                      </div>
+                      </>
                     )}
 
                     {/* 액션 패널 */}
-                    {isExp && !isEditing && (
-                      <div onClick={(e) => e.stopPropagation()} style={{ marginTop: 10, paddingTop: 10, borderTop: '1px solid var(--sand-200)', display: 'flex', flexDirection: 'column', gap: 8 }}>
+                    {!isEditing && (
+                      <>
                         <div style={{ display: 'flex', gap: 5 }}>
                           {TIER_ORDER.map((t) => {
                             const tm = GOAL_STATUS_META[t];
@@ -332,9 +324,9 @@ export function GoalsScreen() {
                             </div>
                           </AiDraftCard>
                         )}
-                      </div>
+                      </>
                     )}
-                  </div>
+                  </GoalCard>
                 );
               })}
             </div>
@@ -362,14 +354,17 @@ export function GoalsScreen() {
               })}
             </div>
             {addError && (
-              <div style={{ background: '#FAE2D8', border: '1px solid var(--coral-200)', color: 'var(--coral-700)', borderRadius: 9, padding: '8px 10px', fontSize: 11, display: 'flex', flexDirection: 'column', gap: 6 }}>
-                <span>{addError}</span>
-                {addLimitHit && addTier !== 'maintain' && (
-                  <button onClick={() => addGoal('maintain')} style={{ alignSelf: 'flex-start', height: 28, padding: '0 10px', borderRadius: 9999, border: '1px solid var(--coral-300, #EBA98F)', background: 'var(--surface-raised)', color: 'var(--coral-700)', fontSize: 11, fontWeight: 600, cursor: 'pointer', fontFamily: 'inherit' }}>
-                    유지(Maintain)로 추가할까요?
-                  </button>
-                )}
-              </div>
+              <ErrorBanner
+                action={
+                  addLimitHit && addTier !== 'maintain' ? (
+                    <button onClick={() => addGoal('maintain')} style={{ alignSelf: 'flex-start', height: 28, padding: '0 10px', borderRadius: 9999, border: '1px solid var(--coral-300, #EBA98F)', background: 'var(--surface-raised)', color: 'var(--coral-700)', fontSize: 11, fontWeight: 600, cursor: 'pointer', fontFamily: 'inherit' }}>
+                      유지(Maintain)로 추가할까요?
+                    </button>
+                  ) : undefined
+                }
+              >
+                {addError}
+              </ErrorBanner>
             )}
             <div style={{ display: 'flex', gap: 6 }}>
               <ReButton variant="ghost" size="sm" onClick={resetAdd}>취소</ReButton>
@@ -398,27 +393,3 @@ const inputStyle: React.CSSProperties = {
   outline: 'none',
   color: 'var(--text-1)',
 };
-
-function IconAction({ icon, label, onClick, tone = 'default', disabled = false }: {
-  icon: React.ReactNode;
-  label: string;
-  onClick: () => void;
-  tone?: 'default' | 'danger';
-  disabled?: boolean;
-}) {
-  return (
-    <button
-      onClick={onClick}
-      disabled={disabled}
-      style={{
-        flex: 1, height: 34, borderRadius: 10, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 5,
-        border: `1px solid ${tone === 'danger' ? 'var(--coral-200)' : 'var(--sand-200)'}`,
-        background: 'var(--surface-ground)',
-        color: tone === 'danger' ? 'var(--danger)' : 'var(--text-2)',
-        fontWeight: 600, fontSize: 11, cursor: disabled ? 'wait' : 'pointer', fontFamily: 'inherit', opacity: disabled ? 0.6 : 1,
-      }}
-    >
-      {icon} {label}
-    </button>
-  );
-}

--- a/src/screens/InboxScreen.tsx
+++ b/src/screens/InboxScreen.tsx
@@ -3,6 +3,9 @@ import { Sparkle, ArrowUp, Archive, TreeStructure, ListChecks, ArrowCounterClock
 import { friendlyError, inboxApi } from '../lib/api';
 import { Segmented } from '../components/Segmented';
 import { ResourceViewerSheet } from '../components/ResourceViewerSheet';
+import { InboxItemCard, InboxAction } from '../components/InboxItemCard';
+import { SkeletonBlock } from '../components/SkeletonBlock';
+import { ErrorBanner } from '../components/ErrorBanner';
 import { useNavigation } from '../contexts/NavigationContext';
 import type { InboxItem, InboxStatus } from '../types/api';
 
@@ -208,11 +211,9 @@ export function InboxScreen() {
       {/* List */}
       <div style={{ flex: 1, overflowY: 'auto', padding: '0 18px 16px', display: 'flex', flexDirection: 'column', gap: 8 }}>
         {error && (
-          <div style={{ background: '#FAE2D8', border: '1px solid var(--coral-200)', color: 'var(--coral-700)', borderRadius: 10, padding: '10px 12px', fontSize: 12 }}>
-            {error}
-          </div>
+          <ErrorBanner>{error}</ErrorBanner>
         )}
-        {isLoading && <Skeleton />}
+        {isLoading && <SkeletonBlock count={3} height={64} radius={14} />}
         {!isLoading && visibleItems.length === 0 && !error && (
           <div style={{ padding: '40px 12px', textAlign: 'center', color: 'var(--text-3)', fontSize: 13 }}>
             {items.length > 0
@@ -233,81 +234,63 @@ export function InboxScreen() {
           // 배지로만 구분한다. 승격(할 일로/목표로)은 BE 가 422 로 막으므로 버튼을 숨긴다.
           const isResource = it.source === 'system';
           return (
-            <div
+            <InboxItemCard
               key={it.inboxId}
-              style={{ background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', borderRadius: 14, padding: 12, display: 'flex', flexDirection: 'column', gap: 8 }}
-            >
-              <div style={{ fontSize: 13, color: 'var(--text-1)', lineHeight: 1.5 }}>{it.rawText}</div>
-              <div style={{ display: 'flex', gap: 5, flexWrap: 'wrap', alignItems: 'center' }}>
-                {/* classified 는 '할 일' 탭에서 자명하므로 상태 배지 생략(#129 — 내부 상태 노출 제거).
-                    처리됨(목표로/할 일로)·보관 배지는 의미가 있어 유지. */}
-                {isResource ? (
-                  <span style={{ height: 'var(--ctrl-xs)', padding: '0 8px', borderRadius: 9999, background: 'var(--brand-soft)', border: '1px solid var(--coral-200)', fontSize: 10, fontWeight: 700, color: 'var(--coral-700)', fontFamily: 'var(--font-mono)', display: 'inline-flex', alignItems: 'center', gap: 4 }}>
-                    <BookOpen size={10} weight="fill" /> 추천 자료
-                  </span>
-                ) : status !== 'classified' && (
-                  <span style={{ height: 'var(--ctrl-xs)', padding: '0 8px', borderRadius: 9999, background: meta.bg, border: `1px solid ${meta.bd}`, fontSize: 10, fontWeight: 700, color: meta.fg, fontFamily: 'var(--font-mono)', display: 'inline-flex', alignItems: 'center' }}>
-                    {badgeLabel}
-                  </span>
-                )}
-                {it.aiCategoryGuess && (
-                  <span style={{ height: 'var(--ctrl-xs)', padding: '0 8px', borderRadius: 9999, background: 'var(--sand-100)', border: '1px solid var(--sand-200)', fontSize: 10, color: 'var(--text-2)', fontWeight: 500, display: 'inline-flex', alignItems: 'center', gap: 4 }}>
-                    <Sparkle size={9} weight="fill" /> {categoryLabel(it.aiCategoryGuess)}
-                  </span>
-                )}
-                <div style={{ flex: 1 }} />
-                {isResource && status !== 'archived' && (
-                  <button
-                    onClick={() => openResource(it)}
-                    style={{ height: 26, padding: '0 10px', borderRadius: 9999, border: '1px solid var(--coral-200)', background: 'var(--brand-soft)', color: 'var(--coral-700)', fontSize: 11, fontWeight: 600, cursor: 'pointer', fontFamily: 'inherit', display: 'inline-flex', alignItems: 'center', gap: 4 }}
-                  >
-                    <BookOpen size={11} weight="fill" /> 열기
-                  </button>
-                )}
-                {!isResource && status !== 'promoted' && status !== 'archived' && (
-                  <>
+              text={it.rawText}
+              aiCategory={it.aiCategoryGuess ? categoryLabel(it.aiCategoryGuess) : undefined}
+              badges={
+                isResource
+                  ? [{
+                      label: '추천 자료',
+                      icon: <BookOpen size={10} weight="fill" />,
+                      bg: 'var(--brand-soft)',
+                      bd: 'var(--coral-200)',
+                      fg: 'var(--coral-700)',
+                    }]
+                  : status !== 'classified'
+                    ? [{ label: badgeLabel, bg: meta.bg, bd: meta.bd, fg: meta.fg }]
+                    : []
+              }
+              actions={
+                <>
+                  {isResource && status !== 'archived' && (
+                    <InboxAction tone="brand" icon={<BookOpen size={11} weight="fill" />} onClick={() => openResource(it)}>
+                      열기
+                    </InboxAction>
+                  )}
+                  {!isResource && status !== 'promoted' && status !== 'archived' && (
+                    <>
+                      <InboxAction icon={<ListChecks size={11} weight="fill" />} onClick={() => convertToAction(it.inboxId)}>
+                        할 일로
+                      </InboxAction>
+                      <InboxAction tone="brand" icon={<TreeStructure size={11} weight="fill" />} onClick={() => convertToGoal(it.inboxId)}>
+                        목표로
+                      </InboxAction>
+                    </>
+                  )}
+                  {status === 'promoted' && (
+                    <InboxAction onClick={() => goToTarget(it)}>
+                      {it.promotedTo === 'action' ? '오늘로' : '목표 보기'} <ArrowRight size={11} weight="bold" />
+                    </InboxAction>
+                  )}
+                  {status === 'archived' && (
+                    <InboxAction icon={<ArrowCounterClockwise size={11} weight="bold" />} onClick={() => restore(it.inboxId)}>
+                      복원
+                    </InboxAction>
+                  )}
+                  {status !== 'archived' && (
                     <button
-                      onClick={() => convertToAction(it.inboxId)}
-                      style={{ height: 26, padding: '0 10px', borderRadius: 9999, border: '1px solid var(--sand-200)', background: 'var(--surface-raised)', color: 'var(--text-2)', fontSize: 11, fontWeight: 600, cursor: 'pointer', fontFamily: 'inherit', display: 'inline-flex', alignItems: 'center', gap: 4 }}
+                      onClick={() => archive(it.inboxId)}
+                      style={{ width: 26, height: 26, borderRadius: 9999, border: 'none', background: 'transparent', color: 'var(--text-3)', cursor: 'pointer', display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}
+                      aria-label="보관"
+                      title="보관"
                     >
-                      <ListChecks size={11} weight="fill" /> 할 일로
+                      <Archive size={13} />
                     </button>
-                    <button
-                      onClick={() => convertToGoal(it.inboxId)}
-                      style={{ height: 26, padding: '0 10px', borderRadius: 9999, border: '1px solid var(--coral-200)', background: 'var(--brand-soft)', color: 'var(--coral-700)', fontSize: 11, fontWeight: 600, cursor: 'pointer', fontFamily: 'inherit', display: 'inline-flex', alignItems: 'center', gap: 4 }}
-                    >
-                      <TreeStructure size={11} weight="fill" /> 목표로
-                    </button>
-                  </>
-                )}
-                {status === 'promoted' && (
-                  <button
-                    onClick={() => goToTarget(it)}
-                    style={{ height: 26, padding: '0 10px', borderRadius: 9999, border: '1px solid var(--sand-200)', background: 'var(--surface-raised)', color: 'var(--text-2)', fontSize: 11, fontWeight: 600, cursor: 'pointer', fontFamily: 'inherit', display: 'inline-flex', alignItems: 'center', gap: 4 }}
-                  >
-                    {it.promotedTo === 'action' ? '오늘로' : '목표 보기'} <ArrowRight size={11} weight="bold" />
-                  </button>
-                )}
-                {status === 'archived' && (
-                  <button
-                    onClick={() => restore(it.inboxId)}
-                    style={{ height: 26, padding: '0 10px', borderRadius: 9999, border: '1px solid var(--sand-200)', background: 'var(--surface-raised)', color: 'var(--text-2)', fontSize: 11, fontWeight: 600, cursor: 'pointer', fontFamily: 'inherit', display: 'inline-flex', alignItems: 'center', gap: 4 }}
-                  >
-                    <ArrowCounterClockwise size={11} weight="bold" /> 복원
-                  </button>
-                )}
-                {status !== 'archived' && (
-                  <button
-                    onClick={() => archive(it.inboxId)}
-                    style={{ width: 26, height: 26, borderRadius: 9999, border: 'none', background: 'transparent', color: 'var(--text-3)', cursor: 'pointer', display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}
-                    aria-label="보관"
-                    title="보관"
-                  >
-                    <Archive size={13} />
-                  </button>
-                )}
-              </div>
-            </div>
+                  )}
+                </>
+              }
+            />
           );
         })}
       </div>
@@ -343,15 +326,5 @@ export function InboxScreen() {
         />
       )}
     </div>
-  );
-}
-
-function Skeleton() {
-  return (
-    <>
-      {[0, 1, 2].map((i) => (
-        <div key={i} style={{ background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', borderRadius: 14, padding: 12, height: 64, opacity: 0.5 }} />
-      ))}
-    </>
   );
 }

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { Sparkle } from '@phosphor-icons/react';
+import { ErrorBanner } from '../components/ErrorBanner';
 
 // Google Identity Services 는 CDN 스크립트(index.html)가 window.google 을 채운다.
 // 공식 타입 패키지 없이 최소 shape 만 선언 — 실제로 쓰는 필드만.
@@ -120,9 +121,7 @@ export function LoginScreen({ onGoogleCredential, onDemoLogin, isBusy, error }: 
         )}
 
         {error && (
-          <div style={{ background: '#FAE2D8', border: '1px solid var(--coral-200)', color: 'var(--coral-700)', borderRadius: 10, padding: '10px 12px', fontSize: 12, width: '100%' }}>
-            {error}
-          </div>
+          <ErrorBanner>{error}</ErrorBanner>
         )}
 
         <button

--- a/src/screens/RecoveryScreen.tsx
+++ b/src/screens/RecoveryScreen.tsx
@@ -8,6 +8,9 @@ import {
 } from '@phosphor-icons/react';
 import { ApiError, friendlyError, recoveryApi } from '../lib/api';
 import { DemoNotice } from '../components/DemoNotice';
+import { RecoveryOptionCard } from '../components/RecoveryOptionCard';
+import { EmptyState } from '../components/EmptyState';
+import { ErrorBanner } from '../components/ErrorBanner';
 import type { Task, RecoveryProposal } from '../types';
 import type { RecoveryCard } from '../types/api';
 
@@ -217,8 +220,8 @@ export function MergedRecoveryScreen({ task, failReason, onAccept, onDismiss, ex
             </div>
           )}
           {usingRealProposals && proposals.length === 0 && (
-            <div style={{ padding: '14px 16px', borderRadius: 12, background: 'var(--surface-raised)', border: '1px dashed var(--sand-200)', fontSize: 12, color: 'var(--text-2)', lineHeight: 1.5, marginBottom: 14 }}>
-              지금은 제안할 복구안이 없어요.
+            <div style={{ marginBottom: 14 }}>
+              <EmptyState>지금은 제안할 복구안이 없어요.</EmptyState>
             </div>
           )}
           {usingRealProposals && aiSource === 'rule' && proposals.length > 0 && (
@@ -228,51 +231,30 @@ export function MergedRecoveryScreen({ task, failReason, onAccept, onDismiss, ex
           )}
 
           <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-            {proposals.map((p, i) => {
-              const isSel = sel === p.id;
-              return (
-                <div
-                  key={p.id}
-                  onClick={() => setSel(p.id)}
-                  style={{ borderRadius: 14, border: `${isSel ? '1.5px' : '1px'} dashed ${isSel ? p.bc : 'var(--sand-300)'}`, background: isSel ? p.bg : 'var(--surface-raised)', cursor: 'pointer', transition: 'all 160ms', padding: '12px 14px' }}
-                >
-                  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: showWhy === p.id ? 8 : 0 }}>
-                    <div style={{ display: 'flex', alignItems: 'center', gap: 10, flex: 1, minWidth: 0 }}>
-                      <div style={{ width: 20, height: 20, borderRadius: 9999, flexShrink: 0, border: `1.5px solid ${isSel ? p.ac : 'var(--sand-300)'}`, background: isSel ? p.ac : 'transparent', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                        {isSel && <Check size={10} color="#FFFCF6" />}
-                      </div>
-                      <div style={{ flex: 1, minWidth: 0 }}>
-                        <div style={{ fontSize: 13, fontWeight: 700, color: 'var(--text-1)', letterSpacing: '-0.01em' }}>{p.title}</div>
-                        {/* if-then: "만약 [trigger] 이면, [action]" */}
-                        {p.desc && (
-                          <div style={{ fontSize: 11, color: 'var(--text-2)', marginTop: 3, lineHeight: 1.45 }}>
-                            {p.trigger ? <><span style={{ color: 'var(--coral-600)', fontWeight: 600 }}>만약 {p.trigger},</span> </> : ''}{p.desc}
-                          </div>
-                        )}
-                        <div style={{ display: 'flex', gap: 8, marginTop: 5, alignItems: 'center' }}>
-                          {i === 0 && <span style={{ height: 'var(--ctrl-xs)', padding: '0 6px', background: p.bg, border: `1px solid ${p.bc}`, borderRadius: 9999, fontSize: 9, fontWeight: 700, color: p.ac, fontFamily: 'var(--font-mono)', display: 'inline-flex', alignItems: 'center', letterSpacing: '0.04em' }}>추천 ✓</span>}
-                          {p.conf > 0 && <span className="tnum" style={{ fontSize: 10, fontFamily: 'var(--font-mono)', fontWeight: 600, color: p.conf > 80 ? 'var(--success)' : p.conf > 65 ? 'var(--warning)' : 'var(--text-3)' }}>성공률 {p.conf}%</span>}
-                          <span style={{ fontSize: 11, color: 'var(--text-3)' }}>{p.time}</span>
-                        </div>
-                      </div>
-                    </div>
-                    <button onClick={(e) => { e.stopPropagation(); setShowWhy(showWhy === p.id ? null : p.id); }} style={{ flexShrink: 0, background: 'transparent', border: 'none', fontSize: 11, color: 'var(--brand)', fontWeight: 600, cursor: 'pointer', fontFamily: 'inherit', padding: '0 0 0 8px', display: 'flex', alignItems: 'center', gap: 3 }}>
-                      <Info size={12} /> 왜?
-                    </button>
-                  </div>
-                  {showWhy === p.id && (
-                    <div style={{ marginTop: 6, padding: '8px 10px', background: 'var(--brand-soft)', borderRadius: 8, fontSize: 11, color: 'var(--coral-700)', lineHeight: 1.5 }}>{p.why}</div>
-                  )}
-                </div>
-              );
-            })}
+            {proposals.map((p, i) => (
+              <RecoveryOptionCard
+                key={p.id}
+                title={p.title}
+                description={p.desc}
+                trigger={p.trigger}
+                confidence={p.conf}
+                timeLabel={p.time}
+                recommended={i === 0}
+                selected={sel === p.id}
+                onSelect={() => setSel(p.id)}
+                why={p.why}
+                whyOpen={showWhy === p.id}
+                onToggleWhy={() => setShowWhy(showWhy === p.id ? null : p.id)}
+                colors={{ bg: p.bg, bc: p.bc, ac: p.ac }}
+              />
+            ))}
           </div>
 
           <div style={{ marginTop: 14, fontSize: 11, color: 'var(--text-3)', textAlign: 'center' }}>실패는 데이터예요. 다시 한 번이면 충분해요.</div>
 
           {decideError && (
-            <div role="alert" style={{ marginBottom: 10, padding: '10px 12px', borderRadius: 10, background: 'var(--coral-50)', border: '1px solid var(--coral-200)', fontSize: 12, color: 'var(--danger)', lineHeight: 1.5 }}>
-              {decideError}
+            <div style={{ marginBottom: 10 }}>
+              <ErrorBanner>{decideError}</ErrorBanner>
             </div>
           )}
           {/* 3버튼: 나중에(거절) / 다른 제안(수정=재생성) / 이 방법으로(수락) — S19 */}

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -4,6 +4,10 @@ import { ApiError, notificationsApi, privacyApi, settingsApi } from '../lib/api'
 import { subscribePush, unsubscribePush, getPushPermission } from '../lib/push';
 import { useNavigation } from '../contexts/NavigationContext';
 import type { ConsentRecord, ConsentType, ToneMode, UserSettings } from '../types/api';
+import { Toggle } from '../components/Toggle';
+import { SectionHeader } from '../components/SectionHeader';
+import { ErrorBanner } from '../components/ErrorBanner';
+import { Toast } from '../components/Toast';
 
 const TONE_OPTIONS: { mode: ToneMode; label: string; desc: string }[] = [
   { mode: 'gentle', label: '부드럽게', desc: '실패도 격려로. 압박 적은 톤.' },
@@ -142,7 +146,7 @@ export function SettingsScreen() {
 
         {/* Tone mode */}
         <section>
-          <SectionLabel icon={<Sparkle size={11} weight="fill" />}>코칭 톤</SectionLabel>
+          <SectionHeader icon={<Sparkle size={11} weight="fill" />}>코칭 톤</SectionHeader>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
             {TONE_OPTIONS.map((o) => {
               const active = settings?.toneMode === o.mode;
@@ -165,7 +169,7 @@ export function SettingsScreen() {
 
         {/* Push */}
         <section>
-          <SectionLabel icon={<BellRinging size={11} weight="fill" />}>알림</SectionLabel>
+          <SectionHeader icon={<BellRinging size={11} weight="fill" />}>알림</SectionHeader>
           <button
             onClick={togglePush}
             disabled={pushBusy}
@@ -184,7 +188,7 @@ export function SettingsScreen() {
 
         {/* Consent */}
         <section>
-          <SectionLabel icon={<Shield size={11} weight="fill" />}>동의 관리</SectionLabel>
+          <SectionHeader icon={<Shield size={11} weight="fill" />}>동의 관리</SectionHeader>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
             {CONSENT_TYPES.map((c) => {
               const granted = consentGranted(c.type);
@@ -207,7 +211,7 @@ export function SettingsScreen() {
 
         {/* Onboarding */}
         <section>
-          <SectionLabel icon={<ArrowClockwise size={11} weight="fill" />}>온보딩</SectionLabel>
+          <SectionHeader icon={<ArrowClockwise size={11} weight="fill" />}>온보딩</SectionHeader>
           <button
             onClick={() => setConfirmRestartInterview(true)}
             style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '12px 14px', width: '100%', background: 'var(--surface-raised)', border: '1.5px solid var(--sand-200)', borderRadius: 12, cursor: 'pointer', fontFamily: 'inherit', textAlign: 'left' }}
@@ -231,7 +235,7 @@ export function SettingsScreen() {
 
         {/* Danger zone */}
         <section>
-          <SectionLabel icon={<Warning size={11} weight="fill" />} tone="danger">데이터 관리</SectionLabel>
+          <SectionHeader icon={<Warning size={11} weight="fill" />} tone="danger">데이터 관리</SectionHeader>
           <button
             onClick={() => setConfirmAnonymize(true)}
             style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '12px 14px', width: '100%', background: 'transparent', border: '1.5px solid var(--coral-200)', borderRadius: 12, cursor: 'pointer', fontFamily: 'inherit', textAlign: 'left' }}
@@ -255,27 +259,9 @@ export function SettingsScreen() {
       </div>
 
       {toast && (
-        <div style={{ position: 'absolute', bottom: 'max(16px, env(safe-area-inset-bottom, 16px))', left: 16, right: 16, padding: '10px 14px', background: 'var(--text-1)', color: '#FAF6EE', borderRadius: 10, fontSize: 12, textAlign: 'center', boxShadow: 'var(--shadow-md)' }}>
-          {toast}
-        </div>
+        <Toast>{toast}</Toast>
       )}
     </div>
   );
 }
 
-function SectionLabel({ icon, children, tone = 'default' }: { icon?: React.ReactNode; children: React.ReactNode; tone?: 'default' | 'danger' }) {
-  return (
-    <div style={{ display: 'flex', alignItems: 'center', gap: 5, fontSize: 10, fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: tone === 'danger' ? 'var(--danger)' : 'var(--text-3)', fontFamily: 'var(--font-mono)', marginBottom: 8 }}>
-      {icon}
-      {children}
-    </div>
-  );
-}
-
-function Toggle({ on }: { on: boolean }) {
-  return (
-    <div style={{ width: 36, height: 20, borderRadius: 9999, background: on ? 'var(--brand)' : 'var(--sand-300)', position: 'relative', flexShrink: 0 }}>
-      <div style={{ position: 'absolute', top: 2, left: on ? 18 : 2, width: 16, height: 16, borderRadius: 9999, background: '#fff', transition: 'left 160ms' }} />
-    </div>
-  );
-}

--- a/src/screens/SetupScreen.tsx
+++ b/src/screens/SetupScreen.tsx
@@ -13,6 +13,7 @@ import type {
 } from '../types/api';
 import { SetupProgress } from '../components/SetupProgress';
 import { useToast } from '../contexts/ToastContext';
+import { ErrorBanner } from '../components/ErrorBanner';
 
 interface SetupScreenProps {
   onDone: () => void;
@@ -200,8 +201,8 @@ export function SetupScreen({ onDone }: SetupScreenProps) {
         )}
 
         {error && (
-          <div style={{ background: '#FAE2D8', border: '1px solid var(--coral-200)', color: 'var(--coral-700)', borderRadius: 10, padding: '10px 12px', fontSize: 11, marginBottom: 12 }}>
-            {error}
+          <div style={{ marginBottom: 12 }}>
+            <ErrorBanner>{error}</ErrorBanner>
           </div>
         )}
 

--- a/src/screens/TodayScreen.tsx
+++ b/src/screens/TodayScreen.tsx
@@ -13,6 +13,11 @@ import { useNavigation } from '../contexts/NavigationContext';
 import { habitsApi, reflectionApi, todayApi } from '../lib/api';
 import { localDateStr } from '../lib/dates';
 import { DemoNotice } from '../components/DemoNotice';
+import { HeroTaskCard } from '../components/HeroTaskCard';
+import { TaskRow } from '../components/TaskRow';
+import { ProgressSheet } from '../components/ProgressSheet';
+import { EmptyState } from '../components/EmptyState';
+import { SkeletonBlock } from '../components/SkeletonBlock';
 import { Gear, Target, DotsThreeVertical } from '@phosphor-icons/react';
 
 // Today 헤더 우상단 — 목표 관리·설정을 하나의 ⋮ 메뉴로 통합 (아이콘 2개 → 1개).
@@ -70,59 +75,6 @@ interface MergedTodayScreenProps {
   // (기존엔 이 화면이 자체 로컬 tasks 상태로만 반영해, 부모가 들고 있는 openTask 등이
   // 실제 카드 id 를 못 찾아 무반응이었다 — #66 대응)
   onAgendaLoaded: (tasks: Task[]) => void;
-}
-
-function Ring({ task }: { task: Task }) {
-  const s = task.status;
-  if (s === 'done') return (
-    <div style={{ width: 26, height: 26, borderRadius: 9999, background: 'var(--success)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-      <Check size={13} color="#FFFCF6" weight="bold" />
-    </div>
-  );
-  if (s === 'failed') return (
-    <div style={{ width: 26, height: 26, borderRadius: 9999, background: 'var(--danger)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-      <X size={13} color="#FFFCF6" />
-    </div>
-  );
-  if (s === 'partial_done' || s === 'recovery_pending') return (
-    <div style={{ width: 26, height: 26, borderRadius: 9999, border: '2px solid var(--brand)', background: `conic-gradient(var(--brand) 0 ${task.progress ?? 67}%, var(--brand-soft) ${task.progress ?? 67}% 100%)` }} />
-  );
-  if (s === 'in_progress') return (
-    <div style={{ width: 26, height: 26, borderRadius: 9999, border: '2px solid var(--brand)', background: 'conic-gradient(var(--brand) 0 40%, var(--surface-raised) 40% 100%)' }} />
-  );
-  return (
-    <div style={{ width: 26, height: 26, borderRadius: 9999, border: '1.5px solid var(--sand-300)', background: 'var(--surface-raised)' }} />
-  );
-}
-
-function PartialSheet({ taskId, taskTitle, onSubmit, onClose }: { taskId: string; taskTitle: string; onSubmit: (pct: number) => void; onClose: () => void }) {
-  const [pct, setPct] = useState(50);
-  return (
-    <div onClick={onClose} style={{ position: 'absolute', inset: 0, background: 'rgba(26,23,20,.45)', zIndex: 40, display: 'flex', alignItems: 'flex-end' }}>
-      <div onClick={(e) => e.stopPropagation()} style={{ background: 'var(--surface-raised)', width: '100%', borderRadius: '22px 22px 0 0', padding: '10px 20px 44px', boxShadow: 'var(--shadow-xl)' }}>
-        <div style={{ width: 36, height: 4, borderRadius: 9999, background: 'var(--sand-300)', margin: '0 auto 18px' }} />
-        <div style={{ fontSize: 17, fontWeight: 600, marginBottom: 4 }}>오늘은 얼마나 했어요?</div>
-        <p style={{ fontSize: 12, color: 'var(--text-3)', marginBottom: 18 }}>{taskTitle}</p>
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 12 }}>
-          <span style={{ fontSize: 11, color: 'var(--text-3)', letterSpacing: '0.08em', textTransform: 'uppercase', fontFamily: 'var(--font-mono)' }}>진척</span>
-          <span className="tnum" style={{ fontSize: 30, fontWeight: 800, color: 'var(--brand)', letterSpacing: '-0.02em' }}>{pct}<span style={{ fontSize: 16, fontWeight: 600 }}>%</span></span>
-        </div>
-        <div style={{ position: 'relative', height: 8, background: 'var(--sand-200)', borderRadius: 9999, marginBottom: 8 }}>
-          <div style={{ position: 'absolute', left: 0, top: 0, bottom: 0, width: `${pct}%`, background: 'var(--brand)', borderRadius: 9999 }} />
-          <div style={{ position: 'absolute', left: `${pct}%`, top: '50%', transform: 'translate(-50%,-50%)', width: 24, height: 24, borderRadius: 9999, background: '#FFFCF6', border: '2px solid var(--brand)', boxShadow: 'var(--shadow-md)' }} />
-        </div>
-        <div style={{ display: 'flex', justifyContent: 'space-between', padding: '0 2px', marginBottom: 18 }}>
-          {[0, 25, 50, 75, 100].map((t) => (
-            <button key={t} onClick={() => setPct(t)} className="tnum" style={{ background: 'transparent', border: 'none', fontSize: 12, cursor: 'pointer', padding: '2px 4px', fontFamily: 'inherit', color: pct === t ? 'var(--brand)' : 'var(--text-3)', fontWeight: pct === t ? 600 : 500 }}>{t}</button>
-          ))}
-        </div>
-        <div style={{ background: 'var(--coral-50)', borderRadius: 10, padding: '8px 10px', fontSize: 11, color: 'var(--coral-700)', marginBottom: 14 }}>
-          저장 시 <b>recovery_pending</b>으로 자동 전이돼요.
-        </div>
-        <button onClick={() => onSubmit(pct)} style={{ width: '100%', height: 44, borderRadius: 12, border: 'none', background: 'var(--brand)', color: '#FFFCF6', fontWeight: 700, fontSize: 14, fontFamily: 'inherit', cursor: 'pointer' }}>저장하기</button>
-      </div>
-    </div>
-  );
 }
 
 // 화면용 Habit — 백엔드 Habit + 이번 주 HabitInstance 를 평탄화한 모양.
@@ -385,16 +337,19 @@ export function MergedTodayScreen({ tasks, onOpen, onMarkDone, onPartial, onFail
         {/* 첫 agenda fetch 가 끝나기 전엔 스켈레톤. 비었으면 배너 하나만(에러 or 안내),
             일정이 있으면 hero + row. 예전엔 배너 2개 + 빈 hero 가 겹쳐 3중으로 떴다. */}
         {agendaLoading ? (
-          <AgendaSkeleton />
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 18 }}>
+            <SkeletonBlock count={1} height={140} radius={24} />
+            <SkeletonBlock count={3} height={64} />
+          </div>
         ) : tasks.length === 0 ? (
           !usingRealAgenda ? (
             <DemoNotice storageKey="today-agenda">
               오늘 일정을 서버에서 불러오지 못했어요. 네트워크 상태를 확인하고 다시 시도해 주세요.
             </DemoNotice>
           ) : (
-            <div style={{ padding: '10px 12px', borderRadius: 12, background: 'var(--surface-raised)', border: '1px dashed var(--sand-200)', fontSize: 12, color: 'var(--text-2)', lineHeight: 1.5 }}>
+            <EmptyState>
               오늘 등록된 일정이 없어요. 주간 계획에서 일정을 추가하면 여기에 표시돼요.
-            </div>
+            </EmptyState>
           )
         ) : (
           <>
@@ -572,11 +527,11 @@ export function MergedTodayScreen({ tasks, onOpen, onMarkDone, onPartial, onFail
 
       {/* Partial sheet */}
       {partialSheet && partialTask && (
-        <PartialSheet
-          taskId={partialSheet}
+        <ProgressSheet
           taskTitle={partialTask.title}
           onSubmit={(pct) => { onPartial(partialSheet, pct); setPartialSheet(null); showToast('부분 완료 기록됨'); }}
           onClose={() => setPartialSheet(null)}
+          note={<>저장 시 <b>회복 대기</b> 상태로 넘어가요.</>}
         />
       )}
 
@@ -589,153 +544,5 @@ export function MergedTodayScreen({ tasks, onOpen, onMarkDone, onPartial, onFail
         </div>
       )}
     </div>
-  );
-}
-
-// ── Agenda Skeleton ───────────────────────────────────────────
-// 첫 /today/agenda fetch 가 settle 될 때까지 hero+task row 자리를 채우는
-// 가벼운 placeholder. 더미→실데이터 깜빡임 방지용. (전역 CSS 없이 인라인만.)
-function AgendaSkeleton() {
-  const box = (h: number, radius: number, bg: string): React.CSSProperties => ({
-    height: h,
-    borderRadius: radius,
-    background: bg,
-    opacity: 0.6,
-  });
-  return (
-    <div aria-hidden style={{ display: 'flex', flexDirection: 'column', gap: 18 }}>
-      {/* hero 자리 */}
-      <div style={box(140, 24, 'var(--sand-100)')} />
-      {/* task row 자리 — 3개 muted placeholder */}
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-        {[0, 1, 2].map((i) => (
-          <div key={i} style={box(64, 12, 'var(--surface-raised)')} />
-        ))}
-      </div>
-    </div>
-  );
-}
-
-// ── Hero Task Card ────────────────────────────────────────────
-// 열품타 패턴 — 화면의 주인공. 제목 크게, CTA 하나.
-function HeroTaskCard({
-  task, done, total,
-  onComplete, onPartial, onFail, onStart, onDetail,
-}: {
-  task: Task | null;
-  done: number;
-  total: number;
-  onComplete: () => void;
-  onPartial: () => void;
-  onFail: () => void;
-  onStart: (id: string) => void;
-  onDetail: () => void;
-}) {
-  if (!task) {
-    return (
-      <div style={{ background: 'var(--surface-raised)', border: '1px dashed var(--sand-300)', borderRadius: 24, padding: '36px 20px', textAlign: 'center', display: 'flex', flexDirection: 'column', gap: 10 }}>
-        <div style={{ fontFamily: 'var(--font-display)', fontWeight: 700, fontSize: 22, color: 'var(--text-2)' }}>오늘 할 일이 없어요</div>
-        <p style={{ fontSize: 13, color: 'var(--text-3)', margin: 0 }}>주간 계획에서 블록을 추가해보세요.</p>
-      </div>
-    );
-  }
-
-  const isActive = task.status === 'in_progress';
-  const pct = total > 0 ? Math.round((done / total) * 100) : 0;
-
-  return (
-    <div style={{ background: 'var(--surface-raised)', border: '1.5px solid var(--coral-200)', borderRadius: 24, padding: '24px 22px', display: 'flex', flexDirection: 'column', gap: 18 }}>
-      <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between' }}>
-        <span style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.1em', color: 'var(--brand)', fontFamily: 'var(--font-mono)' }}>
-          {isActive ? '진행 중' : '다음 할 일'}
-        </span>
-        <span className="tnum" style={{ fontSize: 11, color: 'var(--text-3)', fontFamily: 'var(--font-mono)' }}>{done} / {total} · {pct}%</span>
-      </div>
-
-      <div>
-        <h2 style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 26, letterSpacing: '-0.02em', lineHeight: 1.2, margin: 0, color: 'var(--text-1)' }}>{task.title}</h2>
-        <div style={{ display: 'flex', gap: 6, marginTop: 8, alignItems: 'center', flexWrap: 'wrap' }}>
-          {task.carryover && (
-            <span style={{ height: 'var(--ctrl-xs)', padding: '0 6px', background: '#FBEEDA', border: '1px solid #F2D29A', borderRadius: 9999, fontSize: 10, color: 'var(--warning)', fontWeight: 600, display: 'inline-flex', alignItems: 'center' }}>↩ 이월</span>
-          )}
-          {task.time && <span className="tnum" style={{ fontSize: 12, color: 'var(--text-2)' }}>{task.time}{task.dur ? ` · ${task.dur}` : ''}</span>}
-        </div>
-        {(task.whyNow || task.firstStep) && (
-          <button onClick={onDetail} style={{ marginTop: 10, alignSelf: 'flex-start', background: 'transparent', border: 'none', padding: 0, color: 'var(--brand)', fontSize: 12, fontWeight: 600, cursor: 'pointer', fontFamily: 'inherit', display: 'flex', alignItems: 'center', gap: 3 }}>
-            왜 지금? · 자세히 <CaretRight size={11} />
-          </button>
-        )}
-      </div>
-
-      {isActive ? (
-        <div style={{ display: 'flex', gap: 8 }}>
-          <button
-            onClick={onComplete}
-            style={{ flex: 2, height: 52, borderRadius: 14, border: 'none', background: 'var(--brand)', color: '#FFFCF6', fontWeight: 700, fontSize: 15, fontFamily: 'inherit', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6 }}
-          >
-            <Check size={16} weight="bold" /> 완료
-          </button>
-          <button
-            onClick={onPartial}
-            aria-label="일부만 함"
-            style={{ width: 52, height: 52, borderRadius: 14, border: '1px solid var(--sand-200)', background: 'var(--surface-ground)', color: 'var(--text-2)', fontSize: 16, fontFamily: 'inherit', cursor: 'pointer' }}
-          >◑</button>
-          <button
-            onClick={onFail}
-            aria-label="잘 안됨"
-            style={{ width: 52, height: 52, borderRadius: 14, border: '1px solid var(--coral-200)', background: '#FAE2D8', color: 'var(--danger)', fontSize: 16, fontFamily: 'inherit', cursor: 'pointer' }}
-          >✗</button>
-        </div>
-      ) : (
-        <button
-          onClick={() => onStart(task.id)}
-          style={{ width: '100%', height: 52, borderRadius: 14, border: 'none', background: 'var(--text-1)', color: '#FAF6EE', fontWeight: 700, fontSize: 15, fontFamily: 'inherit', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6 }}
-        >
-          시작하기 <CaretRight size={14} />
-        </button>
-      )}
-    </div>
-  );
-}
-
-// ── Task Row (한 줄 list 아이템) ──────────────────────────────
-// 클릭 동작 분기:
-//   - done: 무반응
-//   - failed: 회복 제안 화면으로
-//   - partial_done / recovery_pending: 회복 제안 화면으로
-//   - todo: hero 로 promote (실제 시작은 hero CTA 에서)
-function TaskRow({
-  task, onSelect, onFailedRecover, onPartialRecover,
-}: {
-  task: Task;
-  onSelect: () => void;
-  onFailedRecover: () => void;
-  onPartialRecover: () => void;
-}) {
-  const done = task.status === 'done';
-  const failed = task.status === 'failed';
-  const partial = task.status === 'partial_done' || task.status === 'recovery_pending';
-  const inProgress = task.status === 'in_progress';
-  const onClick = done ? undefined : failed ? onFailedRecover : partial ? onPartialRecover : onSelect;
-
-  return (
-    <button
-      onClick={onClick}
-      disabled={done}
-      style={{
-        display: 'flex', alignItems: 'center', gap: 12, width: '100%',
-        padding: '10px 14px', borderRadius: 12, border: 'none',
-        background: 'transparent', cursor: done ? 'default' : 'pointer',
-        fontFamily: 'inherit', textAlign: 'left',
-      }}
-    >
-      <span style={{ width: 18, height: 18, borderRadius: 9999, flexShrink: 0, border: done ? 'none' : `1.5px solid ${failed ? 'var(--danger)' : inProgress || partial ? 'var(--brand)' : 'var(--sand-300)'}`, background: done ? 'var(--success)' : 'transparent', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-        {done && <Check size={11} weight="bold" color="#FFFCF6" />}
-        {failed && <span style={{ fontSize: 11, color: 'var(--danger)', fontWeight: 700 }}>✗</span>}
-        {(partial || inProgress) && <span style={{ width: 8, height: 8, borderRadius: 9999, background: 'var(--brand)' }} />}
-      </span>
-      <span style={{ flex: 1, fontSize: 14, color: done ? 'var(--text-3)' : failed ? 'var(--danger)' : 'var(--text-1)', textDecoration: done ? 'line-through' : 'none', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', fontWeight: partial ? 600 : 500 }}>{task.title}</span>
-      {task.time && <span className="tnum" style={{ fontSize: 11, color: 'var(--text-4)', flexShrink: 0 }}>{task.time}</span>}
-    </button>
   );
 }

--- a/src/screens/WeeklyCalendarScreen.tsx
+++ b/src/screens/WeeklyCalendarScreen.tsx
@@ -1,10 +1,13 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { Plus } from '@phosphor-icons/react';
-import { DAYS_KO, DEFAULT_GOAL_CATEGORY, goalColor } from '../data';
+import { DEFAULT_GOAL_CATEGORY, goalColor } from '../data';
 import { ApiError, goalsApi, plansApi } from '../lib/api';
 import { localDateStr } from '../lib/dates';
 import { DemoNotice } from '../components/DemoNotice';
 import { BlockEditSheet } from '../components/BlockEditSheet';
+import { WeekGrid, type WeekGridBlock } from '../components/WeekGrid';
+import { EmptyState } from '../components/EmptyState';
+import { Toast } from '../components/Toast';
 import { useNavigation } from '../contexts/NavigationContext';
 import type { Block } from '../types';
 import type { WeeklyPlanResponse, BlockEditRequest, ApiGoal } from '../types/api';
@@ -157,7 +160,6 @@ export function WeeklyCalendarScreenV2() {
 
   const parseMin = (t: string) => { const [h, m] = t.split(':').map(Number); return h * 60 + m; };
   const toY = (m: number) => (m - START_H * 60) * HOUR_PX / 60;
-  const hours = Array.from({ length: END_H - START_H }, (_, i) => START_H + i);
 
   // 그리드가 0시(자정)부터라 그냥 두면 새벽 빈 칸부터 보인다 — 로드 후 유용한
   // 시간대로 스크롤을 맞춘다: 이번 주면 현재 시각, 아니면 오전 8시(6~20시로 클램프).
@@ -178,6 +180,24 @@ export function WeeklyCalendarScreenV2() {
     // category 는 대부분 'other' 라 목표별 구분이 안 됐다. 없으면 블록 category fallback.
     const cat = (b.goalId && goalMap[b.goalId]?.category) || b.goal;
     return goalColor(cat);
+  };
+
+  // 화면 Block → WeekGrid 가 받는 모양. 드래그 중이면 고스트 위치로 미리 옮겨 그린다.
+  const toGridBlock = (b: BlockWithStatus): WeekGridBlock => {
+    const dragging = dragGhost?.id === b.id;
+    const tMin = dragging ? dragGhost!.minute : parseMin(b.time);
+    return {
+      id: b.id,
+      col: dragging ? dragGhost!.day : b.day,
+      startMin: tMin,
+      durMin: b.dur,
+      title: b.title,
+      glyph: b.status === 'done' ? '✓ ' : b.status === 'failed' ? '✗ ' : b.carryover ? '↩ ' : undefined,
+      subLabel: `${dragging ? formatHHMM(tMin) : b.time}·${b.dur}분`,
+      colors: blockStyle(b),
+      dragging,
+      fixed: b.fixed,
+    };
   };
 
   // ── Drag&drop 15분 snap ──────────────────────────────────────
@@ -438,8 +458,10 @@ export function WeeklyCalendarScreenV2() {
           </div>
         )}
         {!planLoading && usingRealPlan && blocks.length === 0 && (
-          <div style={{ marginBottom: 8, padding: '10px 12px', borderRadius: 12, background: 'var(--surface-raised)', border: '1px dashed var(--sand-200)', fontSize: 12, color: 'var(--text-2)', lineHeight: 1.5 }}>
-            이번 주에 등록된 계획이 없어요. 온보딩에서 주간 계획을 생성하거나, 우측 하단 + 버튼으로 추가해보세요.
+          <div style={{ marginBottom: 8 }}>
+            <EmptyState>
+              이번 주에 등록된 계획이 없어요. 온보딩에서 주간 계획을 생성하거나, 우측 하단 + 버튼으로 추가해보세요.
+            </EmptyState>
           </div>
         )}
         <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
@@ -453,122 +475,23 @@ export function WeeklyCalendarScreenV2() {
         </div>
       </div>
 
-      {/* Day header */}
-      <div style={{ flexShrink: 0, display: 'flex', borderBottom: '1px solid var(--sand-200)' }}>
-        <div style={{ width: TIME_W, flexShrink: 0 }} />
-        {DAYS_KO.map((d, i) => {
-          const isToday = isThisWeek && i === TODAY;
-          return (
-            <div key={d} style={{ width: COL_W, flexShrink: 0, display: 'flex', flexDirection: 'column', alignItems: 'center', padding: '6px 0', background: isToday ? 'rgba(226,109,78,0.04)' : 'transparent' }}>
-              <div style={{ fontSize: 8, fontFamily: 'var(--font-mono)', letterSpacing: '0.08em', color: isToday ? 'var(--brand)' : 'var(--text-3)', marginBottom: 3 }}>{d}</div>
-              <div className="tnum" style={{ width: 22, height: 22, borderRadius: 9999, background: isToday ? 'var(--brand)' : 'transparent', display: 'flex', alignItems: 'center', justifyContent: 'center', fontWeight: 700, fontSize: 11, color: isToday ? '#FFFCF6' : 'var(--text-1)' }}>{dayNumbers[i]}</div>
-            </div>
-          );
-        })}
-      </div>
-
-      {/* Grid */}
-      <div ref={gridRef} style={{ flex: 1, overflowY: 'auto' }}>
-        <div style={{ display: 'flex', minWidth: TIME_W + COL_W * 7 }}>
-          <div style={{ width: TIME_W, flexShrink: 0, background: 'var(--surface-ground)' }}>
-            {hours.map((h) => (
-              <div key={h} style={{ height: HOUR_PX, display: 'flex', alignItems: 'flex-start', paddingTop: 4, justifyContent: 'flex-end', paddingRight: 4 }}>
-                <span className="tnum" style={{ fontSize: 8, color: 'var(--text-3)', fontFamily: 'var(--font-mono)' }}>{h}</span>
-              </div>
-            ))}
-          </div>
-          <div style={{ flex: 1, position: 'relative', minWidth: COL_W * 7 }}>
-            {hours.map((h, i) => (
-              <div key={h} style={{ position: 'absolute', left: 0, right: 0, top: i * HOUR_PX, height: 1, background: 'var(--sand-200)' }} />
-            ))}
-            {DAYS_KO.map((d, i) => (
-              <div key={d} style={{ position: 'absolute', left: i * COL_W, top: 0, bottom: 0, width: 1, background: 'var(--sand-200)' }} />
-            ))}
-            {isThisWeek && <div style={{ position: 'absolute', left: TODAY * COL_W, top: 0, bottom: 0, width: COL_W, background: 'rgba(226,109,78,0.03)' }} />}
-            {/* 로딩 중: weekly 페치가 settle 될 때까지 더미/실데이터 대신 스켈레톤 placeholder.
-                pulse @keyframes 가 index.css 에 없어 정적 muted 박스로 처리(전역 CSS 미추가). */}
-            {planLoading && [
-              { day: 0, min: 14 * 60, dur: 60 },
-              { day: 1, min: 16 * 60, dur: 90 },
-              { day: 2, min: 15 * 60, dur: 45 },
-              { day: 3, min: 18 * 60, dur: 60 },
-              { day: 4, min: 14 * 60 + 30, dur: 75 },
-              { day: 5, min: 20 * 60, dur: 60 },
-            ].map((s, i) => {
-              const y = toY(s.min);
-              const bh = Math.max((s.dur * HOUR_PX / 60) - 2, 20);
-              return (
-                <div
-                  key={`sk-${i}`}
-                  aria-hidden
-                  style={{
-                    position: 'absolute',
-                    left: s.day * COL_W + 2,
-                    top: y + 1,
-                    width: COL_W - 4,
-                    height: bh,
-                    borderRadius: 6,
-                    background: i % 2 === 0 ? 'var(--sand-100)' : 'var(--surface-raised)',
-                    border: '1px solid var(--sand-200)',
-                    opacity: 0.7,
-                    zIndex: 1,
-                  }}
-                />
-              );
-            })}
-            {/* Now line — 이번 주 + 현재 시각이 START_H~END_H 구간일 때만 노출 */}
-            {!planLoading && isThisWeek && nowMin >= START_H * 60 && nowMin <= END_H * 60 && (
-              <div style={{ position: 'absolute', left: TODAY * COL_W, width: COL_W, top: toY(nowMin), height: 2, background: 'var(--brand)', borderRadius: 9999, zIndex: 5 }}>
-                <div style={{ position: 'absolute', left: -3, top: -3, width: 7, height: 7, borderRadius: 9999, background: 'var(--brand)' }} />
-              </div>
-            )}
-            {!planLoading && blocks.map((b) => {
-              // 드래그 중인 블록은 ghost 위치로 미리 표시.
-              const isDragging = dragGhost?.id === b.id;
-              const day = isDragging ? dragGhost!.day : b.day;
-              const tMin = isDragging ? dragGhost!.minute : parseMin(b.time);
-              const y = toY(tMin);
-              if (y < 0) return null;
-              const bh = Math.max((b.dur * HOUR_PX / 60) - 2, 20);
-              const c = blockStyle(b);
-              return (
-                <button
-                  key={b.id}
-                  // onPointerDown 으로 drag/click 둘 다 처리. onClick 은 dragMovedRef 가
-                  // false 일 때만 pointerup 안에서 setEditing 호출.
-                  onPointerDown={(e) => handleBlockPointerDown(e, b)}
-                  style={{
-                    position: 'absolute',
-                    left: day * COL_W + 2,
-                    top: y + 1,
-                    width: COL_W - 4,
-                    height: bh,
-                    background: c.bg,
-                    border: `1.5px ${isDragging ? 'dashed' : 'solid'} ${c.bd}`,
-                    borderRadius: 6,
-                    padding: '3px 4px',
-                    cursor: b.fixed ? 'pointer' : isDragging ? 'grabbing' : 'grab',
-                    textAlign: 'left',
-                    overflow: 'hidden',
-                    fontFamily: 'inherit',
-                    opacity: isDragging ? 0.85 : 1,
-                    boxShadow: isDragging ? '0 4px 12px rgba(0,0,0,0.15)' : 'none',
-                    zIndex: isDragging ? 10 : 1,
-                    touchAction: 'none', // 모바일에서 스크롤과 충돌 방지.
-                    transition: isDragging ? 'none' : 'box-shadow 120ms',
-                  }}
-                >
-                  <div style={{ fontSize: 8, fontWeight: 700, color: c.fg, lineHeight: 1.3, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: bh > 36 ? 'normal' : 'nowrap' }}>
-                    {b.status === 'done' ? '✓ ' : b.status === 'failed' ? '✗ ' : b.carryover ? '↩ ' : ''}{b.title}
-                  </div>
-                  {bh > 36 && <div className="tnum" style={{ fontSize: 7, color: c.fg, opacity: 0.7, marginTop: 1, fontFamily: 'var(--font-mono)' }}>{isDragging ? formatHHMM(tMin) : b.time}·{b.dur}분</div>}
-                </button>
-              );
-            })}
-            <div style={{ height: hours.length * HOUR_PX + HOUR_PX }} />
-          </div>
-        </div>
-      </div>
+      <WeekGrid
+        scrollRef={gridRef}
+        blocks={blocks.map(toGridBlock)}
+        dayNumbers={dayNumbers}
+        todayCol={isThisWeek ? TODAY : null}
+        nowMin={nowMin}
+        startHour={START_H}
+        endHour={END_H}
+        hourPx={HOUR_PX}
+        colWidth={COL_W}
+        timeWidth={TIME_W}
+        loading={planLoading}
+        onBlockPointerDown={(e, gb) => {
+          const b = blocks.find((x) => x.id === gb.id);
+          if (b) handleBlockPointerDown(e, b);
+        }}
+      />
 
       {/* Add FAB */}
       <button onClick={addBlock} style={{ position: 'absolute', right: 18, bottom: 90, width: 48, height: 48, borderRadius: 9999, border: 'none', background: 'var(--brand)', color: '#FFFCF6', cursor: 'pointer', boxShadow: 'var(--shadow-lg)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 5 }}>
@@ -588,24 +511,23 @@ export function WeeklyCalendarScreenV2() {
       )}
 
       {toast && (
-        <div style={{ position: 'absolute', left: 0, right: 0, bottom: 80, display: 'flex', justifyContent: 'center', zIndex: 80, pointerEvents: 'none', padding: '0 16px' }}>
-          <div style={{
-            background: toast.tone === 'error' ? 'var(--danger)' : 'var(--text-1)',
-            color: '#FAF6EE',
-            borderRadius: 12,
-            padding: '10px 18px',
-            fontSize: 13,
-            fontWeight: 500,
-            display: 'flex',
-            alignItems: 'center',
-            gap: 8,
-            boxShadow: 'var(--shadow-lg)',
-            maxWidth: '90%',
-          }}>
-            <span style={{ width: 6, height: 6, background: toast.tone === 'error' ? '#FFFCF6' : 'var(--success)', borderRadius: 9999, flexShrink: 0 }} />
-            <span style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>{toast.msg}</span>
-          </div>
-        </div>
+        <Toast
+          tone={toast.tone === 'error' ? 'error' : 'neutral'}
+          bottom={80}
+          icon={
+            <span
+              style={{
+                width: 6,
+                height: 6,
+                background: toast.tone === 'error' ? '#FFFCF6' : 'var(--success)',
+                borderRadius: 9999,
+                flexShrink: 0,
+              }}
+            />
+          }
+        >
+          <span style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>{toast.msg}</span>
+        </Toast>
       )}
     </div>
   );

--- a/src/screens/WeeklyPlanGenerationScreen.tsx
+++ b/src/screens/WeeklyPlanGenerationScreen.tsx
@@ -1,10 +1,11 @@
 import React, { useState, useEffect } from 'react';
 import { Clock, Lightbulb } from '@phosphor-icons/react';
-import { DAYS_KO, DEFAULT_GOAL_CATEGORY, categoryLabel, goalColor } from '../data';
+import { DEFAULT_GOAL_CATEGORY, categoryLabel, goalColor } from '../data';
 import { SetupProgress } from '../components/SetupProgress';
 import { AiDraftCard } from '../components/AiDraftCard';
 import { DemoNotice } from '../components/DemoNotice';
 import { BlockEditSheet } from '../components/BlockEditSheet';
+import { WeekGrid, type WeekGridBlock } from '../components/WeekGrid';
 import { ApiError, plansApi } from '../lib/api';
 import { localDateStr } from '../lib/dates';
 import { useNavigation } from '../contexts/NavigationContext';
@@ -248,7 +249,6 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
   const SNAP_MIN = 15; // 15분 snap (메인 캘린더와 동일)
   const parseMin = (t: string) => { const [h, m] = t.split(':').map(Number); return h * 60 + m; };
   const toY = (m: number) => (m - START_H * 60) * HOUR_PX / 60;
-  const hours = Array.from({ length: END_H - START_H }, (_, i) => START_H + i);
 
   // 그리드가 0시(자정)부터라 그냥 두면 새벽 빈 칸부터 보인다 — 생성이 끝나면
   // 가장 이른 블록(없으면 오전 8시) 근처로 스크롤을 맞춘다.
@@ -289,6 +289,23 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
   // 표시 주에 속하는 블록만 컬럼과 함께. 편집 시트가 요일(day)로 동작하므로 day=col 로 맞춘다.
   const weekBlocks = blocks.map((b) => ({ b, col: colOf(b) })).filter((x) => x.col >= 0);
   const weekExisting = existingBlocks.map((b) => ({ b, col: colOf(b) })).filter((x) => x.col >= 0);
+
+  // 화면 Block → WeekGrid 가 받는 모양. backdrop(기존 계획)은 muted 로 넘겨 뒤에 흐리게 깔린다.
+  const toGridBlock = (b: Block, col: number, muted = false): WeekGridBlock => {
+    const dragging = dragGhost?.id === b.id;
+    return {
+      id: b.id,
+      col: dragging ? dragGhost!.day : col,
+      startMin: dragging ? dragGhost!.minute : parseMin(b.time),
+      durMin: b.dur,
+      title: b.title,
+      subLabel: `${b.time}·${b.dur}분`,
+      colors: b.fixed ? { bg: 'var(--sand-100)', bd: 'var(--sand-300)', fg: 'var(--text-3)' } : goalColor(b.goal),
+      muted,
+      dragging,
+      fixed: b.fixed,
+    };
+  };
   // 계획 전체의 주 범위(이번 주 월요일 기준 offset) — 이전/다음 주 버튼 활성 판단.
   const thisMonday = new Date(_now);
   thisMonday.setHours(0, 0, 0, 0);
@@ -432,71 +449,22 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
         )}
       </div>
 
-      {/* Day headers — 주간 캘린더(WeeklyCalendarScreen)와 동일하게 요일 아래 날짜 숫자 +
-          오늘 강조를 보여준다. */}
-      <div style={{ flexShrink: 0, display: 'flex', borderBottom: '1px solid var(--sand-200)' }}>
-        <div style={{ width: TIME_W, flexShrink: 0 }} />
-        {DAYS_KO.map((d, i) => {
-          const isToday = i === TODAY;
-          return (
-            <div key={d} style={{ width: COL_W, flexShrink: 0, display: 'flex', flexDirection: 'column', alignItems: 'center', padding: '6px 0', background: isToday ? 'rgba(226,109,78,0.04)' : 'transparent' }}>
-              <div style={{ fontSize: 8, fontFamily: 'var(--font-mono)', letterSpacing: '0.08em', color: isToday ? 'var(--brand)' : 'var(--text-3)', marginBottom: 3 }}>{d}</div>
-              <div className="tnum" style={{ width: 22, height: 22, borderRadius: 9999, background: isToday ? 'var(--brand)' : 'transparent', display: 'flex', alignItems: 'center', justifyContent: 'center', fontWeight: 700, fontSize: 11, color: isToday ? '#FFFCF6' : 'var(--text-1)' }}>{dayNumbers[i]}</div>
-            </div>
-          );
-        })}
-      </div>
-
-      {/* Calendar grid */}
-      <div ref={gridRef} style={{ flex: 1, overflowY: 'auto' }}>
-        <div style={{ display: 'flex', minWidth: TIME_W + COL_W * 7 }}>
-          <div style={{ width: TIME_W, flexShrink: 0, background: 'var(--surface-ground)' }}>
-            {hours.map((h) => (
-              <div key={h} style={{ height: HOUR_PX, display: 'flex', alignItems: 'flex-start', paddingTop: 4, justifyContent: 'flex-end', paddingRight: 4 }}>
-                <span className="tnum" style={{ fontSize: 8, color: 'var(--text-3)', fontFamily: 'var(--font-mono)' }}>{h}</span>
-              </div>
-            ))}
-          </div>
-          <div style={{ flex: 1, position: 'relative', minWidth: COL_W * 7 }}>
-            {hours.map((h, i) => (
-              <div key={h} style={{ position: 'absolute', left: 0, right: 0, top: i * HOUR_PX, height: 1, background: 'var(--sand-200)' }} />
-            ))}
-            {DAYS_KO.map((d, i) => (
-              <div key={d} style={{ position: 'absolute', left: i * COL_W, top: 0, bottom: 0, width: 1, background: 'var(--sand-200)' }} />
-            ))}
-            {/* 기존 계획 — 흐리게·점선·클릭 불가로 draft 뒤에 깔아둔다(#103). 표시 주만(#119). */}
-            {weekExisting.map(({ b, col }) => {
-              const tMin = parseMin(b.time);
-              const y = toY(tMin);
-              if (y < 0) return null;
-              const bh = Math.max((b.dur * HOUR_PX / 60) - 2, 20);
-              const c = b.fixed ? { bg: 'var(--sand-100)', bd: 'var(--sand-300)', fg: 'var(--text-3)' } : goalColor(b.goal);
-              return (
-                <div key={b.id} aria-hidden style={{ position: 'absolute', left: col * COL_W + 2, top: y + 1, width: COL_W - 4, height: bh, background: c.bg, border: `1.5px dashed ${c.bd}`, borderRadius: 6, padding: '3px 4px', overflow: 'hidden', opacity: 0.38, pointerEvents: 'none' }}>
-                  <div style={{ fontSize: 8, fontWeight: 700, color: c.fg, lineHeight: 1.3, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: bh > 32 ? 'normal' : 'nowrap' }}>{b.title}</div>
-                </div>
-              );
-            })}
-            {weekBlocks.map(({ b, col }) => {
-              // 드래그 중이면 블록 자신을 고스트 위치(dragGhost)에 렌더(메인 캘린더와 동일).
-              const isDragging = dragGhost?.id === b.id;
-              const dcol = isDragging ? dragGhost!.day : col;
-              const tMin = isDragging ? dragGhost!.minute : parseMin(b.time);
-              const y = toY(tMin);
-              if (y < 0) return null;
-              const bh = Math.max((b.dur * HOUR_PX / 60) - 2, 20);
-              const c = b.fixed ? { bg: 'var(--sand-100)', bd: 'var(--sand-300)', fg: 'var(--text-3)' } : goalColor(b.goal);
-              return (
-                <button key={b.id} onPointerDown={(e) => handleBlockPointerDown(e, b, col)} style={{ position: 'absolute', left: dcol * COL_W + 2, top: y + 1, width: COL_W - 4, height: bh, background: c.bg, border: `1.5px solid ${c.bd}`, borderRadius: 6, padding: '3px 4px', cursor: b.fixed ? 'pointer' : 'grab', touchAction: 'none', overflow: 'hidden', textAlign: 'left', fontFamily: 'inherit', transition: isDragging ? 'none' : 'box-shadow 120ms, transform 120ms', boxShadow: isDragging ? 'var(--shadow-lg)' : undefined, zIndex: isDragging ? 4 : undefined }}>
-                  <div style={{ fontSize: 8, fontWeight: 700, color: c.fg, lineHeight: 1.3, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: bh > 32 ? 'normal' : 'nowrap' }}>{b.title}</div>
-                  {bh > 32 && <div className="tnum" style={{ fontSize: 7, color: c.fg, opacity: 0.7, marginTop: 1, fontFamily: 'var(--font-mono)' }}>{b.time}·{b.dur}분</div>}
-                </button>
-              );
-            })}
-            <div style={{ height: hours.length * HOUR_PX + HOUR_PX }} />
-          </div>
-        </div>
-      </div>
+      <WeekGrid
+        scrollRef={gridRef}
+        blocks={weekBlocks.map(({ b, col }) => toGridBlock(b, col))}
+        backdrop={weekExisting.map(({ b, col }) => toGridBlock(b, col, true))}
+        dayNumbers={dayNumbers}
+        todayCol={TODAY >= 0 ? TODAY : null}
+        startHour={START_H}
+        endHour={END_H}
+        hourPx={HOUR_PX}
+        colWidth={COL_W}
+        timeWidth={TIME_W}
+        onBlockPointerDown={(e, gb) => {
+          const hit = weekBlocks.find((x) => x.b.id === gb.id);
+          if (hit) handleBlockPointerDown(e, hit.b, hit.col);
+        }}
+      />
 
       {/* AI Draft footer — Issue #12 §1.4 잠금 결정 시각화.
           onAccept 은 우리 handleContinue (plansApi.approve mock-and-replace 포함) 사용.

--- a/src/screens/WeeklyReviewScreen.tsx
+++ b/src/screens/WeeklyReviewScreen.tsx
@@ -1,3 +1,5 @@
+import { ScoreDonut } from '../components/ScoreDonut';
+import { SectionHeader } from '../components/SectionHeader';
 import React, { useEffect, useState } from 'react';
 import { Sparkle, ArrowRight } from '@phosphor-icons/react';
 import { reviewsApi } from '../lib/api';
@@ -40,33 +42,6 @@ function windowLabel(raw: string): string {
   return raw;
 }
 
-// ── Score Donut ────────────────────────────────────────────────
-function ScoreDonut({ score, size = 120, stroke = 12 }: { score: number; size?: number; stroke?: number }) {
-  const r = (size - stroke) / 2;
-  const c = 2 * Math.PI * r;
-  return (
-    <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`} style={{ flexShrink: 0 }}>
-      <circle cx={size / 2} cy={size / 2} r={r} stroke="var(--sand-200)" strokeWidth={stroke} fill="none" />
-      <circle
-        cx={size / 2} cy={size / 2} r={r} stroke="var(--brand)" strokeWidth={stroke} fill="none"
-        strokeLinecap="round" strokeDasharray={c} strokeDashoffset={c * (1 - score / 100)}
-        transform={`rotate(-90 ${size / 2} ${size / 2})`}
-        style={{ transition: 'stroke-dashoffset 800ms ease-out' }}
-      />
-      <text x={size / 2} y={size / 2 - 3} textAnchor="middle" fontSize="30" fontWeight="800" fill="var(--text-1)" fontFamily="Pretendard Variable" style={{ letterSpacing: '-0.04em', fontVariantNumeric: 'tabular-nums' }}>{score}</text>
-      <text x={size / 2} y={size / 2 + 15} textAnchor="middle" fontSize="10" fill="var(--text-3)" fontFamily="Pretendard Variable" letterSpacing="0.06em">/ 100</text>
-    </svg>
-  );
-}
-
-// ── Section label ──────────────────────────────────────────────
-function SectionLabel({ children }: { children: React.ReactNode }) {
-  return (
-    <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--text-3)', fontFamily: 'var(--font-mono)', marginBottom: 10 }}>
-      {children}
-    </div>
-  );
-}
 
 // 0~1 비율이면 %로, 이미 0~100이면 그대로.
 function toPct(v: number | null | undefined): number | null {
@@ -281,7 +256,7 @@ export function WeeklyReviewScreenV2() {
         {/* 카테고리별 성공률 — 백엔드 categorySuccessRate 실데이터. */}
         {real?.categorySuccessRate && Object.keys(real.categorySuccessRate).length > 0 && (
           <div style={{ background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', borderRadius: 14, padding: '12px 14px' }}>
-            <SectionLabel>카테고리별 성공률</SectionLabel>
+            <SectionHeader>카테고리별 성공률</SectionHeader>
             <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginTop: 8 }}>
               {Object.entries(real.categorySuccessRate).map(([cat, rate]) => {
                 const pct = toPct(rate) ?? 0;


### PR DESCRIPTION
## 작업 배경

직전 PR(#169)로 디자인 시스템을 claude.ai/design 에 올렸는데, 올라간 15개가
전부 버튼·칩 같은 **범용 조각**이라 정작 **우리 실제 화면을 조립할 수가 없었습니다.**
화면 UI 6,600줄이 전부 화면 파일 안에 인라인이었기 때문입니다.

16개를 뽑아 화면이 그걸 쓰도록 배선했습니다. **디자인 시스템 15 → 31개.**

## 추출한 것

**화면 주역**

| 컴포넌트 | 어디서 뽑았나 |
|---|---|
| `WeekGrid` | `WeeklyCalendarScreen` + `WeeklyPlanGenerationScreen` (**중복 제거**) |
| `HeroTaskCard` · `TaskRow` · `ProgressSheet` | `TodayScreen` |
| `RecoveryOptionCard` | `RecoveryScreen` |
| `InboxItemCard` + `InboxAction` | `InboxScreen` |
| `GoalCard` | `GoalsScreen` |
| `ScoreDonut` | `WeeklyReviewScreen` |

**상태 표현·입력**
`EmptyState` `ErrorBanner` `SkeletonBlock` `Toast` `TextField` `Toggle` `IconAction`

## 중복 실측 — 왜 이걸 했나

- **주간 시간표가 2개 화면에 통째로 복붙**돼 있었습니다. `HOUR_PX=56` `COL_W=50` `TIME_W=30`
  전부 동일한 값이 양쪽에 각각. 이제 하나뿐이고, **넓게 쓰려면 `colWidth` prop 하나만** 올리면 됩니다.
- **에러 배너(`#FAE2D8`)가 11개 화면**에 각자 인라인
- **빈 상태 점선 박스 10개 화면**, **스켈레톤 6개 화면**이 각자 구현
- `SectionLabel` 이 두 화면에 따로 정의돼 있어 기존 `SectionHeader` 로 흡수(`icon`·`tone` prop 추가)

**화면 코드 순 397줄 감소** (675 삭제 / 278 추가), 번들 689 → 686 kB.

## 곁다리로 잡은 것 3가지

**1. 죽은 코드** — `TodayScreen` 의 `Ring` 은 정의만 되고 **아무데서도 안 쓰였습니다.**
`noUnusedLocals: false` 라 경고가 안 났습니다. 삭제했고, 같은 이유로 DS 에도 안 넣었습니다
(앱이 안 쓰는 컴포넌트를 DS 에 올리면 디자인 툴이 코드에 없는 부품으로 화면을 그리게 됩니다).

**2. 대비** — 작은 글씨에 쓰이던 `var(--brand)` 를 `var(--coral-700)` 로 바꿨습니다.
코랄-500 은 크림 배경에서 **2.98:1 로 WCAG 미달**(#169 규약 문서에 실측치 있음).
**팔레트는 그대로, 명도만** 조정했습니다.

**3. 내부 enum 노출** — `ProgressSheet` 안내 문구
`저장 시 recovery_pending 으로 자동 전이돼요` → `저장 시 회복 대기 상태로 넘어가요`

## 검증

- `npx tsc --noEmit` — 0 errors
- `node scripts/check-api-contract.mjs` — **PASS**
- `npm run build` — 성공
- **Playwright 렌더 검증** — 리팩터로 건드린 **11개 화면 전부 렌더, 런타임 에러 0**
- **API 목킹 후 실데이터 렌더 확인** — today(주역카드+목록) / weekly(그리드+블록+현재시각선) /
  inbox(배지+액션) / goals(tier 배지) 전부 정상
- **DS 번들** — `window.ReActionDS` 31 exports, 프리뷰 **31/31 정상 렌더**, 검증 경고 0

## 리뷰어가 볼 것

대부분 **동작이 같은 순수 이동**입니다. 실제로 봐야 할 건 두 곳:

1. **`WeekGrid`** — 두 화면의 그리드를 하나로 합치면서 데이터 기반 API 로 바꿨습니다.
   드래그 로직(API 호출 포함)은 화면에 그대로 두고, `WeekGrid` 는 그리기만 합니다.
   각 화면은 `toGridBlock()` 매퍼로 자기 모델을 `WeekGridBlock` 으로 변환합니다.
2. **`GoalCard`** — 펼침 영역을 `children` 슬롯으로 바꿨습니다. 수정 폼·액션 패널은
   화면에 남아 있고 카드가 구분선·간격만 제공합니다.

## 별건으로 발견한 것 (이 PR 에 안 넣음)

`InboxScreen` 이 **자체 카테고리 라벨 맵**(`AI_CATEGORY_LABEL`)을 들고 있어
`src/data` 의 정본과 어긋납니다.

- `study` → 정본 "학습" vs 인박스 "학업"
- `career` 는 인박스 맵에 없어서 **화면에 영문 `career` 가 그대로 노출**됩니다

어느 쪽을 정본으로 할지가 제품 판단이라 이 PR 에서는 건드리지 않았습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
