### PR TITLE
fix: 내부 enum 화면 노출 제거 + 회복 화면 실패 배너 중립화

### DIFF
--- a/src/app/ReActionMerged.tsx
+++ b/src/app/ReActionMerged.tsx
@@ -181,7 +181,7 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
         failReason: failReason || activeTask.failReason || '',
         proposalTitle: proposal.title,
         proposalDesc: proposal.desc,
-        proposalTime: proposal.time,
+        proposalTime: proposal.time ?? '',
       });
       setTasks((ts) => ts.map((t) => t.id === activeTask.id ? { ...t, status: 'done' } : t));
     }

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -52,16 +52,49 @@ export const GOAL_CATEGORY_OPTIONS: { value: string; label: string }[] = [
   { value: 'other', label: '기타' },
 ];
 
-const GOAL_CATEGORY_LABEL: Record<string, string> = Object.fromEntries(
-  GOAL_CATEGORY_OPTIONS.map((c) => [c.value, c.label]),
-);
+// 인박스의 AI 카테고리 추측(aiCategoryGuess)에만 나오는 값들. 계약상 자유 문자열이라
+// enum 이 아니고, 목표로 고를 수 있는 카테고리도 아니어서 위 OPTIONS 에는 넣지 않는다.
+// 라벨은 필요하므로 여기 따로 둔다 — 예전엔 InboxScreen 이 자체 맵을 들고 있었고,
+// 그 맵에 없던 'career' 같은 값이 화면에 영문 그대로 노출됐다.
+const EXTRA_CATEGORY_LABEL: Record<string, string> = {
+  chore: '집안일',
+  social: '인간관계',
+  finance: '재정',
+  hobby: '취미',
+  work: '업무',
+  idea: '아이디어',
+};
+
+const GOAL_CATEGORY_LABEL: Record<string, string> = {
+  ...EXTRA_CATEGORY_LABEL,
+  // OPTIONS 가 뒤에 와서 충돌 시 정본이 이긴다(study = '학습').
+  ...Object.fromEntries(GOAL_CATEGORY_OPTIONS.map((c) => [c.value, c.label])),
+};
 
 // 미분류 기본 카테고리 — 한국어 리터럴 '기타' 대신 정식 값 'other' 를 쓴다.
 // (그래야 백엔드 'other' 블록과 같은 값이 되어 색·라벨이 하나로 합쳐진다.)
 export const DEFAULT_GOAL_CATEGORY = 'other';
 
-// 카테고리 값 → 한글 라벨. 알려진 값은 라벨로, 사용자 자유 문자열은 원문 그대로.
+// 내부 코드처럼 생긴 문자열 — 영소문자/숫자/언더스코어만. 사용자가 직접 친 자유
+// 텍스트("면접 준비")와 구분하는 용도.
+const LOOKS_LIKE_CODE = /^[a-z0-9_]+$/;
+
+// 카테고리 값 → 한글 라벨.
+//   알려진 값        → 라벨
+//   사용자 자유 문자열 → 원문 그대로(사용자가 쓴 말을 고치지 않는다)
+//   모르는 내부 코드   → '기타' (영문 enum 을 화면에 흘리지 않는다)
 export function categoryLabel(value: string | null | undefined): string {
   if (!value) return GOAL_CATEGORY_LABEL[DEFAULT_GOAL_CATEGORY];
-  return GOAL_CATEGORY_LABEL[value] ?? value;
+  const known = GOAL_CATEGORY_LABEL[value];
+  if (known) return known;
+  return LOOKS_LIKE_CODE.test(value) ? GOAL_CATEGORY_LABEL[DEFAULT_GOAL_CATEGORY] : value;
+}
+
+// 이 값을 한국어로 이름 붙일 수 있나. 카테고리를 **키로 나열하는** 화면(주간 리뷰의
+// 카테고리별 성공률 등)에서 필요하다 — 모르는 코드를 categoryLabel 로 넘기면 전부
+// '기타' 가 되어 같은 이름의 줄이 여러 개 생기고, 차트가 고장난 것처럼 보인다.
+// 배지 하나를 찍을 땐 categoryLabel 로 충분하다.
+export function isKnownCategory(value: string | null | undefined): boolean {
+  if (!value) return false;
+  return value in GOAL_CATEGORY_LABEL || !LOOKS_LIKE_CODE.test(value);
 }

