### PR TITLE
fix(goals): '분해' 버튼이 가짜 데모 트리를 보여주던 문제 — 실제 저장된 단계 조회로

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -380,8 +380,12 @@ export const goalsApi = {
   remove: (goalId: string) =>
     request<void>(`/goals/${goalId}`, { method: 'DELETE' }),
 
-  decompose: (goalId: string) =>
-    request<GoalDecomposition>(`/goals/${goalId}/decompose`, { method: 'POST', body: {} }),
+  // 이 목표의 **실제 분해 트리** — 계획 승인 시 저장된 goal_nodes 를 읽는다.
+  // 계획을 아직 승인하지 않았으면 nodes=[] 로 온다(에러 아님).
+  // 예전 `POST /decompose` 는 목표와 무관한 데모 트리(캡스톤 → 설계/구현/발표)를 돌려주던
+  // mock 이라 백엔드에서 제거됐다.
+  nodes: (goalId: string) =>
+    request<GoalDecomposition>(`/goals/${goalId}/nodes`),
 };
 
 // ── Time Policies (S07) ───────────────────────────────────────

--- a/src/screens/GoalsScreen.tsx
+++ b/src/screens/GoalsScreen.tsx
@@ -4,7 +4,6 @@ import { ApiError, friendlyError, goalsApi } from '../lib/api';
 import type { ApiGoal, GoalDecomposition, GoalTier } from '../types/api';
 import { GOAL_STATUS_META, GOAL_CATEGORY_OPTIONS, categoryLabel } from '../data';
 import { ReButton } from '../components/ReButton';
-import { AiDraftCard } from '../components/AiDraftCard';
 import { GoalCard } from '../components/GoalCard';
 import { IconAction } from '../components/IconAction';
 import { EmptyState } from '../components/EmptyState';
@@ -140,15 +139,18 @@ export function GoalsScreen() {
     }
   };
 
