### PR TITLE
feat: 주간 시간표 넓히기 — 3일 기본 + 빈 시간대 접기 + 헤더 슬림화

### DIFF
--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -66,6 +66,21 @@ node .ds-sync/package-validate.mjs ./ds-bundle
 ```
 스킬 디렉터리에서 직접 실행하면 `esbuild` 를 못 찾는다 — 반드시 `.ds-sync/` 쪽을 쓸 것.
 
+## 토큰 규칙 (2026-07-29 대비 작업 이후)
+
+**면과 글씨를 같은 토큰으로 쓰지 않는다.** 이름이 곧 규칙:
+
+  기본값   면·아이콘·바   (--brand, --success, --danger …)
+  -ink     글씨          (--brand-ink, --success-ink …)
+  -soft    옅은 배경      (--brand-soft, --success-soft …)
+  --brand-surface        흰 글씨를 얹는 버튼 면 (coral-700)
+
+`--brand`(coral-500)에 **글씨를 얹으면 안 된다** — 크림 위 2.98:1, 흰 글씨 3.14:1.
+컴포넌트를 새로 만들 때 `color:` 에는 `-ink` 를, `background:` 에는 기본값을 쓴다.
+
+`--text-3`/`--text-4` 는 sand 스케일을 참조하지 않는다(면용이라 4.5:1 제약이 없어서).
+바꿀 땐 `$CLAUDE_JOB_DIR/tmp/contrast2.mjs` 같은 실측 스크립트로 재계산할 것.
+
 ## 재동기화 방법
 
 ```