--- a/src/screens/InboxScreen.tsx
+++ b/src/screens/InboxScreen.tsx
@@ -8,6 +8,7 @@ import { SkeletonBlock } from '../components/SkeletonBlock';
 import { ErrorBanner } from '../components/ErrorBanner';
 import { useNavigation } from '../contexts/NavigationContext';
 import type { InboxItem, InboxStatus } from '../types/api';
+import { categoryLabel } from '../data';
 
 // 인박스 탭 단순화(#129): 사용자 멘탈 모델("안 한 것/한 것/버린 것")에 맞춰 3개로.
 // - 할 일 = 아직 triage 안 한 활성 항목(status=classified). 세분화는 카테고리 칩(#112).
@@ -30,14 +31,7 @@ const STATUS_META: Record<InboxStatus, { label: string; bg: string; bd: string; 
 
 // AI 가 추정한 카테고리(aiCategoryGuess) — 백엔드가 고정 enum 없이 자유 문자열로 준다.
 // 알려진 값은 한글로, 모르는 값은 원문 그대로 보여준다(#68).
-const AI_CATEGORY_LABEL: Record<string, string> = {
-  schedule: '일정', project: '프로젝트', study: '학업', health: '건강',
-  chore: '집안일', social: '인간관계', finance: '재정', hobby: '취미',
-  work: '업무', idea: '아이디어', other: '기타',
-};
-function categoryLabel(raw: string): string {
-  return AI_CATEGORY_LABEL[raw] ?? raw;
-}
+
 
 // S24·S25 Life Inbox — 떠오르는 항목을 1줄로 캡처하고 AI 가 카테고리를 추정.
 // 사용자는 나중에 목표(Goal)로 승격하거나 보관할 수 있다.

--- a/src/screens/MorningBriefScreen.tsx
+++ b/src/screens/MorningBriefScreen.tsx
@@ -4,6 +4,7 @@ import { useNavigation } from '../contexts/NavigationContext';
 import { goalsApi, reviewsApi, todayApi } from '../lib/api';
 import { localDateStr } from '../lib/dates';
 import type { AgendaCard } from '../types/api';
+import { categoryLabel } from '../data';
 
 interface MorningBriefScreenProps {
   onStart: () => void;
@@ -183,7 +184,7 @@ export function MorningBriefScreen({ onStart }: MorningBriefScreenProps) {
                           <span style={{ height: 'var(--ctrl-xs)', padding: '0 8px', background: 'var(--sand-100)', border: '1px solid var(--sand-200)', borderRadius: 9999, fontSize: 10, color: 'var(--text-2)', fontWeight: 500, display: 'inline-flex', alignItems: 'center' }}>{b.dur}</span>
                         )}
                         {b.type && (
-                          <span style={{ height: 'var(--ctrl-xs)', padding: '0 8px', background: 'var(--sand-100)', border: '1px solid var(--sand-200)', borderRadius: 9999, fontSize: 10, color: 'var(--text-2)', fontWeight: 500, display: 'inline-flex', alignItems: 'center' }}>{b.type}</span>
+                          <span style={{ height: 'var(--ctrl-xs)', padding: '0 8px', background: 'var(--sand-100)', border: '1px solid var(--sand-200)', borderRadius: 9999, fontSize: 10, color: 'var(--text-2)', fontWeight: 500, display: 'inline-flex', alignItems: 'center' }}>{categoryLabel(b.type)}</span>
                         )}
                       </div>
                       <div style={{ fontSize: 14, fontWeight: 700, letterSpacing: '-0.01em', color: 'var(--text-1)' }}>{b.title}</div>

--- a/src/screens/RecoveryScreen.tsx
+++ b/src/screens/RecoveryScreen.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import {
   ArrowsClockwise,
-  XCircle,
+  Flag,
   Sparkle,
   Check,
   Info,
@@ -23,13 +23,33 @@ const GROUP_COLOR: Record<string, { bg: string; bc: string; ac: string }> = {
 };
 const DEFAULT_COLOR = { bg: 'var(--brand-soft)', bc: 'var(--coral-200)', ac: 'var(--brand)' };
 
-// 실패 태그 코드 → if-then 카드용 자연어 trigger("만약 …")
-const TRIGGER_LABEL: Record<string, string> = {
-  TIME_SHORTAGE: '시간이 부족했다면', LOW_ENERGY: '기운이 없었다면', HARD_TO_START: '시작이 막막했다면',
-  PRIORITY_SHIFT: '우선순위가 바뀌었다면', PLAN_TOO_BIG: '계획이 너무 컸다면', FATIGUE: '피곤했다면',
-  AMBIGUITY: '뭘 할지 모호했다면', CONFLICT: '일정이 겹쳤다면', OVERRUN: '시간이 초과됐다면',
-  AVOIDANCE: '미루게 됐다면', DISTRACTION: '집중이 흐트러졌다면', EMERGENCY: '급한 일이 생겼다면',
-  CONTEXT_LOSS: '맥락을 놓쳤다면',
+// 실패 태그 코드 → 사람이 읽는 두 가지 형태.
+//   ifClause — if-then 카드의 "만약 …" 조건절
+//   because  — [왜?] 패널에서 이 제안을 고른 이유를 설명하는 과거형
+// 백엔드는 태그를 자유 문자열로 주므로 여기 없는 값이 올 수 있다. 그럴 땐
+// 영문 코드를 화면에 흘리지 말고 그냥 생략한다(아래 cardToProposal 참고).
+const TRIGGER_KO: Record<string, { ifClause: string; because: string }> = {
+  TIME_SHORTAGE:  { ifClause: '시간이 부족했다면',      because: '지난번엔 시간이 모자랐어요.' },
+  LOW_ENERGY:     { ifClause: '기운이 없었다면',        because: '그때 기운이 많이 떨어져 있었어요.' },
+  HARD_TO_START:  { ifClause: '시작이 막막했다면',      because: '시작하는 게 제일 어려웠어요.' },
+  PRIORITY_SHIFT: { ifClause: '우선순위가 바뀌었다면',  because: '그날 더 급한 일이 앞섰어요.' },
+  PLAN_TOO_BIG:   { ifClause: '계획이 너무 컸다면',     because: '한 번에 하기엔 덩어리가 컸어요.' },
+  FATIGUE:        { ifClause: '피곤했다면',            because: '몸이 많이 지쳐 있었어요.' },
+  AMBIGUITY:      { ifClause: '뭘 할지 모호했다면',     because: '무엇부터 할지가 분명하지 않았어요.' },
+  CONFLICT:       { ifClause: '일정이 겹쳤다면',        because: '다른 일정과 시간이 겹쳤어요.' },
+  OVERRUN:        { ifClause: '시간이 초과됐다면',      because: '생각보다 시간이 더 걸렸어요.' },
+  AVOIDANCE:      { ifClause: '미루게 됐다면',          because: '자꾸 뒤로 미루게 됐어요.' },
+  DISTRACTION:    { ifClause: '집중이 흐트러졌다면',    because: '중간에 집중이 자주 끊겼어요.' },
+  EMERGENCY:      { ifClause: '급한 일이 생겼다면',     because: '갑자기 급한 일이 생겼어요.' },
+  CONTEXT_LOSS:   { ifClause: '맥락을 놓쳤다면',        because: '이어서 하려니 흐름이 끊겨 있었어요.' },
+};
+
+// optionGroup(백엔드 enum) → 이 방식이 왜 도움이 되는지. 코드값을 그대로 보여주지 않는다.
+const GROUP_WHY: Record<string, string> = {
+  DOWNSCOPE:  '크기를 줄이면 시작 문턱이 낮아져요.',
+  RESCHEDULE: '더 잘 되는 시간대로 옮겨요.',
+  CARRY_OVER: '오늘은 넘기고 내일 이어서 해요.',
+  PARK:       '지금은 접어두고, 여유가 생기면 다시 봐요.',
 };
 
 // 백엔드 RecoveryCard → 화면 RecoveryProposal. conf(성공률)는 백엔드 미제공 → 0(숨김).
@@ -43,10 +63,16 @@ function cardToProposal(c: RecoveryCard): RecoveryProposal {
     ac: col.ac,
     title: c.labelKo,
     desc: c.suggestedActionText,
-    why: c.triggerTag ? `감지된 패턴: ${c.triggerTag}` : `복구 전략: ${c.strategyType}`,
-    time: c.minRecoveryUnitMinutes ? `${c.minRecoveryUnitMinutes}분~` : '—',
+    // 예전엔 `감지된 패턴: TIME_SHORTAGE` 처럼 내부 코드를 그대로 보여줬다.
+    // 매핑되는 것만 한국어로 조립하고, 하나도 못 풀면 why 자체를 비워
+    // [왜?] 버튼이 아예 안 나오게 한다(영문 코드 노출 < 설명 없음).
+    why: [c.triggerTag ? TRIGGER_KO[c.triggerTag]?.because : null, GROUP_WHY[c.optionGroup]]
+      .filter(Boolean)
+      .join(' ') || undefined,
+    // 미상일 때 '—' 를 넣으면 버그처럼 보인다. 비워서 칩 자체가 안 나오게 한다.
+    time: c.minRecoveryUnitMinutes ? `${c.minRecoveryUnitMinutes}분~` : undefined,
     conf: 0,
-    trigger: c.triggerTag ? (TRIGGER_LABEL[c.triggerTag] ?? undefined) : undefined,
+    trigger: c.triggerTag ? TRIGGER_KO[c.triggerTag]?.ifClause : undefined,
   };
 }
 
@@ -196,11 +222,16 @@ export function MergedRecoveryScreen({ task, failReason, onAccept, onDismiss, ex
         <div style={{ position: 'absolute', inset: 0, background: 'radial-gradient(circle at 90% -10%, rgba(226,109,78,0.10) 0%, transparent 50%)', pointerEvents: 'none' }} />
         <div style={{ position: 'relative' }}>
           {task && (
-            <div style={{ display: 'flex', gap: 10, alignItems: 'center', marginBottom: 14, padding: '8px 10px', background: '#FAE2D8', border: '1px solid var(--coral-200)', borderRadius: 10 }}>
-              <XCircle size={14} color="var(--danger)" style={{ flexShrink: 0 }} />
+            // 여기는 "무엇이 멈췄나"를 알려주는 자리지 경고가 아니다. 예전엔 빨간 에러
+            // 박스(#FAE2D8 + danger 아이콘/글씨)라, 회복 화면에서 제일 먼저 보이는 게
+            // 빨간 경고였다 — 바로 아래 "괜찮아요" 카피와 정면으로 어긋난다.
+            // 사실만 중립 톤으로: 무엇을 · 언제 · 왜.
+            <div style={{ display: 'flex', gap: 10, alignItems: 'center', marginBottom: 14, padding: '9px 11px', background: 'var(--sand-100)', border: '1px solid var(--sand-200)', borderRadius: 10 }}>
+              <Flag size={14} color="var(--text-3)" weight="fill" style={{ flexShrink: 0 }} />
               <div style={{ flex: 1, minWidth: 0 }}>
-                <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--danger)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{task.title}</div>
-                {failReason && <div style={{ fontSize: 10, color: 'var(--text-3)' }}>이유: {failReason} · <span style={{ color: 'var(--brand)', fontWeight: 600 }}>실행 기록에 반영</span></div>}
+                <div style={{ fontSize: 9, fontWeight: 700, letterSpacing: '0.08em', color: 'var(--text-3)', fontFamily: 'var(--font-mono)', marginBottom: 1 }}>여기서 멈췄어요</div>
+                <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--text-1)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{task.title}</div>
+                {failReason && <div style={{ fontSize: 10, color: 'var(--text-3)', marginTop: 1 }}>{failReason} · 실행 기록에 남겼어요</div>}
               </div>
             </div>
           )}

--- a/src/screens/WeeklyReviewScreen.tsx
+++ b/src/screens/WeeklyReviewScreen.tsx
@@ -7,6 +7,7 @@ import { localDateStr } from '../lib/dates';
 import { DemoNotice } from '../components/DemoNotice';
 import { useNavigation } from '../contexts/NavigationContext';
 import type { WeeklyReviewResponse, HabitPenaltyCandidate } from '../types/api';
+import { categoryLabel, isKnownCategory } from '../data';
 
 // 이번 주 월요일 (YYYY-MM-DD)
 function thisMonday(): string {
@@ -116,6 +117,11 @@ export function WeeklyReviewScreenV2() {
         : '다음 주엔 다르게 해봐요';
 
   // 실데이터로 만든 KPI 그리드 (백엔드가 주는 지표만). trend 는 비교 데이터 없으면 빈값.
+  // 한국어 이름이 있는 카테고리만. (모르는 코드는 제외 — 위 주석 참고)
+  const namedCategoryRates = Object.entries(real?.categorySuccessRate ?? {}).filter(
+    ([cat]) => isKnownCategory(cat),
+  );
+
   const realKpi = real
     ? ([
         { label: '준수율', val: toPct(real.adherenceRate), target: 80, unit: '%' },
@@ -253,17 +259,20 @@ export function WeeklyReviewScreenV2() {
         </div>
         )}
 
-        {/* 카테고리별 성공률 — 백엔드 categorySuccessRate 실데이터. */}
-        {real?.categorySuccessRate && Object.keys(real.categorySuccessRate).length > 0 && (
+        {/* 카테고리별 성공률 — 백엔드 categorySuccessRate 실데이터.
+            이름 붙일 수 없는 코드는 빼고 보여준다. 전부 '기타' 로 접으면 같은 이름의
+            줄이 여러 개 생겨 차트가 고장난 것처럼 보이고, 이름 없는 줄은 사용자에게
+            알려주는 것도 없다. */}
+        {namedCategoryRates.length > 0 && (
           <div style={{ background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', borderRadius: 14, padding: '12px 14px' }}>
             <SectionHeader>카테고리별 성공률</SectionHeader>
             <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginTop: 8 }}>
-              {Object.entries(real.categorySuccessRate).map(([cat, rate]) => {
+              {namedCategoryRates.map(([cat, rate]) => {
                 const pct = toPct(rate) ?? 0;
                 return (
                   <div key={cat}>
                     <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 11, marginBottom: 3 }}>
-                      <span style={{ color: 'var(--text-2)', fontWeight: 600 }}>{cat}</span>
+                      <span style={{ color: 'var(--text-2)', fontWeight: 600 }}>{categoryLabel(cat)}</span>
                       <span className="tnum" style={{ color: 'var(--text-1)', fontWeight: 700 }}>{pct}%</span>
                     </div>
                     <div style={{ height: 6, background: 'var(--sand-200)', borderRadius: 9999, overflow: 'hidden' }}>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -118,8 +118,11 @@ export interface RecoveryProposal {
   ac: string;
   title: string;
   desc: string;
-  why: string;
-  time: string;
+  // 이 제안을 고른 이유. 백엔드 코드를 한국어로 못 푸는 경우엔 비운다 —
+  // 영문 enum 을 화면에 흘리느니 [왜?] 버튼을 아예 안 보여주는 쪽이 낫다.
+  why?: string;
+  // "20분~" 같은 시점·소요 요약. 백엔드가 안 주면 비운다 — '—' 를 넣으면 버그처럼 보인다.
+  time?: string;
   conf: number;
   // if-then 카드용 trigger(감지된 패턴). 있으면 "만약 [trigger] 이면, [desc]" 로 표시.
   trigger?: string;


### PR DESCRIPTION
## 작업 배경

UI/UX 점검에서 🔴 로 표시한 두 건입니다. 개편 승인과 무관하게 **버그에 가까워** 먼저 고칩니다.
(개편 4단계 중 1단계 — 리스크 낮은 순서)

## 1. 백엔드 enum 이 화면에 그대로 노출되던 곳

| 위치 | 노출되던 값 | 조치 |
|---|---|---|
| 회복 제안 **[왜?]** | `감지된 패턴: TIME_SHORTAGE`<br>`복구 전략: SPLIT_SMALLER` | 태그별 한국어 문장 + optionGroup 별 설명으로 조립 |
| 인박스 카테고리 배지·필터 | `career` | 정본 라벨맵 사용 → **커리어** |
| 주간 리뷰 카테고리별 성공률 | `other`, `study` | `categoryLabel` 적용 |
| 모닝 브리프 블록 배지 | 카테고리 원문 | `categoryLabel` 적용 |

**회복 [왜?]** 는 매핑되는 것만 한국어로 조립하고, 하나도 못 풀면 `why` 를 비워
**[왜?] 버튼 자체를 감춥니다.** 영문 코드를 보여주느니 설명이 없는 편이 낫습니다.

**인박스**는 자체 라벨맵을 들고 있어 `src/data` 정본과 어긋나 있었습니다.

- `study` — 정본 "학습" vs 인박스 "학업"
- `career` — 인박스 맵에 없어서 **영문 그대로 노출**

자체 맵을 지우고 정본을 쓰되, 인박스에만 있던 6개(집안일·인간관계·재정·취미·업무·아이디어)는
정본에 흡수했습니다. **목표 드롭다운(`GOAL_CATEGORY_OPTIONS`)은 건드리지 않았습니다** —
목표로 고를 수 있는 카테고리와 AI 가 추측하는 카테고리는 다른 집합입니다.

### `categoryLabel` 폴백 규칙을 명시

```
알려진 값          → 라벨
사용자 자유 문자열   → 원문 그대로   (사용자가 쓴 말을 고치지 않는다)
모르는 내부 코드     → '기타'        (영문 enum 을 흘리지 않는다)
```

카테고리를 **키로 나열하는** 화면(리뷰 차트)은 `isKnownCategory` 로 걸러냅니다.
모르는 코드를 전부 '기타' 로 접으면 **같은 이름의 줄이 여러 개** 생겨 차트가 고장난 것처럼
보입니다 — 실제로 그렇게 찍혔습니다.

| 고치기 전 | 고친 후 |
|---|---|
| 학습 82% / 커리어 50% / 집안일 100% / **기타 33%** / **기타 10%** | 학습 82% / 커리어 50% / 집안일 100% / 기타 33% |

## 2. 회복 화면 실패 배너

빨간 에러 박스(`#FAE2D8` + danger 아이콘·글씨)가 **회복 화면 최상단**이었습니다.
바로 아래 "끝까지 가지 못해도 괜찮아요. 다시 시작할 방법이 있어요" 카피와 정면으로 어긋납니다.

sand 배경 + 중립 아이콘, `여기서 멈췄어요` 라벨 + 제목 + 사유로 바꿨습니다.
**사실만 전달하고 경고하지 않습니다.**

## 3. 곁다리

시간 미상인 회복 옵션에 `—` 를 찍어 버그처럼 보이던 것 → 칩 자체를 감춥니다.

## 검증

- `npx tsc --noEmit` 0 errors / API 계약 **PASS** / `npm run build` 성공
- Playwright **11개 화면 렌더, 런타임 에러 0**
- **회복 화면 목킹 후 내부 코드 노출 직접 검사** — 아래 전부 화면 텍스트에서 **0건**:
  `DOWNSCOPE` `RESCHEDULE` `PARK` `FATIGUE` `LOW_ENERGY` `SOME_NEW_TAG`
  `SPLIT_SMALLER` `MOVE_MORNING` `PARK_WEEK` `감지된 패턴` `복구 전략`
  (매핑에 없는 태그 `SOME_NEW_TAG` 를 일부러 섞어 폴백 경로까지 확인)
- 인박스 `career` → **커리어**, 미매핑 코드 → **기타** 렌더 확인
- 리뷰 차트 중복 "기타" 줄 사라진 것 확인

## 범위 밖으로 남긴 것

점검에서 같이 지적된 회복 카드의 **라디오 제거 + 카드 전체 탭**은 이 PR 에 넣지 않았습니다
(🔴 가 아닌 개선 항목이라 4단계 계획에 없음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