-  // ── decompose (Draft Layer) ──
-  const runDecompose = async (goal: ApiGoal) => {
+  // ── 분해 트리 조회 ──
+  // 생성이 아니라 **읽기**다. 트리는 계획 승인 시 만들어져 저장돼 있고, 여기서는 그걸 보여줄
+  // 뿐이다. 승인 전 목표는 nodes=[] 로 와서 빈 상태 안내를 띄운다.
+  const openNodes = async (goal: ApiGoal) => {
+    if (decomp?.goalId === goal.goalId) { setDecomp(null); return; }  // 토글
     setDecompBusy(goal.goalId);
     setError(null);
     try {
-      const data = await goalsApi.decompose(goal.goalId);
+      const data = await goalsApi.nodes(goal.goalId);
       setDecomp({ goalId: goal.goalId, data });
     } catch (err: unknown) {
-      setError(friendlyError(err, '분해에 실패했어요.'));
+      setError(friendlyError(err, '단계를 불러오지 못했어요.'));
     } finally {
       setDecompBusy(null);
     }
@@ -295,7 +297,7 @@ export function GoalsScreen() {
                         </div>
                         <div style={{ display: 'flex', gap: 6 }}>
                           <IconAction icon={<PencilSimple size={13} />} label="수정" onClick={() => startEdit(g)} />
-                          <IconAction icon={<TreeStructure size={13} />} label={decompBusy === g.goalId ? '분해 중…' : '분해'} onClick={() => runDecompose(g)} disabled={decompBusy === g.goalId} />
+                          <IconAction icon={<TreeStructure size={13} />} label={decompBusy === g.goalId ? '불러오는 중…' : '단계 보기'} onClick={() => openNodes(g)} disabled={decompBusy === g.goalId} />
                           {confirmDeleteId === g.goalId ? (
                             <button onClick={() => removeGoal(g)} style={{ flex: 1, height: 34, borderRadius: 10, border: 'none', background: 'var(--danger)', color: '#FFFCF6', fontWeight: 700, fontSize: 11, cursor: 'pointer', fontFamily: 'inherit' }}>정말 삭제</button>
                           ) : (
@@ -304,26 +306,26 @@ export function GoalsScreen() {
                         </div>
 
                         {decomp && decomp.goalId === g.goalId && (
-                          <AiDraftCard
-                            isDraft
-                            aiSource="llm"
-                            onAccept={() => setDecomp(null)}
-                            onEdit={() => setDecomp(null)}
-                            onReject={() => runDecompose(g)}
-                            acceptLabel="반영"
-                            editLabel="닫기"
-                            rejectLabel="다시"
-                          >
-                            <div style={{ fontSize: 11, color: 'var(--text-2)', marginBottom: 6 }}>하위 단계 제안</div>
-                            <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
-                              {decomp.data.nodes.map((n) => (
-                                <div key={n.nodeId} style={{ paddingLeft: n.depth * 12, fontSize: 12, color: 'var(--text-1)', display: 'flex', alignItems: 'center', gap: 6 }}>
-                                  <span style={{ width: 4, height: 4, borderRadius: 9999, background: 'var(--brand)', flexShrink: 0 }} />
-                                  {n.title}
+                          <div style={{ marginTop: 8, padding: '10px 12px', borderRadius: 12, background: 'var(--surface-sunken)', border: '1px solid var(--sand-200)' }}>
+                            {decomp.data.nodes.length === 0 ? (
+                              <div style={{ fontSize: 12, color: 'var(--text-2)', lineHeight: 1.55 }}>
+                                아직 이 목표의 단계가 없어요. 계획을 만들고 <b>이대로 시작</b>을 누르면
+                                여기에 단계가 저장돼요.
+                              </div>
+                            ) : (
+                              <>
+                                <div style={{ fontSize: 11, color: 'var(--text-2)', marginBottom: 6 }}>계획에 저장된 단계</div>
+                                <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                                  {decomp.data.nodes.map((n) => (
+                                    <div key={n.nodeId} style={{ paddingLeft: n.depth * 12, fontSize: 12, color: 'var(--text-1)', display: 'flex', alignItems: 'center', gap: 6 }}>
+                                      <span style={{ width: 4, height: 4, borderRadius: 9999, background: 'var(--brand)', flexShrink: 0 }} />
+                                      {n.title}
+                                    </div>
+                                  ))}
                                 </div>
-                              ))}
-                            </div>
-                          </AiDraftCard>
+                              </>
+                            )}
+                          </div>
                         )}
                       </>
                     )}


### PR DESCRIPTION
백엔드 PR: hanium-reaction/reaction-backend#186 (같이 머지해야 한다)

## 문제

목표 관리에서 어떤 목표의 '분해' 를 눌러도 **"캡스톤 → 설계 단계 / 구현 단계 / 발표 준비"** 가 나왔다. 백엔드 `POST /goals/{id}/decompose` 가 목표와 무관하게 하드코딩된 데모 트리를 돌려주는 mock 이었는데, 이 화면이 그걸 `AiDraftCard` 로 "하위 단계 제안" 이라며 그렸다. 사용자에겐 가짜라는 표시가 없다.

## 수정

백엔드가 mock 을 제거하고 `GET /goals/{id}/nodes`(계획 승인 시 저장된 실제 `goal_nodes`)로 대체했다. 이 화면도 거기에 맞춘다.

- `goalsApi.decompose` → `goalsApi.nodes` (POST 생성 → GET 조회)
- 버튼 **'분해' → '단계 보기'**. 같은 목표를 다시 누르면 접힌다(토글).
- `AiDraftCard`(수락/수정/재생성) → **읽기 전용 패널**. 저장된 것을 보여줄 뿐이라 수락할 것도 재생성할 것도 없다.
- **빈 상태 추가** — 계획 미승인 목표는 `nodes=[]` 로 오므로 *"계획을 만들고 이대로 시작을 누르면 여기에 단계가 저장돼요"* 를 띄운다. 예전엔 이 경우가 아예 없었다(mock 이 항상 뭔가 돌려줬으므로).

## 곁들여

이 변경으로 **확정한 마일스톤이 계획 이후 사라지던 것**도 일부 해소된다. 사용자가 "계획의 큰 그림" 에서 확인한 마일스톤이 계획에 branch 로 고정되는데, 지금까지 그 뒤로는 어디서도 볼 수 없었다(`goalNodes` 가 FE 전체에서 미사용). 이제 목표 관리에서 마일스톤 → 세션 구조를 볼 수 있다.

## 검증

`tsc` · `vite build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
