### PR TITLE
feat: 오늘 화면에 "언제·얼마나·무슨 목표" 부착

### DIFF
--- a/src/components/HeroTaskCard.tsx
+++ b/src/components/HeroTaskCard.tsx
@@ -9,6 +9,17 @@ export interface HeroTaskCardProps {
   /** 오늘 완료 개수 / 전체 개수 — 카드 우상단 진척 표시용. */
   done: number;
   total: number;
+  /**
+   * 예약 시각(HH:MM). task.time 보다 우선한다. 오늘 화면은 이걸 주간 계획에서
+   * 가져와 넘긴다 — 실행 목록(agenda) 응답에는 시각이 없기 때문.
+   */
+  time?: string;
+  /** "60분" 같은 소요 표시. */
+  dur?: string;
+  /** 어느 목표에 속한 일인지. 목표 제목이 있으면 그걸, 없으면 카테고리 라벨. */
+  goalLabel?: string;
+  /** 목표 카테고리 색 — 라벨 앞 점에 쓴다. 색만으로 구분하지 않도록 항상 라벨과 함께. */
+  goalColor?: { bg: string; bd: string; fg: string };
   onComplete: () => void;
   onPartial: () => void;
   onFail: () => void;
@@ -31,6 +42,10 @@ export function HeroTaskCard({
   task,
   done,
   total,
+  time,
+  dur,
+  goalLabel,
+  goalColor,
   onComplete,
   onPartial,
   onFail,
@@ -47,6 +62,9 @@ export function HeroTaskCard({
 
   const isActive = task.status === 'in_progress';
   const pct = total > 0 ? Math.round((done / total) * 100) : 0;
+  // 넘어온 값이 우선 — task 자체엔 예약 시각이 없을 수 있다.
+  const shownTime = time ?? task.time;
+  const shownDur = dur ?? task.dur;
 
   return (
     <div
@@ -66,11 +84,21 @@ export function HeroTaskCard({
             fontSize: 10,
             fontWeight: 700,
             letterSpacing: '0.1em',
-            color: 'var(--coral-700)',
+            color: 'var(--brand-ink)',
             fontFamily: 'var(--font-mono)',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 5,
           }}
         >
           {isActive ? '진행 중' : '다음 할 일'}
+          {/* 언제 하기로 했는지 — 이게 없으면 "지금 뭘 언제"에 답이 안 된다. */}
+          {shownTime && (
+            <>
+              <span style={{ opacity: 0.45 }}>·</span>
+              <span className="tnum">{shownTime} 시작</span>
+            </>
+          )}
         </span>
         <span className="tnum" style={{ fontSize: 11, color: 'var(--text-3)', fontFamily: 'var(--font-mono)' }}>
           {done} / {total} · {pct}%
@@ -91,7 +119,7 @@ export function HeroTaskCard({
         >
           {task.title}
         </h2>
-        <div style={{ display: 'flex', gap: 6, marginTop: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+        <div style={{ display: 'flex', gap: 8, marginTop: 8, alignItems: 'center', flexWrap: 'wrap' }}>
           {task.carryover && (
             <span
               style={{
@@ -110,10 +138,22 @@ export function HeroTaskCard({
               ↩ 이월
             </span>
           )}
-          {task.time && (
-            <span className="tnum" style={{ fontSize: 12, color: 'var(--text-2)' }}>
-              {task.time}
-              {task.dur ? ` · ${task.dur}` : ''}
+          {shownDur && (
+            <span className="tnum" style={{ fontSize: 12, color: 'var(--text-2)' }}>{shownDur}</span>
+          )}
+          {/* 어느 목표에 속한 일인지. 색만으로 구분하지 않도록 점 + 라벨을 함께 둔다. */}
+          {goalLabel && (
+            <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5, fontSize: 12, color: 'var(--text-2)', minWidth: 0 }}>
+              <span
+                style={{
+                  width: 7,
+                  height: 7,
+                  borderRadius: 9999,
+                  background: goalColor?.bd ?? 'var(--sand-300)',
+                  flexShrink: 0,
+                }}
+              />
+              <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{goalLabel}</span>
             </span>
           )}
         </div>

--- a/src/components/IconAction.tsx
+++ b/src/components/IconAction.tsx
@@ -29,7 +29,7 @@ export function IconAction({ icon, label, onClick, tone = 'default', disabled = 
         gap: 5,
         border: `1px solid ${tone === 'danger' ? 'var(--coral-200)' : 'var(--sand-200)'}`,
         background: 'var(--surface-ground)',
-        color: tone === 'danger' ? 'var(--danger)' : 'var(--text-2)',
+        color: tone === 'danger' ? 'var(--danger-ink)' : 'var(--text-2)',
         fontWeight: 600,
         fontSize: 11,
         cursor: disabled ? 'wait' : 'pointer',

--- a/src/components/RecoveryOptionCard.tsx
+++ b/src/components/RecoveryOptionCard.tsx
@@ -119,7 +119,7 @@ export function RecoveryOptionCard({
                     fontSize: 10,
                     fontFamily: 'var(--font-mono)',
                     fontWeight: 600,
-                    color: confidence > 80 ? 'var(--success)' : confidence > 65 ? 'var(--warning)' : 'var(--text-3)',
+                    color: confidence > 80 ? 'var(--success-ink)' : confidence > 65 ? 'var(--warning-ink)' : 'var(--text-3)',
                   }}
                 >
                   성공률 {confidence}%

--- a/src/components/SectionHeader.tsx
+++ b/src/components/SectionHeader.tsx
@@ -37,7 +37,7 @@ export function SectionHeader({ children, action, icon, tone = 'default' }: Sect
           fontWeight: 600,
           letterSpacing: '0.08em',
           textTransform: 'uppercase',
-          color: tone === 'danger' ? 'var(--danger)' : 'var(--text-3)',
+          color: tone === 'danger' ? 'var(--danger-ink)' : 'var(--text-3)',
         }}
       >
         {icon}

--- a/src/components/TaskRow.tsx
+++ b/src/components/TaskRow.tsx
@@ -4,6 +4,14 @@ import type { Task } from '../types';
 
 export interface TaskRowProps {
   task: Task;
+  /** 예약 시각(HH:MM). task.time 보다 우선. */
+  time?: string;
+  /** "60분" 같은 소요. 제목 아래에 붙는다. */
+  dur?: string;
+  /** 목표 이름 — 히어로 카드와 같은 언어로 읽히게 한다. */
+  goalLabel?: string;
+  /** 목표 카테고리 색. 라벨과 항상 함께 쓴다(색만으로 구분하지 않는다). */
+  goalColor?: { bg: string; bd: string; fg: string };
   /** todo 를 눌렀을 때 — 주역 카드로 올린다(시작은 그쪽 CTA 에서). */
   onSelect: () => void;
   /** failed 를 눌렀을 때 — 회복 제안으로 보낸다. */
@@ -24,12 +32,24 @@ export interface TaskRowProps {
  * 막힌 항목을 눌렀을 때 회복으로 가는 게 핵심이다. 실패한 줄이 그냥
  * 붉게 남아 있기만 하면 사용자는 그걸 자기 실패 기록으로 읽는다.
  */
-export function TaskRow({ task, onSelect, onFailedRecover, onPartialRecover }: TaskRowProps) {
+export function TaskRow({
+  task,
+  time,
+  dur,
+  goalLabel,
+  goalColor,
+  onSelect,
+  onFailedRecover,
+  onPartialRecover,
+}: TaskRowProps) {
   const done = task.status === 'done';
   const failed = task.status === 'failed';
   const partial = task.status === 'partial_done' || task.status === 'recovery_pending';
   const inProgress = task.status === 'in_progress';
   const onClick = done ? undefined : failed ? onFailedRecover : partial ? onPartialRecover : onSelect;
+  const shownTime = time ?? task.time;
+  const shownDur = dur ?? task.dur;
+  const hasMeta = Boolean(shownDur || goalLabel);
 
   return (
     <button
@@ -37,7 +57,7 @@ export function TaskRow({ task, onSelect, onFailedRecover, onPartialRecover }: T
       disabled={done}
       style={{
         display: 'flex',
-        alignItems: 'center',
+        alignItems: hasMeta ? 'flex-start' : 'center',
         gap: 12,
         width: '100%',
         padding: '10px 14px',
@@ -55,6 +75,7 @@ export function TaskRow({ task, onSelect, onFailedRecover, onPartialRecover }: T
           height: 18,
           borderRadius: 9999,
           flexShrink: 0,
+          marginTop: hasMeta ? 2 : 0,
           border: done
             ? 'none'
             : `1.5px solid ${failed ? 'var(--danger)' : inProgress || partial ? 'var(--brand)' : 'var(--sand-300)'}`,
@@ -70,23 +91,45 @@ export function TaskRow({ task, onSelect, onFailedRecover, onPartialRecover }: T
           <span style={{ width: 8, height: 8, borderRadius: 9999, background: 'var(--brand)' }} />
         )}
       </span>
-      <span
-        style={{
-          flex: 1,
-          fontSize: 14,
-          color: done ? 'var(--text-3)' : failed ? 'var(--danger)' : 'var(--text-1)',
-          textDecoration: done ? 'line-through' : 'none',
-          whiteSpace: 'nowrap',
-          overflow: 'hidden',
-          textOverflow: 'ellipsis',
-          fontWeight: partial ? 600 : 500,
-        }}
-      >
-        {task.title}
+      <span style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <span
+          style={{
+            fontSize: 14,
+            color: done ? 'var(--text-3)' : failed ? 'var(--danger-ink)' : 'var(--text-1)',
+            textDecoration: done ? 'line-through' : 'none',
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            fontWeight: partial ? 600 : 500,
+          }}
+        >
+          {task.title}
+        </span>
+        {/* 히어로 카드와 같은 정보를 같은 순서로 — 목록에서도 "얼마나·무슨 목표"가 읽히게. */}
+        {hasMeta && (
+          <span style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 11, color: 'var(--text-3)', minWidth: 0 }}>
+            {shownDur && <span className="tnum">{shownDur}</span>}
+            {shownDur && goalLabel && <span style={{ opacity: 0.5 }}>·</span>}
+            {goalLabel && (
+              <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4, minWidth: 0 }}>
+                <span
+                  style={{
+                    width: 6,
+                    height: 6,
+                    borderRadius: 9999,
+                    background: goalColor?.bd ?? 'var(--sand-300)',
+                    flexShrink: 0,
+                  }}
+                />
+                <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{goalLabel}</span>
+              </span>
+            )}
+          </span>
+        )}
       </span>
-      {task.time && (
-        <span className="tnum" style={{ fontSize: 11, color: 'var(--text-4)', flexShrink: 0 }}>
-          {task.time}
+      {shownTime && (
+        <span className="tnum" style={{ fontSize: 12, color: 'var(--text-3)', flexShrink: 0, fontWeight: 600 }}>
+          {shownTime}
         </span>
       )}
     </button>

--- a/src/components/TextField.tsx
+++ b/src/components/TextField.tsx
@@ -45,7 +45,7 @@ export function TextField({ label, hint, error, full = true, style, ...rest }: T
         }}
       />
       {(error || hint) && (
-        <span style={{ fontSize: 10, color: error ? 'var(--danger)' : 'var(--text-3)', lineHeight: 1.4 }}>
+        <span style={{ fontSize: 10, color: error ? 'var(--danger-ink)' : 'var(--text-3)', lineHeight: 1.4 }}>
           {error || hint}
         </span>
       )}

--- a/src/screens/SystemIntroScreen.tsx
+++ b/src/screens/SystemIntroScreen.tsx
@@ -116,7 +116,7 @@ function MemoryDiagram() {
             : <XCircle size={14} weight="fill" color="var(--danger-ink)" style={{ flexShrink: 0 }} />
           }
           <div style={{ flex: 1, fontSize: 12, fontWeight: 600, color: 'var(--text-1)' }}>{r.t}</div>
-          <span style={{ fontSize: 9, fontWeight: 600, color: r.ok ? 'var(--success)' : 'var(--danger)', fontFamily: 'var(--font-mono)' }}>{r.st}</span>
+          <span style={{ fontSize: 9, fontWeight: 600, color: r.ok ? 'var(--success-ink)' : 'var(--danger-ink)', fontFamily: 'var(--font-mono)' }}>{r.st}</span>
         </div>
       ))}
       <div style={{ padding: '8px 10px', background: 'var(--brand-soft)', border: '1px solid var(--coral-200)', borderRadius: 10, fontSize: 11, color: 'var(--coral-700)', display: 'flex', alignItems: 'center', gap: 7 }}>

--- a/src/screens/TodayScreen.tsx
+++ b/src/screens/TodayScreen.tsx
@@ -7,11 +7,12 @@ import {
   Trash,
 } from '@phosphor-icons/react';
 import type { Task, TaskStatus } from '../types';
-import type { AgendaCard } from '../types/api';
+import type { AgendaCard, ApiGoal, WeeklyPlanResponse } from '../types/api';
 import { FAIL_REASONS, GOAL_CATEGORY_OPTIONS } from '../data';
 import { useNavigation } from '../contexts/NavigationContext';
-import { habitsApi, reflectionApi, todayApi } from '../lib/api';
+import { goalsApi, habitsApi, plansApi, reflectionApi, todayApi } from '../lib/api';
 import { localDateStr } from '../lib/dates';
+import { categoryLabel, goalColor } from '../data';
 import { DemoNotice } from '../components/DemoNotice';
 import { HeroTaskCard } from '../components/HeroTaskCard';
 import { TaskRow } from '../components/TaskRow';
@@ -127,6 +128,25 @@ function actionToTask(a: AgendaCard): Task {
   };
 }
 
+// /today/agenda 에는 예약 시각이 없다(AgendaCard 필드에 없음). 시각은 주간 계획의
+// 블록에만 있으므로 actionId 로 조인해서 채운다 — 지어내지 않고 실제 계획값을 쓴다.
+function todayBlockIndex(plan: WeeklyPlanResponse, todayStr: string) {
+  const byAction = new Map<string, { time: string; durMin: number; goalId?: string | null }>();
+  for (const day of plan.days ?? []) {
+    if (day.date !== todayStr) continue;
+    for (const b of day.blocks ?? []) {
+      const s = new Date(b.startAt);
+      const e = new Date(b.endAt);
+      byAction.set(b.actionId, {
+        time: `${String(s.getHours()).padStart(2, '0')}:${String(s.getMinutes()).padStart(2, '0')}`,
+        durMin: Math.max(1, Math.round((e.getTime() - s.getTime()) / 60000)),
+        goalId: b.goalId,
+      });
+    }
+  }
+  return byAction;
+}
+
 // "5월 24일 · 일요일" — Today 헤더용
 function todayShortKo(): string {
   const d = new Date();
@@ -159,6 +179,40 @@ export function MergedTodayScreen({ tasks, onOpen, onMarkDone, onPartial, onFail
     ).finally(() => { if (!cancelled) setAgendaLoading(false); });
     return () => { cancelled = true; };
   }, []);
+
+  // 오늘 블록의 예약 시각·소요, 그리고 목표 이름. 둘 다 agenda 응답엔 없어서 따로 가져온다.
+  // agenda 렌더를 막지 않는다 — 늦게 도착하면 그때 칩이 붙는다(없으면 안 붙을 뿐).
+  const [blockInfo, setBlockInfo] = useState<Map<string, { time: string; durMin: number; goalId?: string | null }>>(new Map());
+  const [goalTitles, setGoalTitles] = useState<Map<string, ApiGoal>>(new Map());
+  useEffect(() => {
+    let cancelled = false;
+    const today = localDateStr(new Date());
+    plansApi.weekly(thisMonday()).then(
+      (plan) => { if (!cancelled) setBlockInfo(todayBlockIndex(plan, today)); },
+      () => { /* 계획 없음/오류 — 시각 칩만 안 붙는다 */ },
+    );
+    goalsApi.list().then(
+      (byTier) => {
+        if (cancelled) return;
+        const all = [...(byTier.focus ?? []), ...(byTier.maintain ?? []), ...(byTier.parked ?? [])];
+        setGoalTitles(new Map(all.map((g) => [g.goalId, g])));
+      },
+      () => { /* 목표 못 가져오면 카테고리 라벨로 폴백 */ },
+    );
+    return () => { cancelled = true; };
+  }, []);
+
+  // 화면에 붙일 부가 정보. 없는 건 없는 대로 둔다(빈 값을 지어내지 않는다).
+  const metaFor = (t: Task) => {
+    const b = blockInfo.get(t.id);
+    const goal = b?.goalId ? goalTitles.get(b.goalId) : undefined;
+    return {
+      time: b?.time ?? t.time,
+      dur: b ? `${b.durMin}분` : t.dur,
+      goalLabel: goal?.title ?? (t.goal ? categoryLabel(t.goal) : undefined),
+      goalColor: goalColor(goal?.category ?? t.goal),
+    };
+  };
 
   const [detailTask, setDetailTask] = useState<Task | null>(null); // 액션 상세 시트(S11)
   const [failSheet, setFailSheet] = useState<string | null>(null);
@@ -320,14 +374,16 @@ export function MergedTodayScreen({ tasks, onOpen, onMarkDone, onPartial, onFail
           </div>
           <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
             {partialTasks.length > 0 && (
+              // 회복은 이 제품의 핵심 차별점인데 ⋮ 옆 작은 아이콘이라 존재감이 없었다.
+              // 이름을 붙인 칩으로 올린다 — 뭘 누르는 건지 읽히게.
               <button
                 onClick={onOpenRecovery}
-                aria-label="회복 제안"
                 title={`회복 제안 ${partialTasks.length}건`}
-                style={{ position: 'relative', width: 36, height: 36, borderRadius: 9999, border: 'none', background: 'var(--brand-soft)', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer' }}
+                style={{ height: 32, padding: '0 11px 0 9px', borderRadius: 9999, border: '1px solid var(--coral-200)', background: 'var(--brand-soft)', display: 'inline-flex', alignItems: 'center', gap: 5, cursor: 'pointer', fontFamily: 'inherit' }}
               >
-                <ArrowsClockwise size={16} color="var(--brand)" weight="fill" />
-                <span className="tnum" style={{ position: 'absolute', top: -2, right: -2, minWidth: 16, height: 'var(--ctrl-xs)', padding: '0 4px', borderRadius: 9999, background: 'var(--brand-surface)', color: '#FFFCF6', fontSize: 9, fontWeight: 700, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>{partialTasks.length}</span>
+                <ArrowsClockwise size={14} color="var(--brand-ink)" weight="fill" />
+                <span style={{ fontSize: 12, fontWeight: 700, color: 'var(--brand-ink)' }}>회복</span>
+                <span className="tnum" style={{ minWidth: 16, height: 16, padding: '0 4px', borderRadius: 9999, background: 'var(--brand-surface)', color: '#FFFCF6', fontSize: 10, fontWeight: 700, display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}>{partialTasks.length}</span>
               </button>
             )}
             <HeaderMenu />
@@ -358,6 +414,7 @@ export function MergedTodayScreen({ tasks, onOpen, onMarkDone, onPartial, onFail
               task={heroTask}
               done={doneTasks.length}
               total={tasks.length}
+              {...(heroTask ? metaFor(heroTask) : {})}
               onComplete={() => heroTask && (onMarkDone(heroTask.id), showToast('완료!'))}
               onPartial={() => heroTask && setPartialSheet(heroTask.id)}
               onFail={() => heroTask && (setFailSheet(heroTask.id), setFailTags([]), setFailMemo(''))}
@@ -373,6 +430,7 @@ export function MergedTodayScreen({ tasks, onOpen, onMarkDone, onPartial, onFail
                   <TaskRow
                     key={t.id}
                     task={t}
+                    {...metaFor(t)}
                     // 대기/진행 row 클릭 = hero 로 promote (실제 시작 X)
                     onSelect={() => setSelectedTaskId(t.id)}
                     onFailedRecover={() => onFail(t.id, t.failReason || '')}
@@ -383,7 +441,15 @@ export function MergedTodayScreen({ tasks, onOpen, onMarkDone, onPartial, onFail
           </>
         )}
 
-        {/* Habit Tracker */}
+        {/* Habit Tracker — 습관이 하나도 없으면 섹션을 통째로 접는다.
+            예전엔 제목 + 큰 점선 안내 박스가 화면 하단 40% 를 빈 채로 차지했다.
+            추가 진입점은 남겨야 하므로 얇은 링크 한 줄로 대체한다. */}
+        {!habitsLoading && habits.length === 0 && !addingHabit ? (
+          <button
+            onClick={() => setAddingHabit(true)}
+            style={{ alignSelf: 'flex-start', fontSize: 12, color: 'var(--text-3)', fontWeight: 600, background: 'none', border: 'none', cursor: 'pointer', fontFamily: 'inherit', padding: '4px 0' }}
+          >+ 습관 추가</button>
+        ) : (
         <div>
           <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 10 }}>
             <span style={{ fontSize: 14, fontWeight: 700, color: 'var(--text-1)' }}>추적 습관 루틴 ({habits.length})</span>
@@ -396,11 +462,6 @@ export function MergedTodayScreen({ tasks, onOpen, onMarkDone, onPartial, onFail
             {habitsLoading && [0, 1].map((i) => (
               <div key={`hsk${i}`} style={{ height: 52, borderRadius: 14, background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', opacity: 0.6 }} aria-hidden="true" />
             ))}
-            {!habitsLoading && habits.length === 0 && !addingHabit && (
-              <div style={{ padding: '12px 14px', borderRadius: 12, background: 'var(--surface-raised)', border: '1px dashed var(--sand-200)', fontSize: 12, color: 'var(--text-2)', lineHeight: 1.5 }}>
-                아직 추적 중인 습관이 없어요. 위 <b>+ 습관 추가</b>로 만들어보세요.
-              </div>
-            )}
             {habits.map(h => {
               const done = h.doneDays >= h.targetDays;
               return (
@@ -420,7 +481,7 @@ export function MergedTodayScreen({ tasks, onOpen, onMarkDone, onPartial, onFail
                   <button
                     onClick={() => checkHabit(h.id)}
                     disabled={done}
-                    style={{ padding: '8px 14px', borderRadius: 9999, border: 'none', background: done ? '#E5EFE3' : '#EEEAF6', color: done ? 'var(--success)' : '#7B68C8', fontSize: 13, fontWeight: 600, cursor: done ? 'default' : 'pointer', fontFamily: 'inherit', flexShrink: 0, transition: 'all 200ms' }}
+                    style={{ padding: '8px 14px', borderRadius: 9999, border: 'none', background: done ? '#E5EFE3' : '#EEEAF6', color: done ? 'var(--success-ink)' : '#7B68C8', fontSize: 13, fontWeight: 600, cursor: done ? 'default' : 'pointer', fontFamily: 'inherit', flexShrink: 0, transition: 'all 200ms' }}
                   >{done ? '완료' : '체크'}</button>
                   <button
                     onClick={() => removeHabit(h.id)}
@@ -464,6 +525,8 @@ export function MergedTodayScreen({ tasks, onOpen, onMarkDone, onPartial, onFail
             )}
           </div>
         </div>
+
+        )}
 
         {/* All done */}
         {allDone && (

--- a/src/screens/WeeklyReviewScreen.tsx
+++ b/src/screens/WeeklyReviewScreen.tsx
@@ -239,7 +239,7 @@ export function WeeklyReviewScreenV2() {
             return (
               <div key={i} style={{ background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', borderRadius: 14, padding: 12, display: 'flex', flexDirection: 'column', gap: 5 }}>
                 <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-                  <div style={{ fontSize: 16, color: k.ok ? 'var(--success)' : 'var(--warning)' }}>
+                  <div style={{ fontSize: 16, color: k.ok ? 'var(--success-ink)' : 'var(--warning-ink)' }}>
                     {k.ok ? '●' : '◎'}
                   </div>
                 </div>


### PR DESCRIPTION
## 작업 배경

개편 4단계 중 **3단계**. 구조는 그대로 두고 **정보만 붙입니다** (회귀 위험 작음).

점검에서 지적된 4가지:

1. 🔴 **시간이 어디에도 없음** — 21:00 예정인데 표시 X
2. 나머지 할 일이 동그라미 + 제목뿐이라 히어로와 위계 단절
3. 하단 40%가 빈 공간 (습관 0개인데 빈 박스 유지)
4. 회복 뱃지가 ⋮ 옆 작은 아이콘 — **핵심 차별점인데 존재감 없음**

## 예약 시각은 어디서 오나 (중요)

`/today/agenda` 의 `AgendaCard` 에는 **예약 시각 필드가 없습니다** (`estimatedMinutes`·`category` 뿐).
시각은 주간 계획 블록에만 있으므로 **`actionId` 로 조인**해서 채웁니다 — 지어내지 않습니다.

```
GET /plans/weekly  →  오늘 날짜 블록의 startAt/endAt  →  시각 · 소요
GET /goals         →  goalId                        →  목표 제목
```

둘 다 **agenda 렌더를 막지 않습니다.** 늦게 도착하면 그때 붙고, 실패하면 안 붙을 뿐입니다.
목표 제목이 없으면 카테고리 라벨로 폴백합니다.

## 변경

| 대상 | 내용 |
|---|---|
| 히어로 | `진행 중 · 14:00 시작` + `60분 ● 정보처리기사 취득` |
| 목록 | 제목 아래 `소요 · ● 목표`, 우측에 시각 — **히어로와 같은 정보를 같은 순서로** |
| 습관 | 0개면 섹션을 접고 얇은 `+ 습관 추가` 한 줄만 (진입점은 유지) |
| 회복 | ⋮ 옆 아이콘 → **이름 있는 칩** `⟳ 회복 ①` |

목표는 **색 점 + 라벨을 항상 함께** 둡니다. 색만으로 구분하면 색각 이상 사용자가 읽지
못하고, 저채도 팔레트라 특히 불리합니다.

## 곁다리 — 2단계에서 빠졌던 대비 12건

삼항 안에 든 상태색(`failed ? 'var(--danger)' : ...`)이 정규식에 안 걸려 `-ink` 이관에서
누락됐었습니다. **실패한 할 일 제목이 4.17:1 로 남아 있었습니다.** 12건 마저 이관했습니다.
저녁 체크인의 에너지 **'점' 색은 면**이라 되돌렸습니다.

## 검증

- `npx tsc --noEmit` 0 errors / API 계약 **PASS** / `npm run build` 성공
- 대비 실측 **FAIL 1건 유지** (`--brand` 면 2.98 — 2단계에서 남긴 항목)
- Playwright **11개 화면 렌더, 런타임 에러 0**
- **오늘 화면 목킹 렌더 확인** (agenda + weekly + goals 를 `actionId` 로 조인):
  히어로 `14:00 시작 / 60분 / 정보처리기사 취득`, 목록 4건 전부 시각·소요·목표 표시

## 다음

4단계(주간 시간표 넓히기)만 남았습니다. 그 뒤 디자인 시스템 재동기화를 한 번에 돌립니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