--- a/.design-sync/config.json
+++ b/.design-sync/config.json
@@ -52,8 +52,8 @@
     },
     "WeekGrid": {
       "cardMode": "single",
-      "primaryStory": "ThisWeek",
-      "viewport": "420x620"
+      "primaryStory": "ThreeDay",
+      "viewport": "420x560"
     },
     "ProgressSheet": {
       "cardMode": "single",

--- a/.design-sync/previews/HeroTaskCard.tsx
+++ b/.design-sync/previews/HeroTaskCard.tsx
@@ -6,9 +6,13 @@ const wrap: React.CSSProperties = { maxWidth: 360 };
 export const NextUp = () => (
   <div style={wrap}>
     <HeroTaskCard
-      task={{ id: '1', title: '알고리즘 2문제 풀기', status: 'todo', time: '14:00', dur: '60분', whyNow: '오전에 집중이 잘 되는 시간대예요.' }}
+      task={{ id: '1', title: '알고리즘 2문제 풀기', status: 'todo', whyNow: '오전에 집중이 잘 되는 시간대예요.' }}
       done={1}
       total={5}
+      time="14:00"
+      dur="60분"
+      goalLabel="정보처리기사 취득"
+      goalColor={{ bg: '#E4EDF6', bd: '#B8D0E8', fg: '#31506E' }}
       onComplete={noop}
       onPartial={noop}
       onFail={noop}
@@ -21,9 +25,13 @@ export const NextUp = () => (
 export const InProgress = () => (
   <div style={wrap}>
     <HeroTaskCard
-      task={{ id: '1', title: '정보처리기사 실기 정리', status: 'in_progress', time: '10:00', dur: '120분' }}
+      task={{ id: '1', title: '정보처리기사 실기 정리', status: 'in_progress' }}
       done={2}
       total={5}
+      time="10:00"
+      dur="120분"
+      goalLabel="정보처리기사 취득"
+      goalColor={{ bg: '#E4EDF6', bd: '#B8D0E8', fg: '#31506E' }}
       onComplete={noop}
       onPartial={noop}
       onFail={noop}
@@ -36,9 +44,13 @@ export const InProgress = () => (
 export const CarriedOver = () => (
   <div style={wrap}>
     <HeroTaskCard
-      task={{ id: '1', title: '포트폴리오 초안 쓰기', status: 'todo', time: '13:00', dur: '90분', carryover: true }}
+      task={{ id: '1', title: '포트폴리오 초안 쓰기', status: 'todo', carryover: true }}
       done={0}
       total={4}
+      time="13:00"
+      dur="90분"
+      goalLabel="포트폴리오"
+      goalColor={{ bg: '#FBEEDA', bd: '#F2D29A', fg: '#7A5411' }}
       onComplete={noop}
       onPartial={noop}
       onFail={noop}

--- a/.design-sync/previews/TaskRow.tsx
+++ b/.design-sync/previews/TaskRow.tsx
@@ -2,24 +2,38 @@ import { TaskRow } from 're-action-web';
 
 const noop = () => {};
 const list: React.CSSProperties = { maxWidth: 340, display: 'flex', flexDirection: 'column', gap: 2 };
+const study = { bg: '#E4EDF6', bd: '#B8D0E8', fg: '#31506E' };
+const health = { bg: '#E5EFE3', bd: '#B4DFC8', fg: 'var(--success-ink)' };
+
+const cb = { onSelect: noop, onFailedRecover: noop, onPartialRecover: noop };
 
 export const AllStates = () => (
   <div style={list}>
-    <TaskRow task={{ id: '1', title: '토익 LC 파트3', status: 'done', time: '09:00' }} onSelect={noop} onFailedRecover={noop} onPartialRecover={noop} />
-    <TaskRow task={{ id: '2', title: '알고리즘 2문제', status: 'in_progress', time: '14:00' }} onSelect={noop} onFailedRecover={noop} onPartialRecover={noop} />
-    <TaskRow task={{ id: '3', title: '헬스 가기', status: 'partial_done', time: '19:00' }} onSelect={noop} onFailedRecover={noop} onPartialRecover={noop} />
-    <TaskRow task={{ id: '4', title: '정보처리기사 실기', status: 'failed', time: '10:00' }} onSelect={noop} onFailedRecover={noop} onPartialRecover={noop} />
-    <TaskRow task={{ id: '5', title: '독서 30분', status: 'todo', time: '21:00' }} onSelect={noop} onFailedRecover={noop} onPartialRecover={noop} />
+    <TaskRow task={{ id: '1', title: '토익 LC 파트3', status: 'done' }} time="09:00" dur="90분" goalLabel="토익 900점" goalColor={study} {...cb} />
+    <TaskRow task={{ id: '2', title: '알고리즘 2문제', status: 'in_progress' }} time="14:00" dur="60분" goalLabel="정보처리기사" goalColor={study} {...cb} />
+    <TaskRow task={{ id: '3', title: '헬스 가기', status: 'partial_done' }} time="19:00" dur="60분" goalLabel="주 3회 운동" goalColor={health} {...cb} />
+    <TaskRow task={{ id: '4', title: '정보처리기사 실기', status: 'failed' }} time="10:00" dur="120분" goalLabel="정보처리기사" goalColor={study} {...cb} />
+    <TaskRow task={{ id: '5', title: '독서 30분', status: 'todo' }} time="21:00" dur="30분" {...cb} />
+  </div>
+);
+
+// 시각·소요·목표를 아직 못 가져온 상태 — 없으면 없는 대로 한 줄로 줄어든다.
+export const WithoutMeta = () => (
+  <div style={list}>
+    <TaskRow task={{ id: '1', title: '토익 LC 파트3', status: 'done' }} {...cb} />
+    <TaskRow task={{ id: '2', title: '알고리즘 2문제', status: 'todo' }} {...cb} />
   </div>
 );
 
 export const LongTitle = () => (
   <div style={list}>
     <TaskRow
-      task={{ id: '1', title: '정보처리기사 실기 기출 5개년 오답 정리하고 요약본 만들기', status: 'todo', time: '15:30' }}
-      onSelect={noop}
-      onFailedRecover={noop}
-      onPartialRecover={noop}
+      task={{ id: '1', title: '정보처리기사 실기 기출 5개년 오답 정리하고 요약본 만들기', status: 'todo' }}
+      time="15:30"
+      dur="120분"
+      goalLabel="정보처리기사 취득"
+      goalColor={study}
+      {...cb}
     />
   </div>
 );

--- a/.design-sync/previews/WeekGrid.tsx
+++ b/.design-sync/previews/WeekGrid.tsx
@@ -3,7 +3,7 @@ import { WeekGrid } from 're-action-web';
 const shell: React.CSSProperties = {
   display: 'flex',
   flexDirection: 'column',
-  height: 560,
+  height: 520,
   width: 390,
   background: 'var(--surface-ground)',
   border: '1px solid var(--sand-200)',
@@ -11,35 +11,55 @@ const shell: React.CSSProperties = {
   overflow: 'hidden',
 };
 
-const study = { bg: '#E4EDF6', bd: '#B8D0E8', fg: '#3A5C7D' };
-const health = { bg: '#E5EFE3', bd: '#B4DFC8', fg: 'var(--success)' };
-const done = { bg: '#E5EFE3', bd: '#B4DFC8', fg: 'var(--success)' };
-const failed = { bg: '#FAE2D8', bd: 'var(--coral-200)', fg: 'var(--danger)' };
+const study = { bg: '#E4EDF6', bd: '#B8D0E8', fg: '#31506E' };
+const project = { bg: '#FBEEDA', bd: '#F2D29A', fg: '#7A5411' };
+const done = { bg: '#E5EFE3', bd: '#B4DFC8', fg: 'var(--success-ink)' };
+const failed = { bg: '#FAE2D8', bd: 'var(--coral-200)', fg: 'var(--danger-ink)' };
 const fixed = { bg: 'var(--sand-100)', bd: 'var(--sand-300)', fg: 'var(--text-3)' };
 
 const WEEK = [
-  { id: '1', col: 0, startMin: 9 * 60, durMin: 90, title: '토익 LC 파트3', subLabel: '09:00·90분', glyph: '✓ ', colors: done },
-  { id: '2', col: 0, startMin: 14 * 60, durMin: 60, title: '알고리즘 2문제', subLabel: '14:00·60분', colors: study },
-  { id: '3', col: 1, startMin: 10 * 60, durMin: 120, title: '정보처리기사 실기', subLabel: '10:00·120분', glyph: '✗ ', colors: failed },
-  { id: '4', col: 2, startMin: 11 * 60, durMin: 90, title: '전공 수업', subLabel: '11:00·90분', colors: fixed, fixed: true },
-  { id: '5', col: 2, startMin: 19 * 60, durMin: 60, title: '헬스', subLabel: '19:00·60분', colors: health },
-  { id: '6', col: 3, startMin: 9 * 60, durMin: 45, title: '토익 RC 파트5', subLabel: '09:00·45분', colors: study },
-  { id: '7', col: 4, startMin: 13 * 60, durMin: 90, title: '포트폴리오 정리', subLabel: '13:00·90분', colors: study },
+  { id: '1', col: 2, startMin: 9 * 60, durMin: 90, title: '토익 LC 파트3', subLabel: '09:00·90분', glyph: '✓ ', colors: done },
+  { id: '2', col: 2, startMin: 14 * 60, durMin: 60, title: '알고리즘 2문제 풀기', subLabel: '14:00·60분', colors: study },
+  { id: '3', col: 2, startMin: 11 * 60, durMin: 120, title: '정보처리기사 실기', subLabel: '11:00·120분', glyph: '✗ ', colors: failed },
+  { id: '4', col: 3, startMin: 13 * 60, durMin: 90, title: '캡스톤 발표자료', subLabel: '13:00·90분', colors: project },
+  { id: '5', col: 4, startMin: 15 * 60, durMin: 60, title: '전공 수업', subLabel: '15:00·60분', colors: fixed, fixed: true },
+  { id: '6', col: 0, startMin: 10 * 60, durMin: 60, title: '토익 RC', subLabel: '10:00·60분', colors: study },
+  { id: '7', col: 5, startMin: 11 * 60, durMin: 60, title: '독서', subLabel: '11:00·60분', colors: study },
 ];
 
-export const ThisWeek = () => (
+// 기본값 — 모바일에서 실제로 쓰는 모양. 3칸만 보여주고 열을 넓게 쓴다.
+export const ThreeDay = () => (
+  <div style={shell}>
+    <WeekGrid
+      blocks={WEEK}
+      visibleCols={[2, 3, 4]}
+      dayNumbers={[27, 28, 29, 30, 31, 1, 2]}
+      todayCol={2}
+      nowMin={15 * 60 + 30}
+      startHour={8}
+      endHour={20}
+      colWidth={108}
+      hourPx={64}
+      timeWidth={34}
+    />
+  </div>
+);
+
+// 한 주 전체 조망. 열이 좁아 제목이 접히므로 "훑어보기" 용도다.
+export const SevenDay = () => (
   <div style={shell}>
     <WeekGrid
       blocks={WEEK}
       dayNumbers={[27, 28, 29, 30, 31, 1, 2]}
       todayCol={2}
       nowMin={15 * 60 + 30}
-      startHour={8}
-      endHour={22}
+      startHour={9}
+      endHour={19}
     />
   </div>
 );
 
+// 확정 전 초안을 앞에, 이전 계획을 뒤에 흐리게 — 온보딩 계획 확인 화면의 모양.
 export const WithDraftBackdrop = () => (
   <div style={shell}>
     <WeekGrid
@@ -52,30 +72,14 @@ export const WithDraftBackdrop = () => (
         { id: 'o2', col: 4, startMin: 13 * 60, durMin: 60, title: '지난 계획', colors: fixed, muted: true },
       ]}
       dayNumbers={[3, 4, 5, 6, 7, 8, 9]}
-      startHour={8}
-      endHour={20}
-    />
-  </div>
-);
-
-export const Wider = () => (
-  <div style={{ ...shell, width: 480 }}>
-    <WeekGrid
-      blocks={WEEK}
-      dayNumbers={[27, 28, 29, 30, 31, 1, 2]}
-      todayCol={2}
-      nowMin={15 * 60 + 30}
-      startHour={8}
-      endHour={20}
-      colWidth={62}
-      hourPx={64}
-      timeWidth={34}
+      startHour={9}
+      endHour={17}
     />
   </div>
 );
 
 export const Loading = () => (
   <div style={shell}>
-    <WeekGrid blocks={[]} dayNumbers={[27, 28, 29, 30, 31, 1, 2]} todayCol={2} startHour={12} endHour={22} loading />
+    <WeekGrid blocks={[]} dayNumbers={[27, 28, 29, 30, 31, 1, 2]} todayCol={2} startHour={13} endHour={22} loading />
   </div>
 );

--- a/src/components/WeekGrid.tsx
+++ b/src/components/WeekGrid.tsx
@@ -45,6 +45,13 @@ export interface WeekGridProps {
   loading?: boolean;
   /** 블록을 누르거나 끌기 시작할 때. 드래그/탭 분기는 호출한 쪽에서 판단한다. */
   onBlockPointerDown?: (e: React.PointerEvent, block: WeekGridBlock) => void;
+  /**
+   * 보여줄 요일 칸(0=월 … 6=일). 없으면 7일 전부.
+   * 3일 뷰는 [2,3,4] 처럼 넘긴다 — 같은 폭에 칸이 셋뿐이라 colWidth 를 두 배로 줄 수 있고,
+   * 그래야 "캡스톤 발표 / 자료" 처럼 제목이 깨지지 않는다.
+   * 여기 없는 칸의 블록은 렌더하지 않는다.
+   */
+  visibleCols?: number[];
   /** 스크롤 위치를 밖에서 제어할 때(첫 블록으로 스크롤 등). */
   scrollRef?: React.Ref<HTMLDivElement>;
 }
@@ -84,13 +91,19 @@ export function WeekGrid({
   timeWidth = 30,
   loading = false,
   onBlockPointerDown,
+  visibleCols,
   scrollRef,
 }: WeekGridProps) {
+  const cols = visibleCols ?? [0, 1, 2, 3, 4, 5, 6];
+  // 실제 요일 번호 → 화면상 몇 번째 칸인가. 3일 뷰에서 col 2 가 0번 칸이 된다.
+  const slotOf = (col: number) => cols.indexOf(col);
   const hours = Array.from({ length: endHour - startHour }, (_, i) => startHour + i);
   const toY = (m: number) => ((m - startHour * 60) * hourPx) / 60;
-  const bodyWidth = colWidth * 7;
+  const bodyWidth = colWidth * cols.length;
 
   const renderBlock = (b: WeekGridBlock, interactive: boolean) => {
+    const slot = slotOf(b.col);
+    if (slot < 0) return null; // 지금 안 보이는 요일
     const y = toY(b.startMin);
     if (y < 0) return null;
     const h = Math.max((b.durMin * hourPx) / 60 - 2, 20);
@@ -98,7 +111,7 @@ export function WeekGrid({
     const dashed = b.muted || b.dragging;
     const common: React.CSSProperties = {
       position: 'absolute',
-      left: b.col * colWidth + 2,
+      left: slot * colWidth + 2,
       top: y + 1,
       width: colWidth - 4,
       height: h,
@@ -113,22 +126,22 @@ export function WeekGrid({
       <>
         <div
           style={{
-            fontSize: 8,
+            fontSize: colWidth >= 80 ? 11 : 8,
             fontWeight: 700,
             color: c.fg,
             lineHeight: 1.3,
             overflow: 'hidden',
             textOverflow: 'ellipsis',
-            whiteSpace: h > 36 ? 'normal' : 'nowrap',
+            whiteSpace: h > 36 || colWidth >= 80 ? 'normal' : 'nowrap',
           }}
         >
           {b.glyph ?? ''}
           {b.title}
         </div>
-        {h > 36 && b.subLabel && (
+        {(h > 36 || colWidth >= 80) && b.subLabel && (
           <div
             className="tnum"
-            style={{ fontSize: 7, color: c.fg, opacity: 0.7, marginTop: 1, fontFamily: 'var(--font-mono)' }}
+            style={{ fontSize: colWidth >= 80 ? 10 : 7, color: c.fg, opacity: 0.7, marginTop: 1, fontFamily: 'var(--font-mono)' }}
           >
             {b.subLabel}
           </div>
@@ -171,7 +184,8 @@ export function WeekGrid({
       {/* 요일 헤더 */}
       <div style={{ flexShrink: 0, display: 'flex', borderBottom: '1px solid var(--sand-200)' }}>
         <div style={{ width: timeWidth, flexShrink: 0 }} />
-        {DAYS_KO.map((d, i) => {
+        {cols.map((i) => {
+          const d = DAYS_KO[i];
           const isToday = todayCol === i;
           return (
             <div
@@ -188,7 +202,7 @@ export function WeekGrid({
             >
               <div
                 style={{
-                  fontSize: 8,
+                  fontSize: colWidth >= 80 ? 10 : 8,
                   fontFamily: 'var(--font-mono)',
                   letterSpacing: '0.08em',
                   color: isToday ? 'var(--coral-700)' : 'var(--text-3)',
@@ -237,7 +251,7 @@ export function WeekGrid({
                   paddingRight: 4,
                 }}
               >
-                <span className="tnum" style={{ fontSize: 8, color: 'var(--text-3)', fontFamily: 'var(--font-mono)' }}>
+                <span className="tnum" style={{ fontSize: colWidth >= 80 ? 10 : 8, color: 'var(--text-3)', fontFamily: 'var(--font-mono)' }}>
                   {h}
                 </span>
               </div>
@@ -251,17 +265,17 @@ export function WeekGrid({
                 style={{ position: 'absolute', left: 0, right: 0, top: i * hourPx, height: 1, background: 'var(--sand-200)' }}
               />
             ))}
-            {DAYS_KO.map((d, i) => (
+            {cols.map((c, i) => (
               <div
-                key={d}
+                key={c}
                 style={{ position: 'absolute', left: i * colWidth, top: 0, bottom: 0, width: 1, background: 'var(--sand-200)' }}
               />
             ))}
-            {todayCol != null && (
+            {todayCol != null && slotOf(todayCol) >= 0 && (
               <div
                 style={{
                   position: 'absolute',
-                  left: todayCol * colWidth,
+                  left: slotOf(todayCol) * colWidth,
                   top: 0,
                   bottom: 0,
                   width: colWidth,
@@ -271,13 +285,13 @@ export function WeekGrid({
             )}
 
             {loading &&
-              LOADING_SLOTS.map((s, i) => (
+              LOADING_SLOTS.filter((s) => slotOf(s.col) >= 0).map((s, i) => (
                 <div
                   key={`sk-${i}`}
                   aria-hidden
                   style={{
                     position: 'absolute',
-                    left: s.col * colWidth + 2,
+                    left: slotOf(s.col) * colWidth + 2,
                     top: toY(s.startMin) + 1,
                     width: colWidth - 4,
                     height: Math.max((s.durMin * hourPx) / 60 - 2, 20),
@@ -293,11 +307,11 @@ export function WeekGrid({
             {!loading && backdrop.map((b) => renderBlock(b, false))}
 
             {/* 현재 시각 선 — 오늘 칸에만, 표시 구간 안일 때만. */}
-            {!loading && todayCol != null && nowMin != null && nowMin >= startHour * 60 && nowMin <= endHour * 60 && (
+            {!loading && todayCol != null && slotOf(todayCol) >= 0 && nowMin != null && nowMin >= startHour * 60 && nowMin <= endHour * 60 && (
               <div
                 style={{
                   position: 'absolute',
-                  left: todayCol * colWidth,
+                  left: slotOf(todayCol) * colWidth,
                   width: colWidth,
                   top: toY(nowMin),
                   height: 2,

--- a/src/screens/WeeklyCalendarScreen.tsx
+++ b/src/screens/WeeklyCalendarScreen.tsx
@@ -150,15 +150,40 @@ export function WeeklyCalendarScreenV2() {
     return `W${wk} · ${start.getMonth() + 1}/${start.getDate()}–${end.getMonth() + 1}/${end.getDate()}`;
   })();
 
-  // 자정부터 자정까지 24시간 전체를 스크롤로 훑을 수 있어야 한다 — 6시로 좁혀두면
-  // "시작 시간" 선택지(07:00~22:00) 밖은 물론 그 이전 새벽 시간대 블록도 y<0 으로
-  // 렌더 자체가 안 돼 시간표에서 사라진다(#85 의 근본 원인과 동일한 종류의 결함).
-  const START_H = 0, END_H = 24;
-  const HOUR_PX = 56;
-  const COL_W = 50;
-  const TIME_W = 30;
-
   const parseMin = (t: string) => { const [h, m] = t.split(':').map(Number); return h * 60 + m; };
+
+  // ── 밀도 ────────────────────────────────────────────────────
+  // 390px 에 7열 × 24시간을 넣으면 열이 50px 이라 "캡스톤 발표 / 자료" 처럼 제목이
+  // 깨지고 글씨가 8px 이 된다. 기본은 3일 뷰로 열을 넓히고, 전체 조망이 필요하면
+  // 7일로 토글한다. 시간표 자체는 그대로 — 드래그·다중 주 로직 전부 재사용.
+  const [dayView, setDayView] = useState<3 | 7>(3);
+  const TIME_W = dayView === 3 ? 34 : 30;
+  const COL_W = dayView === 3 ? 108 : 50;
+  const HOUR_PX = dayView === 3 ? 64 : 56;
+
+  // 3일 뷰에서 보여줄 칸 — 오늘(이번 주가 아니면 월요일)부터 3일.
+  // 주 끝에 걸치면 뒤로 당겨 항상 3칸이 차게 한다.
+  const visibleCols = (() => {
+    if (dayView === 7) return [0, 1, 2, 3, 4, 5, 6];
+    const anchor = Math.min(isThisWeek ? TODAY : 0, 4);
+    return [anchor, anchor + 1, anchor + 2];
+  })();
+
+  // 블록이 하나도 없는 새벽·심야를 잘라낸다. 주 4블록인데 24시간을 스크롤하는 게
+  // 지금 화면의 가장 큰 낭비다. 잘라내도 앞뒤로 1시간 여유는 남겨 드래그로 옮길
+  // 자리를 준다. '전체 시간' 토글로 다시 24시간을 펼 수 있다.
+  const [showAllHours, setShowAllHours] = useState(false);
+  const [START_H, END_H] = (() => {
+    if (showAllHours || blocks.length === 0) return [0, 24];
+    const mins = blocks.map((b) => parseMin(b.time));
+    const ends = blocks.map((b, i) => mins[i] + b.dur);
+    const lo = Math.max(0, Math.floor(Math.min(...mins) / 60) - 1);
+    const hi = Math.min(24, Math.ceil(Math.max(...ends) / 60) + 1);
+    // 너무 좁으면 오히려 어색하다 — 최소 8시간은 보여준다.
+    return hi - lo >= 8 ? [lo, hi] : [Math.max(0, Math.min(lo, 24 - 8)), Math.max(hi, Math.min(24, lo + 8))];
+  })();
+  const hiddenHours = 24 - (END_H - START_H);
+
   const toY = (m: number) => (m - START_H * 60) * HOUR_PX / 60;
 
   // 그리드가 0시(자정)부터라 그냥 두면 새벽 빈 칸부터 보인다 — 로드 후 유용한
@@ -167,9 +192,11 @@ export function WeeklyCalendarScreenV2() {
     if (planLoading) return;
     const el = gridRef.current;
     if (!el) return;
+    // 빈 시간대를 접었으면 맨 위가 곧 첫 블록 근처라 그대로 둔다.
+    if (START_H > 0 || END_H < 24) { el.scrollTop = 0; return; }
     const targetH = isThisWeek ? Math.min(Math.max(_now.getHours(), 6), 20) : 8;
     el.scrollTop = Math.max(0, toY(targetH * 60) - 8);
-  }, [planLoading, isThisWeek, weekStartStr]);
+  }, [planLoading, isThisWeek, weekStartStr, START_H, END_H, dayView]);
 
   const blockStyle = (b: BlockWithStatus) => {
     if (b.status === 'done')   return { bg: '#E5EFE3', bd: '#b4dfc8', fg: 'var(--success)' };
@@ -303,6 +330,15 @@ export function WeeklyCalendarScreenV2() {
     }
   };
 
+  // 가로 드래그 거리 → 새 요일. 3일 뷰에선 보이는 칸(visibleCols) 안에서만 움직인다 —
+  // 화면에 없는 요일로 끌어다 놓으면 블록이 사라진 것처럼 보이기 때문.
+  const dayFromDx = (startDay: number, dx: number): number => {
+    const from = visibleCols.indexOf(startDay);
+    if (from < 0) return startDay;
+    const to = Math.max(0, Math.min(visibleCols.length - 1, from + Math.round(dx / COL_W)));
+    return visibleCols[to];
+  };
+
   // pointerdown 핸들러 — 블록에 등록.
   const handleBlockPointerDown = (e: React.PointerEvent, block: BlockWithStatus) => {
     if (block.fixed) return; // 고정 블록은 드래그 불가.
@@ -325,8 +361,7 @@ export function WeeklyCalendarScreenV2() {
       if (!dragMovedRef.current) return;
       // 픽셀 → 분 변환. 15분 snap.
       const minDelta = Math.round((dy / HOUR_PX) * 60 / SNAP_MIN) * SNAP_MIN;
-      const dayDelta = Math.round(dx / COL_W);
-      const newDay = Math.max(0, Math.min(6, startDay + dayDelta));
+      const newDay = dayFromDx(startDay, dx);
       const newMinute = Math.max(0, Math.min(24 * 60 - block.dur, startMinute + minDelta));
       setDragGhost({ id: block.id, day: newDay, minute: newMinute });
     };
@@ -345,8 +380,7 @@ export function WeeklyCalendarScreenV2() {
       const dx = ev.clientX - startX;
       const dy = ev.clientY - startY;
       const minDelta = Math.round((dy / HOUR_PX) * 60 / SNAP_MIN) * SNAP_MIN;
-      const dayDelta = Math.round(dx / COL_W);
-      const newDay = Math.max(0, Math.min(6, startDay + dayDelta));
+      const newDay = dayFromDx(startDay, dx);
       const newMinute = Math.max(0, Math.min(24 * 60 - block.dur, startMinute + minDelta));
       setDragGhost(null);
       if (newDay === startDay && newMinute === startMinute) return; // no-op.
@@ -357,6 +391,17 @@ export function WeeklyCalendarScreenV2() {
     targetEl.addEventListener('pointerup', onUp);
     targetEl.addEventListener('pointercancel', onUp);
   };
+
+  // 조작법은 상시 배너 대신 최초 1회만 알려준다.
+  const HINT_KEY = 'reaction.weekly.dragHintSeen';
+  useEffect(() => {
+    if (planLoading || blocks.length === 0) return;
+    try {
+      if (localStorage.getItem(HINT_KEY)) return;
+      localStorage.setItem(HINT_KEY, '1');
+    } catch { return; /* 프라이빗 모드 등 — 힌트를 건너뛴다 */ }
+    showToast('블록을 탭하면 수정, 끌면 15분 단위로 이동돼요');
+  }, [planLoading, blocks.length]);
 
   const handleSave = async (updated: Block) => {
     const prev = blocks.find((b) => b.id === updated.id);
@@ -449,7 +494,8 @@ export function WeeklyCalendarScreenV2() {
             >이번 주</button>
           )}
         </div>
-        <p style={{ fontSize: 11, color: 'var(--text-3)', margin: '0 0 8px' }}>블록을 탭하면 수정, 길게 누른 채 끌면 15분 단위로 이동돼요.</p>
+        {/* 조작 안내는 상시 UI 로 두지 않는다 — 헤더가 화면의 35% 를 먹던 원인 중 하나.
+            블록을 처음 만졌을 때 한 번만 토스트로 알려준다. */}
         {!planLoading && !usingRealPlan && (
           <div style={{ marginBottom: 8 }}>
             <DemoNotice storageKey="weekly-calendar">
@@ -464,14 +510,44 @@ export function WeeklyCalendarScreenV2() {
             </EmptyState>
           </div>
         )}
-        <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+        {/* 칩은 완료·대기만. 이월은 0 일 때가 대부분이라 자리만 차지했다.
+            같은 줄에 3일/7일 토글과 시간대 접기를 둬서 헤더를 2줄로 유지한다. */}
+        <div style={{ display: 'flex', gap: 6, alignItems: 'center', flexWrap: 'wrap' }}>
           {[
-            { label: '완료', n: blocks.filter((b) => b.status === 'done').length, bg: '#E5EFE3', bd: '#b4dfc8', fg: 'var(--success)' },
-            { label: '이월', n: blocks.filter((b) => b.carryover).length, bg: '#FBEEDA', bd: '#F2D29A', fg: 'var(--warning)' },
-            { label: '대기', n: blocks.filter((b) => b.status === 'pending' && !b.carryover).length, bg: 'var(--sand-100)', bd: 'var(--sand-200)', fg: 'var(--text-2)' },
+            { label: '완료', n: blocks.filter((b) => b.status === 'done').length, bg: '#E5EFE3', bd: '#b4dfc8', fg: 'var(--success-ink)' },
+            { label: '대기', n: blocks.filter((b) => b.status === 'pending').length, bg: 'var(--sand-100)', bd: 'var(--sand-200)', fg: 'var(--text-2)' },
           ].map((c, i) => (
             <span key={i} className="tnum" style={{ height: 'var(--ctrl-xs)', padding: '0 9px', background: c.bg, border: `1px solid ${c.bd}`, borderRadius: 9999, fontSize: 10, color: c.fg, fontWeight: 600, display: 'inline-flex', alignItems: 'center', fontFamily: 'var(--font-mono)' }}>{c.label} {c.n}</span>
           ))}
+
+          <div style={{ flex: 1 }} />
+
+          {hiddenHours > 0 && !showAllHours && (
+            <button
+              onClick={() => setShowAllHours(true)}
+              style={{ height: 'var(--ctrl-xs)', padding: '0 9px', borderRadius: 9999, border: '1px dashed var(--sand-300)', background: 'transparent', color: 'var(--text-3)', fontSize: 10, fontWeight: 600, cursor: 'pointer', fontFamily: 'var(--font-mono)' }}
+            >빈 {hiddenHours}시간 접힘</button>
+          )}
+          {showAllHours && (
+            <button
+              onClick={() => setShowAllHours(false)}
+              style={{ height: 'var(--ctrl-xs)', padding: '0 9px', borderRadius: 9999, border: '1px solid var(--sand-200)', background: 'var(--surface-raised)', color: 'var(--text-3)', fontSize: 10, fontWeight: 600, cursor: 'pointer', fontFamily: 'var(--font-mono)' }}
+            >24시간</button>
+          )}
+
+          <div style={{ display: 'inline-flex', background: 'var(--sand-100)', borderRadius: 9999, padding: 2, gap: 2 }}>
+            {([3, 7] as const).map((n) => {
+              const on = dayView === n;
+              return (
+                <button
+                  key={n}
+                  onClick={() => setDayView(n)}
+                  className="tnum"
+                  style={{ height: 22, padding: '0 10px', borderRadius: 9999, border: 'none', background: on ? 'var(--surface-raised)' : 'transparent', color: on ? 'var(--text-1)' : 'var(--text-3)', fontSize: 10, fontWeight: 700, cursor: 'pointer', fontFamily: 'var(--font-mono)', boxShadow: on ? 'var(--shadow-sm, 0 1px 2px rgba(0,0,0,.06))' : 'none' }}
+                >{n}일</button>
+              );
+            })}
+          </div>
         </div>
       </div>
 
@@ -487,6 +563,7 @@ export function WeeklyCalendarScreenV2() {
         colWidth={COL_W}
         timeWidth={TIME_W}
         loading={planLoading}
+        visibleCols={visibleCols}
         onBlockPointerDown={(e, gb) => {
           const b = blocks.find((x) => x.id === gb.id);
           if (b) handleBlockPointerDown(e, b);


### PR DESCRIPTION
## 작업 배경

개편 4단계 중 **마지막**. **시간표는 이 제품의 정체성이라 유지**하고, 밀도만 손봅니다.
문제는 시간표 자체가 아니라 390px 에 7열 × 24시간을 우겨넣은 것이었습니다.

| 고칠 것 | 내용 |
|---|---|
| ① 열 폭 ~50px | 제목이 "캡스톤 발표 / 자료" 로 깨지고 글씨가 8px |
| ② 헤더가 화면의 35% | 주 네비 + 안내문구 + 칩 3개 |
| ③ 주에 블록 4개인데 24시간 스크롤 | |
| ④ 조작 안내문이 상시 UI 로 박힘 | |

## 조치

**3일 기본 뷰** — 열 **50px → 108px**, 시간 칸 56px → 64px.
제목이 한 줄에 들어가고 시각·소요가 함께 보입니다 (블록 글씨 **8px → 11px**).
**7일 토글**로 전체 조망도 유지합니다.

**빈 시간대 접기** — 블록이 있는 구간만 보여줍니다(앞뒤 1시간 여유, 최소 8시간).
`빈 N시간 접힘` 칩을 누르면 24시간을 폅니다.

**헤더 2줄** — 안내문구는 **최초 1회 토스트**로 옮겼고, 칩은 완료·대기만 남겼습니다
(이월은 대개 0이라 자리만 차지했습니다).

### WeekGrid API

`visibleCols` 를 추가했습니다. 실제 요일 번호 → 화면 칸 인덱스를 매핑하고,
안 보이는 요일의 블록은 렌더하지 않습니다. `colWidth ≥ 80` 이면 타이포가 커집니다.

**드래그의 가로 이동은 보이는 칸 안에서만** 움직입니다 — 화면에 없는 요일로 끌어다
놓으면 블록이 사라진 것처럼 보이기 때문입니다.

## 검증 — 드래그가 가장 깨지기 쉬워 실측했습니다

| 뷰 | 드래그 | 결과 |
|---|---|---|
| 3일 | 128px 아래로 | 14:00 → **16:00** ✓ |
| 7일 | 126px 아래로 | 16:00 → **18:15** ✓ |

- **`PATCH /plans/{id}/blocks/{id}` 2건 모두 올바른 `startAt` 으로 전송됨**
- 24시간 펼치기 토글 동작 확인
- Playwright **11개 화면 렌더, 런타임 에러 0**
- `tsc` 0 errors / API 계약 **PASS** / `build` 성공

## 디자인 시스템 재동기화

4단계가 모두 끝나 claude.ai/design 프로젝트를 갱신했습니다 (**31개, 프리뷰 31/31 정상**).

- `WeekGrid` 프리뷰를 **3일 / 7일 / 초안+잔상 / 로딩** 4종으로 다시 작성
- `HeroTaskCard`·`TaskRow` 프리뷰에 시각·소요·목표 프롭 반영
- 토큰 규칙(면 vs `-ink` vs `-soft`)을 `.design-sync/NOTES.md` 에 기록

## 4단계 전체 요약

| 단계 | PR | 핵심 |
|---|---|---|
| ① enum 노출 + 회복 배너 | #171 | 내부 코드 노출 0건, 빨간 경고 → 중립 톤 |
| ② 대비 | #172 | 실측 FAIL **16 → 1**, 팔레트 유지 |
| ③ 오늘 정보 부착 | #173 | 시각·소요·목표, 빈 습관 접기, 회복 칩 승격 |
| ④ 시간표 넓히기 | 이 PR | 열 50 → 108px, 빈 시간대 접기, 헤더 2줄 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
