### PR TITLE
feat(loading): 로딩 자리표시가 '빈 화면' 이 아니라 '기다리는 중' 으로 읽히게

### DIFF
--- a/src/components/SkeletonBlock.tsx
+++ b/src/components/SkeletonBlock.tsx
@@ -15,8 +15,10 @@ export interface SkeletonBlockProps {
  * 첫 fetch 가 끝날 때까지 자리를 잡아두는 placeholder.
  *
  * 이게 있어야 "더미 → 실데이터" 깜빡임 없이 빈 화면을 정직하게 넘길 수 있다.
- * 애니메이션은 쓰지 않는다 — 전역 @keyframes 를 추가하지 않기로 한 결정에 따라
- * 정적 muted 박스로만 표현한다.
+ *
+ * 은은한 shimmer 를 넣는다(index.css 의 .rx-skeleton). 정적 muted 박스만 두면
+ * 실측 화면에서 "로딩 중" 이 아니라 "데이터가 없는 빈 화면" 으로 읽혀서,
+ * 사용자가 기다려야 하는 상황인 줄 모른다.
  */
 export function SkeletonBlock({ count = 3, height = 64, radius = 12, gap = 8 }: SkeletonBlockProps) {
   return (
@@ -24,11 +26,15 @@ export function SkeletonBlock({ count = 3, height = 64, radius = 12, gap = 8 }: 
       {Array.from({ length: count }, (_, i) => (
         <div
           key={i}
+          className="rx-skeleton"
           style={{
             height,
             borderRadius: radius,
             border: '1px solid var(--sand-200)',
-            background: i % 2 === 0 ? 'var(--surface-raised)' : 'var(--sand-100)',
+            // backgroundColor 로 준다 — background 단축 속성을 쓰면 .rx-skeleton 의
+            // shimmer 그라디언트(background-image/size)까지 같이 리셋돼 애니메이션이
+            // 돌아도 눈에 보이는 게 없다(실측으로 확인).
+            backgroundColor: i % 2 === 0 ? 'var(--surface-raised)' : 'var(--sand-100)',
             opacity: 0.6,
           }}
         />

--- a/src/index.css
+++ b/src/index.css
@@ -334,6 +334,31 @@ body {
   to { width: 100%; }
 }
 
+/* Skeleton shimmer — 로딩 자리표시가 '빈 화면' 이 아니라 '기다리는 중' 으로 읽히게.
+   정적 muted 박스만 두면 사용자는 데이터가 없는 줄 알고 기다리지 않는다.
+   prefers-reduced-motion 에서는 움직임 대신 옅은 밝기만 남긴다. */
+@keyframes rx-shimmer {
+  0%   { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+.rx-skeleton {
+  /* 바탕이 크림(#FAF6EE~#FFFCF6)이라 흰색 하이라이트는 보이지 않는다 — 실측으로 확인.
+     밝은 쪽이 아니라 sand 톤으로 '어둡게' 쓸어야 눈에 띈다. */
+  background-image: linear-gradient(
+    100deg,
+    transparent 18%,
+    rgba(180, 163, 129, 0.28) 38%,
+    rgba(180, 163, 129, 0.28) 56%,
+    transparent 78%
+  );
+  background-size: 200% 100%;
+  background-repeat: no-repeat;
+  animation: rx-shimmer 1.4s linear infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .rx-skeleton { animation: none; }
+}
+
 /* Toast entrance */
 @keyframes toastIn {
   from { transform: translateY(8px); opacity: 0; }

--- a/src/screens/GoalClassificationScreen.tsx
+++ b/src/screens/GoalClassificationScreen.tsx
@@ -7,6 +7,7 @@ import type { Goal, GoalStatus } from '../types';
 import { SetupProgress } from '../components/SetupProgress';
 import { AiDraftCard } from '../components/AiDraftCard';
 import { ErrorBanner } from '../components/ErrorBanner';
+import { SkeletonBlock } from '../components/SkeletonBlock';
 
 interface GoalClassificationScreenProps {
   onNext: () => void;
@@ -140,9 +141,7 @@ export function GoalClassificationScreen({ onNext, outcome }: GoalClassification
         )}
 
         <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-          {isLoading && [0, 1, 2].map((i) => (
-            <div key={`sk${i}`} style={{ height: 68, borderRadius: 14, border: '1px solid var(--sand-200)', background: 'var(--surface-raised)', opacity: 0.6 }} aria-hidden="true" />
-          ))}
+          {isLoading && <SkeletonBlock count={3} height={68} radius={14} />}
           {!isLoading && usingReal && goals.length === 0 && (
             <div style={{ padding: '14px 16px', borderRadius: 12, background: 'var(--surface-raised)', border: '1px dashed var(--sand-200)', fontSize: 12, color: 'var(--text-2)', lineHeight: 1.5 }}>
               아직 등록된 목표가 없어요. 목표 파악 인터뷰를 완료하면 여기에 표시돼요.

--- a/src/screens/MorningBriefScreen.tsx
+++ b/src/screens/MorningBriefScreen.tsx
@@ -5,6 +5,7 @@ import { goalsApi, reviewsApi, todayApi } from '../lib/api';
 import { localDateStr } from '../lib/dates';
 import type { AgendaCard } from '../types/api';
 import { categoryLabel } from '../data';
+import { SkeletonBlock } from '../components/SkeletonBlock';
 
 interface MorningBriefScreenProps {
   onStart: () => void;
@@ -159,9 +160,7 @@ export function MorningBriefScreen({ onStart }: MorningBriefScreenProps) {
           <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--text-3)', fontFamily: 'var(--font-mono)', marginBottom: 10 }}>오늘의 실행 계획</div>
           {loading ? (
             <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }} aria-hidden="true">
-              {[0, 1].map((i) => (
-                <div key={i} style={{ height: 64, borderRadius: 16, background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', opacity: 0.6 }} />
-              ))}
+              <SkeletonBlock count={3} height={64} radius={16} gap={10} />
             </div>
           ) : blocks.length === 0 ? (
             <div style={{ padding: '14px 16px', borderRadius: 16, background: 'var(--surface-raised)', border: '1px dashed var(--sand-200)', fontSize: 12, color: 'var(--text-2)', lineHeight: 1.5 }}>

--- a/src/screens/SetupScreen.tsx
+++ b/src/screens/SetupScreen.tsx
@@ -14,6 +14,7 @@ import type {
 import { SetupProgress } from '../components/SetupProgress';
 import { useToast } from '../contexts/ToastContext';
 import { ErrorBanner } from '../components/ErrorBanner';
+import { SkeletonBlock } from '../components/SkeletonBlock';
 
 interface SetupScreenProps {
   onDone: () => void;
@@ -360,5 +361,5 @@ function TimeChips({ icon, title, options, value, onChange }: {
 }
 
 function SkeletonRow() {
-  return <div style={{ background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', borderRadius: 12, height: 50, opacity: 0.5 }} />;
+  return <SkeletonBlock count={1} height={50} radius={12} />;
 }

--- a/src/screens/TodayScreen.tsx
+++ b/src/screens/TodayScreen.tsx
@@ -452,16 +452,17 @@ export function MergedTodayScreen({ tasks, onOpen, onMarkDone, onPartial, onFail
         ) : (
         <div>
           <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 10 }}>
-            <span style={{ fontSize: 14, fontWeight: 700, color: 'var(--text-1)' }}>추적 습관 루틴 ({habits.length})</span>
+            {/* 아직 못 불러온 개수를 (0) 으로 단정하면 거짓 정보다 — 로딩 중엔 숫자를 비운다. */}
+            <span style={{ fontSize: 14, fontWeight: 700, color: 'var(--text-1)' }}>
+              추적 습관 루틴{habitsLoading ? '' : ` (${habits.length})`}
+            </span>
             <button
               onClick={() => setAddingHabit(true)}
               style={{ fontSize: 12, color: 'var(--brand-ink)', fontWeight: 600, background: 'none', border: 'none', cursor: 'pointer', fontFamily: 'inherit' }}
             >+ 습관 추가</button>
           </div>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-            {habitsLoading && [0, 1].map((i) => (
-              <div key={`hsk${i}`} style={{ height: 52, borderRadius: 14, background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', opacity: 0.6 }} aria-hidden="true" />
-            ))}
+            {habitsLoading && <SkeletonBlock count={2} height={52} radius={14} gap={10} />}
             {habits.map(h => {
               const done = h.doneDays >= h.targetDays;
               return (


### PR DESCRIPTION
## 문제

로그인 직후 화면을 **100ms 간격으로 훑어보니**, 요청은 계속 진행 중인데
화면은 **테두리만 있는 빈 박스 몇 개**였습니다. 로딩 표시가 "있긴 있는" 상태였지만
사용자 눈에는 **데이터가 없는 화면과 구분되지 않습니다.**

## 1. 스켈레톤에 shimmer

`.rx-skeleton`(index.css)으로 은은한 쓸림을 넣었습니다.
`prefers-reduced-motion` 에서는 애니메이션을 끕니다.

**두 번 헛짚어서 실측으로 잡았습니다:**

| 헛짚음 | 원인 | 수정 |
|---|---|---|
| 애니메이션은 도는데 안 보임 | 인라인 `background` **단축 속성**이 클래스의 `background-image`/`size` 를 리셋 | `backgroundColor` 로 변경 |
| 그라디언트는 살았는데 여전히 안 보임 | **흰색** 하이라이트를 크림 배경(`#FAF6EE~#FFFCF6`)에 얹음 | sand 톤으로 **어둡게** 쓸도록 변경 |

검증은 계산된 스타일이 아니라 **스켈레톤 한 개를 두 시점에 캡처해 픽셀이 실제로
달라지는지**로 했습니다 (1.4KB → 7.1KB — 그라디언트가 실제로 그려짐).

## 2. 로딩 중에 개수를 단정하지 않는다

`추적 습관 루틴 (0)` — **아직 못 불러온 개수를 0 으로** 표시하고 있었습니다.
거짓 정보였고, 로드 후 0개면 섹션이 접히면서 **레이아웃이 튀었습니다.**
로딩 중엔 숫자를 비웁니다.

## 3. 화면별로 흩어진 인라인 스켈레톤을 공용 컴포넌트로

`GoalClassification` / `MorningBrief` / `Setup` / `Today 습관` — 각자 다른 값으로
muted 박스를 만들고 있었습니다. `SkeletonBlock` 으로 통일해 shimmer 가 전부 적용됩니다.

## 검증

- **로그인 클릭 후 100ms 간격 14프레임** — 로딩 표시가 끊기는 구간 없음
- shimmer 픽셀 변화 실측 확인
- 11개 화면 회귀 렌더, 런타임 에러 **0**
- `tsc` 0 errors · API 계약 **PASS** · `build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)
