### PR TITLE
chore(api): 백엔드 API 동기화 (routine)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2317,6 +2317,26 @@
             "title": "Rawtext",
             "type": "string"
           },
+          "resourceSlug": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Resourceslug"
+          },
+          "source": {
+            "default": "user",
+            "enum": [
+              "user",
+              "system"
+            ],
+            "title": "Source",
+            "type": "string"
+          },
           "status": {
             "title": "Status",
             "type": "string"
@@ -2342,6 +2362,30 @@
           "promotedGoalId"
         ],
         "title": "InboxItem",
+        "type": "object"
+      },
+      "InboxResourceDetail": {
+        "description": "GET /inbox/resources/{slug} — 시스템 항목이 가리키는 정적 자료 본문.\n\n`markdown` 은 frontmatter 를 걷어낸 본문이다(파일 원문이 아니다). FE 는 첫 H1 이\n`title` 과 같을 때만 본문에서 덜어내므로 **둘 다 가공 없이** 실어야 한다.",
+        "properties": {
+          "markdown": {
+            "title": "Markdown",
+            "type": "string"
+          },
+          "slug": {
+            "title": "Slug",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "slug",
+          "title",
+          "markdown"
+        ],
+        "title": "InboxResourceDetail",
         "type": "object"
       },
       "InboxUpdateRequest": {
@@ -5487,7 +5531,7 @@
         ]
       },
       "post": {
-        "description": "신규 목표 — tier 한도 (Focus ≤3 / Maintain ≤5) enforce.",
+        "description": "신규 목표 — tier 한도 (Focus ≤3 / Maintain ≤5) enforce.\n\n생성 직후 그 카테고리의 추천 자료를 인박스에 넣는다 (#171). best-effort — savepoint\n안에서 돌기 때문에 자료 삽입이 실패해도 목표 생성은 그대로 성공한다.",
         "operationId": "create_goal_goals_post",
         "parameters": [
           {
@@ -6286,6 +6330,65 @@
           }
         },
         "summary": "Create Inbox",
+        "tags": [
+          "inbox"
+        ]
+      }
+    },
+    "/inbox/resources/{slug}": {
+      "get": {
+        "description": "시스템 항목이 가리키는 정적 자료 본문 (#171).\n\n**인증만 필요하고 소유권 검사는 하지 않는다** — 자료는 사용자별 개인 데이터가 아니라\n레포에 커밋된 정적 공용 콘텐츠라 소유권 개념이 없다. 인증은 라우터 단위로 걸려 있다.\n\n`slug` 는 레지스트리의 dict 키 조회에만 쓰이고 경로와 결합되지 않으므로 경로 순회가\n성립하지 않는다. 규격을 벗어난 slug 는 그냥 404 로 떨어진다.",
+        "operationId": "get_inbox_resource_inbox_resources__slug__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "slug",
+            "required": true,
+            "schema": {
+              "title": "Slug",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InboxResourceDetail"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Inbox Resource",
         "tags": [
           "inbox"
         ]

--- a/openapi.json
+++ b/openapi.json
@@ -1681,7 +1681,7 @@
         "type": "object"
       },
       "GoalDecomposition": {
-        "description": "POST /goals/{id}/decompose 응답 — Goal Structuring 결과.",
+        "description": "GET /goals/{id}/nodes 응답 — 계획 승인 시 영속된 실제 분해 트리.\n\n계획을 아직 승인하지 않은 목표는 트리가 없다 → `nodes=[]`, `root_node_id=None`.",
         "properties": {
           "goalId": {
             "title": "Goalid",
@@ -1695,8 +1695,15 @@
             "type": "array"
           },
           "rootNodeId": {
-            "title": "Rootnodeid",
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rootnodeid"
           }
         },
         "required": [
@@ -5657,10 +5664,10 @@
         ]
       }
     },
-    "/goals/{goal_id}/decompose": {
-      "post": {
-        "description": "Goal Structuring 호출 → `goal_nodes` 트리.\n\nIssue #22 본 PR 은 mock stub 응답 (LLM 통합은 PR #33 머지된 main 위 후속 PR).\n실 구현 시 `prompts/planning/goal_decompose.v1.md` + `aiClient.run(...)` + HITL Draft Layer\n(ADR-0005 §2.5.1).",
-        "operationId": "decompose_goal_goals__goal_id__decompose_post",
+    "/goals/{goal_id}/nodes": {
+      "get": {
+        "description": "이 목표의 **실제 분해 트리** — 계획 승인 시 영속된 `goal_nodes` 를 그대로 읽는다.\n\n이 자리에 있던 `POST /{goal_id}/decompose` 는 목표와 무관하게 하드코딩된 데모 트리\n(캡스톤 → 설계/구현/발표)를 돌려줬고 FE 가 그걸 화면에 그렸다. 어떤 목표를 분해해도\n같은 캡스톤 단계가 나왔다 — 안 보여주느니만 못한 상태라 제거하고, 실제 분해를 읽는\n조회로 대체한다. 분해 자체는 First Plan(`planning/goal_decompose` + 마일스톤)이 이미\n수행하고 승인 시 영속한다.\n\n계획을 아직 승인하지 않은 목표는 트리가 없으므로 `nodes=[]` (404 아님 — 목표는 존재하고\n분해만 아직 없는 정상 상태다). `rootNodeId` 도 그때는 null.",
+        "operationId": "list_goal_nodes_goals__goal_id__nodes_get",
         "parameters": [
           {
             "in": "path",
@@ -5710,7 +5717,7 @@
             "description": "Validation Error"
           }
         },
-        "summary": "Decompose Goal",
+        "summary": "List Goal Nodes",
         "tags": [
           "goals"
         ]

--- a/openapi.json
+++ b/openapi.json
@@ -2254,6 +2254,50 @@
         "title": "IdentityContext",
         "type": "object"
       },
+      "InboxAdoptStepRequest": {
+        "description": "POST /inbox/{id}/adopt-step — 자료의 몇 번째 한 걸음을 채택할지.",
+        "properties": {
+          "stepIndex": {
+            "minimum": 0.0,
+            "title": "Stepindex",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "stepIndex"
+        ],
+        "title": "InboxAdoptStepRequest",
+        "type": "object"
+      },
+      "InboxAdoptedStep": {
+        "description": "채택 결과 — 오늘 할 일로 만들어진 카드.\n\n자료 항목 자체는 `promoted` 로 바뀌지 않는다. 한 걸음을 채택한 것이지 자료를\n승격한 게 아니고, 사용자가 나중에 다른 걸음을 또 채택하거나 다시 읽을 수 있다.",
+        "properties": {
+          "actionId": {
+            "title": "Actionid",
+            "type": "string"
+          },
+          "resourceSlug": {
+            "title": "Resourceslug",
+            "type": "string"
+          },
+          "targetDate": {
+            "title": "Targetdate",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "actionId",
+          "title",
+          "targetDate",
+          "resourceSlug"
+        ],
+        "title": "InboxAdoptedStep",
+        "type": "object"
+      },
       "InboxCreateRequest": {
         "description": "POST /inbox — 1줄 캡처.",
         "properties": {
@@ -2365,7 +2409,7 @@
         "type": "object"
       },
       "InboxResourceDetail": {
-        "description": "GET /inbox/resources/{slug} — 시스템 항목이 가리키는 정적 자료 본문.\n\n`markdown` 은 frontmatter 를 걷어낸 본문이다(파일 원문이 아니다). FE 는 첫 H1 이\n`title` 과 같을 때만 본문에서 덜어내므로 **둘 다 가공 없이** 실어야 한다.",
+        "description": "GET /inbox/resources/{slug} — 시스템 항목이 가리키는 정적 자료 본문.\n\n`markdown` 은 frontmatter 를 걷어낸 본문이다(파일 원문이 아니다). FE 는 첫 H1 이\n`title` 과 같을 때만 본문에서 덜어내므로 **둘 다 가공 없이** 실어야 한다.\n\n`steps` 는 이 자료가 제안하는 한 걸음들 — 사용자가 골라 오늘 할 일로 채택한다\n(`POST /inbox/{id}/adopt-step`). 자료가 읽고 끝나지 않게 하는 유일한 출구다.",
         "properties": {
           "markdown": {
             "title": "Markdown",
@@ -2375,6 +2419,13 @@
             "title": "Slug",
             "type": "string"
           },
+          "steps": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Steps",
+            "type": "array"
+          },
           "title": {
             "title": "Title",
             "type": "string"
@@ -2383,7 +2434,8 @@
         "required": [
           "slug",
           "title",
-          "markdown"
+          "markdown",
+          "steps"
         ],
         "title": "InboxResourceDetail",
         "type": "object"
@@ -6458,6 +6510,75 @@
           }
         },
         "summary": "Update Inbox",
+        "tags": [
+          "inbox"
+        ]
+      }
+    },
+    "/inbox/{inbox_id}/adopt-step": {
+      "post": {
+        "description": "자료가 제안한 '한 걸음'을 오늘 할 일로 채택한다 (#171 후속).\n\n자료를 읽고 끝나지 않게 하는 **유일한 출구**다. 여기서 만든 `ActionItem` 은\n`source='inbox'` + `inbox_item_id` 로 자료에 연결되므로, 그 뒤 체크인 → 21시 회고\n→ 실패 사유 → 회복 카드는 **기존 루프가 그대로** 처리한다. 회복을 새로 만들지 않는다\n(AGENTS §1: 회복 시점은 21시 일괄 회고만).\n\n자료 항목은 `promoted` 로 바꾸지 않는다 — 한 걸음을 채택한 것이지 자료를 승격한 게\n아니고, 나중에 다른 걸음을 또 채택하거나 다시 읽을 수 있어야 한다.",
+        "operationId": "adopt_resource_step_inbox__inbox_id__adopt_step_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "inbox_id",
+            "required": true,
+            "schema": {
+              "title": "Inbox Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InboxAdoptStepRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InboxAdoptedStep"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Adopt Resource Step",
         "tags": [
           "inbox"
         ]

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -37,6 +37,8 @@ import type {
   HabitCreateRequest,
   HabitInstance,
   HabitUpdateRequest,
+  InboxAdoptedStep,
+  InboxAdoptStepRequest,
   InboxCreateRequest,
   InboxItem,
   InboxResource,
@@ -477,6 +479,10 @@ export const inboxApi = {
   // 추천 자료 본문(마크다운) 조회 (#163, backend#171). 미존재 slug 는 404.
   resource: (slug: string) =>
     request<InboxResource>(`/inbox/resources/${encodeURIComponent(slug)}`),
+
+  // 자료가 제안한 한 걸음을 오늘 할 일로 채택 (#171 후속). 자료는 promoted 로 바뀌지 않음.
+  adoptStep: (inboxId: string, body: InboxAdoptStepRequest) =>
+    request<InboxAdoptedStep>(`/inbox/${inboxId}/adopt-step`, { method: 'POST', body }),
 };
 
 // ── Habits (S27) ──────────────────────────────────────────────

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -165,7 +165,7 @@ export interface GoalNode {
 
 export interface GoalDecomposition {
   goalId: string;
-  rootNodeId: string;
+  rootNodeId: string | null;
   nodes: GoalNode[];
 }
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -292,10 +292,8 @@ export interface InboxItem {
   promotedGoalId: string | null;
   // 승격 대상 구분(#122) — 'action'(할 일로) / 'goal'(목표로). 없으면 goal 로 간주.
   promotedTo?: 'goal' | 'action' | null;
-  // 시스템이 넣은 추천 자료 항목 구분(#163, backend#171). 필드가 없으면 사용자 캡처로
-  // 간주하므로 BE 미배포 상태에서도 기존 동작 그대로다(안전한 no-op).
-  // ⚠️ BE 배포 후 `npm run gen:api` 로 실제 계약과 대조할 것.
-  source?: 'user' | 'system' | null;
+  // 시스템이 넣은 추천 자료 항목 구분(#163, backend#171). 기본값 'user'.
+  source: 'user' | 'system';
   resourceSlug?: string | null;
 }
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -306,11 +306,25 @@ export interface InboxResource {
   slug: string;
   title: string;
   markdown: string;
+  // 이 자료가 제안하는 한 걸음들 (#171 후속) — POST /inbox/{id}/adopt-step 로 채택.
+  steps: string[];
 }
 
 export interface InboxUpdateRequest {
   userCategory?: InboxCategory;
   status?: InboxStatus;
+}
+
+export interface InboxAdoptStepRequest {
+  stepIndex: number;
+}
+
+// 자료의 한 걸음을 채택해 만들어진 오늘 할 일 카드 (#171 후속).
+export interface InboxAdoptedStep {
+  actionId: string;
+  title: string;
+  targetDate: string;
+  resourceSlug: string;
 }
 
 // ── Habits (S27) ──────────────────────────────────────────────

--- a/src/types/openapi.d.ts
+++ b/src/types/openapi.d.ts
@@ -237,6 +237,9 @@ export interface paths {
         /**
          * Create Goal
          * @description 신규 목표 — tier 한도 (Focus ≤3 / Maintain ≤5) enforce.
+         *
+         *     생성 직후 그 카테고리의 추천 자료를 인박스에 넣는다 (#171). best-effort — savepoint
+         *     안에서 돌기 때문에 자료 삽입이 실패해도 목표 생성은 그대로 성공한다.
          */
         post: operations["create_goal_goals_post"];
         delete?: never;
@@ -444,6 +447,32 @@ export interface paths {
          * @description 1줄 캡처 + AI category 추정 (LLM 1회, 8s timeout, 실패 시 룰 fallback).
          */
         post: operations["create_inbox_inbox_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/inbox/resources/{slug}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Inbox Resource
+         * @description 시스템 항목이 가리키는 정적 자료 본문 (#171).
+         *
+         *     **인증만 필요하고 소유권 검사는 하지 않는다** — 자료는 사용자별 개인 데이터가 아니라
+         *     레포에 커밋된 정적 공용 콘텐츠라 소유권 개념이 없다. 인증은 라우터 단위로 걸려 있다.
+         *
+         *     `slug` 는 레지스트리의 dict 키 조회에만 쓰이고 경로와 결합되지 않으므로 경로 순회가
+         *     성립하지 않는다. 규격을 벗어난 slug 는 그냥 404 로 떨어진다.
+         */
+        get: operations["get_inbox_resource_inbox_resources__slug__get"];
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -2625,10 +2654,33 @@ export interface components {
             promotedTo?: ("goal" | "action") | null;
             /** Rawtext */
             rawText: string;
+            /** Resourceslug */
+            resourceSlug?: string | null;
+            /**
+             * Source
+             * @default user
+             * @enum {string}
+             */
+            source: "user" | "system";
             /** Status */
             status: string;
             /** Usercategory */
             userCategory: string | null;
+        };
+        /**
+         * InboxResourceDetail
+         * @description GET /inbox/resources/{slug} — 시스템 항목이 가리키는 정적 자료 본문.
+         *
+         *     `markdown` 은 frontmatter 를 걷어낸 본문이다(파일 원문이 아니다). FE 는 첫 H1 이
+         *     `title` 과 같을 때만 본문에서 덜어내므로 **둘 다 가공 없이** 실어야 한다.
+         */
+        InboxResourceDetail: {
+            /** Markdown */
+            markdown: string;
+            /** Slug */
+            slug: string;
+            /** Title */
+            title: string;
         };
         /**
          * InboxUpdateRequest
@@ -4641,6 +4693,39 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["InboxItem"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_inbox_resource_inbox_resources__slug__get: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InboxResourceDetail"];
                 };
             };
             /** @description Validation Error */

--- a/src/types/openapi.d.ts
+++ b/src/types/openapi.d.ts
@@ -269,24 +269,29 @@ export interface paths {
         patch: operations["update_goal_goals__goal_id__patch"];
         trace?: never;
     };
-    "/goals/{goal_id}/decompose": {
+    "/goals/{goal_id}/nodes": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        get?: never;
-        put?: never;
         /**
-         * Decompose Goal
-         * @description Goal Structuring 호출 → `goal_nodes` 트리.
+         * List Goal Nodes
+         * @description 이 목표의 **실제 분해 트리** — 계획 승인 시 영속된 `goal_nodes` 를 그대로 읽는다.
          *
-         *     Issue #22 본 PR 은 mock stub 응답 (LLM 통합은 PR #33 머지된 main 위 후속 PR).
-         *     실 구현 시 `prompts/planning/goal_decompose.v1.md` + `aiClient.run(...)` + HITL Draft Layer
-         *     (ADR-0005 §2.5.1).
+         *     이 자리에 있던 `POST /{goal_id}/decompose` 는 목표와 무관하게 하드코딩된 데모 트리
+         *     (캡스톤 → 설계/구현/발표)를 돌려줬고 FE 가 그걸 화면에 그렸다. 어떤 목표를 분해해도
+         *     같은 캡스톤 단계가 나왔다 — 안 보여주느니만 못한 상태라 제거하고, 실제 분해를 읽는
+         *     조회로 대체한다. 분해 자체는 First Plan(`planning/goal_decompose` + 마일스톤)이 이미
+         *     수행하고 승인 시 영속한다.
+         *
+         *     계획을 아직 승인하지 않은 목표는 트리가 없으므로 `nodes=[]` (404 아님 — 목표는 존재하고
+         *     분해만 아직 없는 정상 상태다). `rootNodeId` 도 그때는 null.
          */
-        post: operations["decompose_goal_goals__goal_id__decompose_post"];
+        get: operations["list_goal_nodes_goals__goal_id__nodes_get"];
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -2348,7 +2353,9 @@ export interface components {
         };
         /**
          * GoalDecomposition
-         * @description POST /goals/{id}/decompose 응답 — Goal Structuring 결과.
+         * @description GET /goals/{id}/nodes 응답 — 계획 승인 시 영속된 실제 분해 트리.
+         *
+         *     계획을 아직 승인하지 않은 목표는 트리가 없다 → `nodes=[]`, `root_node_id=None`.
          */
         GoalDecomposition: {
             /** Goalid */
@@ -2356,7 +2363,7 @@ export interface components {
             /** Nodes */
             nodes: components["schemas"]["GoalNode"][];
             /** Rootnodeid */
-            rootNodeId: string;
+            rootNodeId: string | null;
         };
         /**
          * GoalNode
@@ -4293,7 +4300,7 @@ export interface operations {
             };
         };
     };
-    decompose_goal_goals__goal_id__decompose_post: {
+    list_goal_nodes_goals__goal_id__nodes_get: {
         parameters: {
             query?: never;
             header?: {

--- a/src/types/openapi.d.ts
+++ b/src/types/openapi.d.ts
@@ -499,6 +499,34 @@ export interface paths {
         patch: operations["update_inbox_inbox__inbox_id__patch"];
         trace?: never;
     };
+    "/inbox/{inbox_id}/adopt-step": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Adopt Resource Step
+         * @description 자료가 제안한 '한 걸음'을 오늘 할 일로 채택한다 (#171 후속).
+         *
+         *     자료를 읽고 끝나지 않게 하는 **유일한 출구**다. 여기서 만든 `ActionItem` 은
+         *     `source='inbox'` + `inbox_item_id` 로 자료에 연결되므로, 그 뒤 체크인 → 21시 회고
+         *     → 실패 사유 → 회복 카드는 **기존 루프가 그대로** 처리한다. 회복을 새로 만들지 않는다
+         *     (AGENTS §1: 회복 시점은 21시 일괄 회고만).
+         *
+         *     자료 항목은 `promoted` 로 바꾸지 않는다 — 한 걸음을 채택한 것이지 자료를 승격한 게
+         *     아니고, 나중에 다른 걸음을 또 채택하거나 다시 읽을 수 있어야 한다.
+         */
+        post: operations["adopt_resource_step_inbox__inbox_id__adopt_step_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/inbox/{inbox_id}/archive": {
         parameters: {
             query?: never;
@@ -2630,6 +2658,31 @@ export interface components {
             season: string;
         };
         /**
+         * InboxAdoptStepRequest
+         * @description POST /inbox/{id}/adopt-step — 자료의 몇 번째 한 걸음을 채택할지.
+         */
+        InboxAdoptStepRequest: {
+            /** Stepindex */
+            stepIndex: number;
+        };
+        /**
+         * InboxAdoptedStep
+         * @description 채택 결과 — 오늘 할 일로 만들어진 카드.
+         *
+         *     자료 항목 자체는 `promoted` 로 바뀌지 않는다. 한 걸음을 채택한 것이지 자료를
+         *     승격한 게 아니고, 사용자가 나중에 다른 걸음을 또 채택하거나 다시 읽을 수 있다.
+         */
+        InboxAdoptedStep: {
+            /** Actionid */
+            actionId: string;
+            /** Resourceslug */
+            resourceSlug: string;
+            /** Targetdate */
+            targetDate: string;
+            /** Title */
+            title: string;
+        };
+        /**
          * InboxCreateRequest
          * @description POST /inbox — 1줄 캡처.
          */
@@ -2673,12 +2726,17 @@ export interface components {
          *
          *     `markdown` 은 frontmatter 를 걷어낸 본문이다(파일 원문이 아니다). FE 는 첫 H1 이
          *     `title` 과 같을 때만 본문에서 덜어내므로 **둘 다 가공 없이** 실어야 한다.
+         *
+         *     `steps` 는 이 자료가 제안하는 한 걸음들 — 사용자가 골라 오늘 할 일로 채택한다
+         *     (`POST /inbox/{id}/adopt-step`). 자료가 읽고 끝나지 않게 하는 유일한 출구다.
          */
         InboxResourceDetail: {
             /** Markdown */
             markdown: string;
             /** Slug */
             slug: string;
+            /** Steps */
+            steps: string[];
             /** Title */
             title: string;
         };
@@ -4763,6 +4821,43 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["InboxItem"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    adopt_resource_step_inbox__inbox_id__adopt_step_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                inbox_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["InboxAdoptStepRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InboxAdoptedStep"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
백엔드(`reaction-backend@main`) OpenAPI 스펙 변경을 프론트 타입·래퍼에 반영합니다.

## (a) 신규/변경 엔드포인트
- `POST /inbox/{inbox_id}/adopt-step` 신규 배포 (backend#171 후속) — 자료가 제안한 "한 걸음"을 오늘 할 일로 채택. 요청 `InboxAdoptStepRequest { stepIndex: number }`, 응답 `InboxAdoptedStep { actionId, title, targetDate, resourceSlug }` (전부 required). 결과 `ActionItem` 은 `source='inbox'` + `inbox_item_id` 로 연결되며, 자료 항목 자체는 `promoted` 로 바뀌지 않음(한 걸음 채택 ≠ 자료 승격).
- `InboxResourceDetail`(`GET /inbox/resources/{slug}` 응답)에 `steps: string[]` 필드 추가 (필수) — 이 자료가 제안하는 한 걸음 목록.
- (이전 동기화 반영분 유지) `GET /inbox/resources/{slug}` 신규 배포, `InboxItem.source` required·non-null 정정, `POST /goals/{goal_id}/decompose` 제거 → `GET /goals/{goal_id}/nodes` 대체.

## (b) 수정한 타입·래퍼
- `openapi.json` / `src/types/openapi.d.ts`: 재생성 (자동)
- `src/types/api.ts`: `InboxResource` 에 `steps: string[]` 추가, `InboxAdoptStepRequest`/`InboxAdoptedStep` 타입 신규 추가
- `src/lib/api.ts`: `inboxApi.adoptStep(inboxId, body)` 래퍼 신규 추가 (`POST /inbox/{id}/adopt-step`)

## (c) check:api 요약
```
openapi 경로 73개 · api.ts 호출 86개
✅ OK   86
⚠️  WARN 0
❌ GONE 0
🆕 NEW  2  (GET /health, GET /inbox — 기존부터 있던 false positive, 이번 동기화와 무관)
결과: PASS
```
검증 게이트 모두 통과: `check:api` (GONE 0), `tsc --noEmit`, `npm run build`.

## (d) 화면 연동 후보
- `POST /inbox/{id}/adopt-step` (신규 WARN→OK): `src/screens/InboxScreen.tsx` 등에서 아직 미연동. 자료 상세(`inboxApi.resource`)에서 받아온 `steps` 목록을 보여주고, 항목 선택 시 `inboxApi.adoptStep(inboxId, { stepIndex })` 호출 → 성공 시 오늘 할 일 목록 갱신하는 화면 작업이 필요합니다. 현재는 래퍼만 있고 화면 표시는 없는 상태(더미 없음, 미표시).

---
_Generated by [Claude Code](https://claude.ai/code/session_018nfoBP6t35GxYFYGM4Upkk)_