### PR TITLE
fix(auth): 로그인 후 계정 정보를 다 불러올 때까지 로딩 — 빈 화면·잘못된 진입 제거

### DIFF
--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -5,7 +5,7 @@ import { LoginScreen } from '../screens/LoginScreen';
 import { NavigationContext, STATE_TO_SCREEN } from '../contexts/NavigationContext';
 import { ToastProvider } from '../contexts/ToastContext';
 import { IosInstallCard } from '../components/IosInstallCard';
-import { ApiError, authApi, friendlyError, onboardingApi, setAccessToken } from '../lib/api';
+import { ApiError, authApi, friendlyError, onAuthExpired, onboardingApi, setAccessToken, stubLoginAllowed } from '../lib/api';
 import type { ScreenId, TabId } from '../types';
 import type { OnboardingState, UserProfile } from '../types/api';
 
@@ -58,6 +58,18 @@ export function AppShell() {
   const [needsLogin, setNeedsLogin] = useState(false);
   const [authBusy, setAuthBusy] = useState(false);
   const [authError, setAuthError] = useState<string | null>(null);
+  // 로그인 성공 후 계정 정보를 다시 확인하는 동안. 이게 없으면 로그인 직후 앱이
+  // 곧바로 렌더돼, 계정 상태가 덜 온 채로 라우팅되고 화면은 빈 상태로 남는다.
+  const [sessionLoading, setSessionLoading] = useState(false);
+  // 계정 정보를 못 불러왔을 때. 예전엔 조용히 intro(온보딩)로 떨어져서,
+  // 이미 온보딩을 끝낸 사용자가 처음부터 다시 하는 것처럼 보였다.
+  const [bootError, setBootError] = useState<string | null>(null);
+
+  // ?force=<screen> — 시연·개발용 강제 진입. 계정 상태 판단보다 우선한다.
+  const forcedScreen =
+    typeof window === 'undefined'
+      ? null
+      : (new URLSearchParams(window.location.search).get('force') as ScreenId | null);
 
   // /auth/me(또는 로그인) 성공 응답을 화면 상태에 반영 — 부팅 시와 로그인 버튼 클릭 시 공용.
   const applyProfile = useCallback((profile: UserProfile) => {
@@ -90,15 +102,31 @@ export function AppShell() {
     }
   }, []);
 
+  // 로그인 응답의 user 를 그대로 쓰지 않고 /auth/me 로 한 번 더 확인한다.
+  // 부팅 경로와 같은 소스를 써야 진입 화면(onboardingState) 판단이 어긋나지 않는다.
+  // 이 동안 스플래시를 유지해 "로그인은 됐는데 빈 화면" 을 없앤다.
+  const loadSessionAfterLogin = useCallback(async (fallbackProfile: UserProfile) => {
+    setSessionLoading(true);
+    try {
+      applyProfile(await authApi.me());
+    } catch {
+      // /auth/me 가 실패하면 로그인 응답의 user 로라도 진행한다(로그인 자체는 성공했으므로).
+      applyProfile(fallbackProfile);
+    } finally {
+      setSessionLoading(false);
+    }
+  }, [applyProfile]);
+
   // 실제 Google 로그인 — LoginScreen 의 GIS 콜백에서 받은 id_token 을 백엔드로 전달.
   const handleGoogleCredential = useCallback(async (idToken: string) => {
     setAuthBusy(true);
     setAuthError(null);
     try {
       const session = await authApi.loginWithGoogle(idToken);
-      setAccessToken(session.accessToken);
-      applyProfile(session.user);
+      setAccessToken(session.accessToken, 'real');
       setNeedsLogin(false);
+      setBootError(null);
+      await loadSessionAfterLogin(session.user);
     } catch (err) {
       setAuthError(
         friendlyError(err, '로그인에 실패했어요. 다시 시도해주세요.'),
@@ -106,7 +134,7 @@ export function AppShell() {
     } finally {
       setAuthBusy(false);
     }
-  }, [applyProfile]);
+  }, [loadSessionAfterLogin]);
 
   // 데모 계정 명시적 진입 — 로그인 화면에서 사용자가 직접 눌렀을 때만(자동 아님).
   const handleDemoLogin = useCallback(async () => {
@@ -114,9 +142,10 @@ export function AppShell() {
     setAuthError(null);
     try {
       const session = await authApi.loginWithGoogle(stubIdToken());
-      setAccessToken(session.accessToken);
-      applyProfile(session.user);
+      setAccessToken(session.accessToken, 'stub');
       setNeedsLogin(false);
+      setBootError(null);
+      await loadSessionAfterLogin(session.user);
     } catch (err) {
       setAuthError(
         friendlyError(err, '로그인에 실패했어요. 다시 시도해주세요.'),
@@ -124,7 +153,18 @@ export function AppShell() {
     } finally {
       setAuthBusy(false);
     }
-  }, [applyProfile]);
+  }, [loadSessionAfterLogin]);
+
+  // 되살릴 수 없는 401 = 세션 종료. 토큰은 api 레이어에서 이미 버렸다.
+  // 여기서 로그인 화면으로 돌려보내지 않으면 "데이터만 안 나오는 화면" 에 갇힌다.
+  useEffect(() => {
+    onAuthExpired(() => {
+      setNeedsLogin(true);
+      setSessionLoading(false);
+      setAuthError('로그인이 만료됐어요. 다시 로그인해 주세요.');
+    });
+    return () => onAuthExpired(null);
+  }, []);
 
   // 부팅 — /auth/me 로 사용자 상태 확인 후 applyProfile 이 계정 onboarding_state
   // 로 진입 화면을 결정한다(#120). ACTIVE→today, 중간 상태→resume, WELCOME→intro.
@@ -157,16 +197,15 @@ export function AppShell() {
         //    VITE_ALLOW_STUB_LOGIN=false 로 꺼서 가짜 토큰 자동 발급을 막고
         //    실제 Google 로그인 화면(LoginScreen)을 보여준다.
         //    ?login=1 로 강제로 로그인 화면을 확인할 수 있다(수동 테스트용).
-        const forceLogin = new URLSearchParams(window.location.search).get('login') === '1';
         let profile;
         try {
           profile = await authApi.me();
         } catch (err) {
-          const stubLoginAllowed = import.meta.env.VITE_ALLOW_STUB_LOGIN !== 'false' && !forceLogin;
           if (err instanceof ApiError && err.status === 401) {
-            if (stubLoginAllowed) {
+            // api 레이어 자가치유와 같은 판단을 쓴다(stubLoginAllowed).
+            if (stubLoginAllowed()) {
               const session = await authApi.loginWithGoogle(stubIdToken());
-              setAccessToken(session.accessToken);
+              setAccessToken(session.accessToken, 'stub');
               profile = session.user;
             } else {
               // 실제 로그인 필요 — 로그인 화면으로 전환하고 부팅을 종료한다(아래 finally).
@@ -180,9 +219,12 @@ export function AppShell() {
         if (cancelled) return;
         applyProfile(profile);
       } catch (err) {
-        // 백엔드 미기동/네트워크 오류는 그냥 로컬 데모 모드(intro 시작)로 fallback.
-        if (!(err instanceof ApiError)) {
-          console.warn('[bootstrap] auth failed — local demo mode', err);
+        // 예전엔 여기서 조용히 넘겨 intro(온보딩) 화면으로 떨어졌다 — 이미 온보딩을
+        // 끝낸 계정도 처음부터 다시 하는 것처럼 보였고, 사용자는 왜 그런지 알 수 없었다.
+        // 이제 사실을 표시하고 재시도를 준다.
+        console.warn('[bootstrap] 계정 정보를 불러오지 못했습니다', err);
+        if (!cancelled) {
+          setBootError(friendlyError(err, '계정 정보를 불러오지 못했어요. 네트워크 상태를 확인해 주세요.'));
         }
       } finally {
         if (!cancelled) setIsBootstrapping(false);
@@ -195,8 +237,20 @@ export function AppShell() {
     };
   }, []);
 
-  if (isBootstrapping) {
-    return <BootSplash />;
+  // 부팅 중 + 로그인 직후 계정 정보를 받는 동안 모두 스플래시를 유지한다.
+  // 데이터가 오기 전에 앱을 렌더하면 "로그인은 됐는데 빈 화면" 이 된다.
+  if (isBootstrapping || sessionLoading) {
+    return <BootSplash label={sessionLoading ? '계정 정보를 불러오는 중…' : undefined} />;
+  }
+
+  // 계정 정보를 못 불러온 상태로 앱에 들여보내지 않는다 — 어느 화면을 보여줘야 할지
+  // 모르는 채로 렌더하면 온보딩을 끝낸 사용자도 처음 화면으로 떨어진다.
+  //
+  // 단, `?force=<screen>` 은 "이 화면을 보겠다" 고 이미 정한 것이므로 막지 않는다.
+  // 시연·개발에서 백엔드가 안 붙어도 화면을 확인할 수 있어야 하고, 각 화면은
+  // 데이터가 없으면 정직한 빈 상태를 보여주도록 되어 있다.
+  if (bootError && !needsLogin && !forcedScreen) {
+    return <BootFailed message={bootError} onRetry={() => window.location.reload()} onLogin={() => { setBootError(null); setNeedsLogin(true); }} />;
   }
 
   if (needsLogin) {
@@ -237,15 +291,17 @@ export function AppShell() {
   );
 }
 
-function BootSplash() {
+function BootSplash({ label }: { label?: string }) {
   return (
     <div
       style={{
         position: 'fixed',
         inset: 0,
         display: 'flex',
+        flexDirection: 'column',
         alignItems: 'center',
         justifyContent: 'center',
+        gap: 14,
         background: 'var(--surface-ground)',
       }}
     >
@@ -258,6 +314,92 @@ function BootSplash() {
         }}
       >
         RE:ACTION
+      </div>
+      {/* 무엇을 기다리는지 알려준다 — 그냥 로고만 있으면 멈춘 것처럼 보인다. */}
+      {label && (
+        <div style={{ fontSize: 12, color: 'var(--text-3)' }} role="status">{label}</div>
+      )}
+    </div>
+  );
+}
+
+// 계정 정보를 못 불러왔을 때. 빈 화면이나 엉뚱한 온보딩으로 떨어뜨리지 않고
+// 무엇이 안 됐는지 말하고 다음 행동을 준다.
+function BootFailed({
+  message,
+  onRetry,
+  onLogin,
+}: {
+  message: string;
+  onRetry: () => void;
+  onLogin: () => void;
+}) {
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 16,
+        padding: '40px 28px',
+        textAlign: 'center',
+        background: 'var(--surface-ground)',
+      }}
+    >
+      <div
+        style={{
+          fontFamily: 'var(--font-mono)',
+          fontSize: 11,
+          letterSpacing: '0.12em',
+          color: 'var(--text-3)',
+        }}
+      >
+        RE:ACTION
+      </div>
+      <p
+        role="alert"
+        style={{ margin: 0, fontSize: 14, lineHeight: 1.65, color: 'var(--text-1)', maxWidth: 300 }}
+      >
+        {message}
+      </p>
+      <div style={{ display: 'flex', gap: 8 }}>
+        <button
+          onClick={onRetry}
+          style={{
+            height: 'var(--ctrl-lg)',
+            padding: '0 18px',
+            borderRadius: 12,
+            border: 'none',
+            background: 'var(--brand-surface)',
+            color: '#FFFCF6',
+            fontWeight: 700,
+            fontSize: 14,
+            fontFamily: 'inherit',
+            cursor: 'pointer',
+          }}
+        >
+          다시 시도
+        </button>
+        <button
+          onClick={onLogin}
+          style={{
+            height: 'var(--ctrl-lg)',
+            padding: '0 18px',
+            borderRadius: 12,
+            border: '1px solid var(--sand-200)',
+            background: 'var(--surface-raised)',
+            color: 'var(--text-2)',
+            fontWeight: 600,
+            fontSize: 14,
+            fontFamily: 'inherit',
+            cursor: 'pointer',
+          }}
+        >
+          다시 로그인
+        </button>
       </div>
     </div>
   );

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -151,10 +151,44 @@ function getToken(): string | null {
   return window.localStorage.getItem(TOKEN_KEY);
 }
 
-export function setAccessToken(token: string | null): void {
+// 세션을 어떻게 얻었는지. 'real' = 실제 Google 로그인, 'stub' = 데모/개발용.
+// 401 자가치유가 실제 사용자를 데모 계정으로 갈아타게 만들면 안 되므로 구분해 둔다.
+const AUTH_KIND_KEY = 'reaction.authKind';
+export type AuthKind = 'real' | 'stub';
+
+export function setAccessToken(token: string | null, kind?: AuthKind): void {
   if (typeof window === 'undefined') return;
-  if (token) window.localStorage.setItem(TOKEN_KEY, token);
-  else window.localStorage.removeItem(TOKEN_KEY);
+  if (token) {
+    window.localStorage.setItem(TOKEN_KEY, token);
+    if (kind) window.localStorage.setItem(AUTH_KIND_KEY, kind);
+  } else {
+    window.localStorage.removeItem(TOKEN_KEY);
+    window.localStorage.removeItem(AUTH_KIND_KEY);
+  }
+}
+
+export function getAuthKind(): AuthKind | null {
+  if (typeof window === 'undefined') return null;
+  const v = window.localStorage.getItem(AUTH_KIND_KEY);
+  return v === 'real' || v === 'stub' ? v : null;
+}
+
+// 세션이 끝났음(되살릴 수 없는 401)을 앱 껍데기에 알린다.
+// 예전엔 401 이 각 화면의 개별 에러로만 끝나서, 세션이 만료되면 "데이터가 안 불러와지는"
+// 화면만 남고 재로그인 유도가 없었다.
+type AuthExpiredHandler = () => void;
+let authExpiredHandler: AuthExpiredHandler | null = null;
+export function onAuthExpired(handler: AuthExpiredHandler | null): void {
+  authExpiredHandler = handler;
+}
+
+// stub 자동 로그인을 허용하는가 — AppShell 부트스트랩과 api 레이어 자가치유가
+// 같은 판단을 써야 한다. 예전엔 api 레이어가 VITE_ALLOW_STUB_LOGIN 만 봐서,
+// `?login=1` 로 로그인 화면을 강제해도 자가치유가 먼저 자동 로그인해 무력화됐다.
+export function stubLoginAllowed(): boolean {
+  if (typeof window === 'undefined') return false;
+  if (import.meta.env.VITE_ALLOW_STUB_LOGIN === 'false') return false;
+  return new URLSearchParams(window.location.search).get('login') !== '1';
 }
 
 // stub 로그인 idToken — 브라우저별 전용 계정(demo:<deviceId>), `?demo=stub` 이면 시드 계정.
@@ -185,9 +219,15 @@ async function request<T>(path: string, opts: RequestOptions = {}): Promise<T> {
   const { method = 'GET', body, idempotencyKey, anonymous = false, _retry = false } = opts;
   const headers: Record<string, string> = { Accept: 'application/json' };
   if (body !== undefined) headers['Content-Type'] = 'application/json';
+  // 토큰을 실제로 실어보냈는지 — 아래 401 처리에서 "세션 만료" 와 "애초에 미로그인" 을
+  // 구분하는 데 쓴다. 구분하지 않으면 첫 방문자에게도 "로그인이 만료됐어요" 가 뜬다.
+  let sentToken = false;
   if (!anonymous) {
     const token = getToken();
-    if (token) headers['Authorization'] = `Bearer ${token}`;
+    if (token) {
+      headers['Authorization'] = `Bearer ${token}`;
+      sentToken = true;
+    }
   }
   if (idempotencyKey) headers['Idempotency-Key'] = idempotencyKey;
 
@@ -203,12 +243,16 @@ async function request<T>(path: string, opts: RequestOptions = {}): Promise<T> {
   if (!res.ok) {
     // 401 자가치유: 인증 필요 호출인데 토큰이 없/만료면 stub 재로그인 후 1회 재시도.
     // (부트스트랩 타이밍/토큰 유실로 "인증 헤더 없음" 401 이 나던 문제 방지)
+    // stub 자가치유는 데모/개발 세션에만 적용한다. 실제 Google 로그인 사용자에게
+    // 적용하면 만료된 순간 조용히 '데모 계정' 으로 갈아타서, 로그인은 되어 있는데
+    // 남의(또는 빈) 데이터가 보이는 상태가 된다.
     if (
       res.status === 401 &&
       !anonymous &&
       !_retry &&
       typeof window !== 'undefined' &&
-      import.meta.env.VITE_ALLOW_STUB_LOGIN !== 'false'
+      getAuthKind() !== 'real' &&
+      stubLoginAllowed()
     ) {
       try {
         const session = await request<AuthSession>('/auth/google', {
@@ -216,11 +260,18 @@ async function request<T>(path: string, opts: RequestOptions = {}): Promise<T> {
           body: { idToken: stubIdToken() },
           anonymous: true,
         });
-        setAccessToken(session.accessToken);
+        setAccessToken(session.accessToken, 'stub');
         return await request<T>(path, { ...opts, _retry: true });
       } catch {
         /* 재로그인 실패 — 아래에서 원래 401 을 그대로 던진다 */
       }
+    }
+
+    // 여기까지 온 401 은 되살릴 수 없다 — 토큰을 버리고 재로그인으로 보낸다.
+    // 토큰을 보내지 않았던 요청(= 애초에 로그인 상태가 아님)은 만료가 아니므로 알리지 않는다.
+    if (res.status === 401 && !anonymous && sentToken) {
+      setAccessToken(null);
+      authExpiredHandler?.();
     }
 
     let payload: ApiErrorPayload | null = null;


### PR DESCRIPTION
## 작업 배경

"로그인해도 계정 정보나 캘린더가 안 불러와지는 케이스"를 추적해 **원인 4건**을 찾았습니다.

## 1. 로그인 응답의 `user` 로 라우팅하고 있었다

부팅은 `/auth/me` 를 쓰는데 **로그인 성공 경로만 로그인 응답의 `user` 를 그대로** 썼습니다.
두 소스가 갈라져 있어, 로그인 응답의 `onboardingState` 가 덜 채워져 오면 진입 화면이 틀리고
(온보딩 끝낸 계정이 처음 화면으로), 그 사이 앱은 이미 렌더돼 빈 화면만 남았습니다.

```
로그인 성공 → /auth/me 로 재확인 → 그 결과로 라우팅
그 동안 스플래시 유지 ("계정 정보를 불러오는 중…")
/auth/me 실패 시엔 로그인 응답 user 로라도 진행 (로그인 자체는 성공했으므로)
```

## 2. 되살릴 수 없는 401 이 각 화면의 개별 에러로만 끝났다

세션이 만료되면 화면마다 "불러오지 못했어요" 만 뜨고 **재로그인 유도가 없어서**
데이터만 안 나오는 앱에 갇혔습니다. api 레이어가 토큰을 버리고 앱 껍데기에 알립니다
(`onAuthExpired`) → 로그인 화면 + `로그인이 만료됐어요`.

**토큰을 실어보낸 요청에만** 알립니다 — 구분하지 않으면 첫 방문자에게도 만료 메시지가 뜹니다.

## 3. 401 자가치유가 실제 사용자를 데모 계정으로 갈아탔다

401 이면 무조건 stub 재로그인을 시도해서, **실제 Google 로그인 사용자의 토큰이 만료된 순간
조용히 `demo:<deviceId>` 계정으로 바뀌었습니다.** 로그인은 되어 있는데 남의(또는 빈) 데이터가
보이는 상태입니다.

세션 종류(`authKind='real'|'stub'`)를 저장해 **실제 로그인 사용자에게는 자가치유를 적용하지 않습니다.**

## 4. `?login=1` 이 무력화돼 있었다

AppShell 은 `?login=1` 을 봤지만 **api 레이어 자가치유는 `VITE_ALLOW_STUB_LOGIN` 만 봐서**,
로그인 화면을 강제해도 자가치유가 먼저 자동 로그인했습니다.
`stubLoginAllowed()` 로 양쪽이 같은 판단을 쓰게 했습니다.

## 부팅 실패를 조용히 넘기지 않는다

예전엔 `/auth/me` 실패를 `console.warn` 만 하고 **intro(온보딩)로 떨어졌습니다** —
이미 온보딩을 끝낸 계정도 처음부터 다시 하는 것처럼 보였고 이유를 알 수 없었습니다.
이제 사실을 표시하고 **[다시 시도] / [다시 로그인]** 을 줍니다.

단, **`?force=<screen>` 은 막지 않습니다.** 시연·개발에서 백엔드가 안 붙어도 화면을 봐야 하고,
각 화면은 이미 정직한 빈 상태를 렌더합니다.
(이 예외 없이는 데모 경로가 전부 막혔습니다 — 회귀 검증에서 11개 화면이 모두 재시도 화면으로
바뀌어 잡았습니다.)

## 검증 — Playwright 시나리오

| 시나리오 | 결과 |
|---|---|
| 로그인 성공 | 로그인 응답 `WELCOME` vs `/auth/me` `ACTIVE` → **today 진입** (=`/auth/me` 채택)<br>호출 순서 `POST /auth/google` → `GET /auth/me` 확인 |
| 데이터 401 | 토큰 폐기(`token=false`, `authKind=null`) + `로그인이 만료됐어요` |
| 부팅 500 | 재시도 화면 노출 (온보딩으로 떨어지지 않음) |
| 첫 방문자 401 | 만료 메시지 **미노출** |
| 11개 화면 회귀 | 전부 렌더, 런타임 에러 **0** |

`tsc` 0 errors · API 계약 **PASS** · `build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)
