### PR TITLE
feat(inbox): 자료의 '한 걸음'을 오늘 할 일로 — 걸음 선택 UI (#187)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1681,7 +1681,7 @@
         "type": "object"
       },
       "GoalDecomposition": {
-        "description": "POST /goals/{id}/decompose 응답 — Goal Structuring 결과.",
+        "description": "GET /goals/{id}/nodes 응답 — 계획 승인 시 영속된 실제 분해 트리.\n\n계획을 아직 승인하지 않은 목표는 트리가 없다 → `nodes=[]`, `root_node_id=None`.",
         "properties": {
           "goalId": {
             "title": "Goalid",
@@ -1695,8 +1695,15 @@
             "type": "array"
           },
           "rootNodeId": {
-            "title": "Rootnodeid",
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rootnodeid"
           }
         },
         "required": [
@@ -2247,6 +2254,50 @@
         "title": "IdentityContext",
         "type": "object"
       },
+      "InboxAdoptStepRequest": {
+        "description": "POST /inbox/{id}/adopt-step — 자료의 몇 번째 한 걸음을 채택할지.",
+        "properties": {
+          "stepIndex": {
+            "minimum": 0.0,
+            "title": "Stepindex",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "stepIndex"
+        ],
+        "title": "InboxAdoptStepRequest",
+        "type": "object"
+      },
+      "InboxAdoptedStep": {
+        "description": "채택 결과 — 오늘 할 일로 만들어진 카드.\n\n자료 항목 자체는 `promoted` 로 바뀌지 않는다. 한 걸음을 채택한 것이지 자료를\n승격한 게 아니고, 사용자가 나중에 다른 걸음을 또 채택하거나 다시 읽을 수 있다.",
+        "properties": {
+          "actionId": {
+            "title": "Actionid",
+            "type": "string"
+          },
+          "resourceSlug": {
+            "title": "Resourceslug",
+            "type": "string"
+          },
+          "targetDate": {
+            "title": "Targetdate",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "actionId",
+          "title",
+          "targetDate",
+          "resourceSlug"
+        ],
+        "title": "InboxAdoptedStep",
+        "type": "object"
+      },
       "InboxCreateRequest": {
         "description": "POST /inbox — 1줄 캡처.",
         "properties": {
@@ -2310,6 +2361,26 @@
             "title": "Rawtext",
             "type": "string"
           },
+          "resourceSlug": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Resourceslug"
+          },
+          "source": {
+            "default": "user",
+            "enum": [
+              "user",
+              "system"
+            ],
+            "title": "Source",
+            "type": "string"
+          },
           "status": {
             "title": "Status",
             "type": "string"
@@ -2335,6 +2406,38 @@
           "promotedGoalId"
         ],
         "title": "InboxItem",
+        "type": "object"
+      },
+      "InboxResourceDetail": {
+        "description": "GET /inbox/resources/{slug} — 시스템 항목이 가리키는 정적 자료 본문.\n\n`markdown` 은 frontmatter 를 걷어낸 본문이다(파일 원문이 아니다). FE 는 첫 H1 이\n`title` 과 같을 때만 본문에서 덜어내므로 **둘 다 가공 없이** 실어야 한다.\n\n`steps` 는 이 자료가 제안하는 한 걸음들 — 사용자가 골라 오늘 할 일로 채택한다\n(`POST /inbox/{id}/adopt-step`). 자료가 읽고 끝나지 않게 하는 유일한 출구다.",
+        "properties": {
+          "markdown": {
+            "title": "Markdown",
+            "type": "string"
+          },
+          "slug": {
+            "title": "Slug",
+            "type": "string"
+          },
+          "steps": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Steps",
+            "type": "array"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "slug",
+          "title",
+          "markdown",
+          "steps"
+        ],
+        "title": "InboxResourceDetail",
         "type": "object"
       },
       "InboxUpdateRequest": {
@@ -5480,7 +5583,7 @@
         ]
       },
       "post": {
-        "description": "신규 목표 — tier 한도 (Focus ≤3 / Maintain ≤5) enforce.",
+        "description": "신규 목표 — tier 한도 (Focus ≤3 / Maintain ≤5) enforce.\n\n생성 직후 그 카테고리의 추천 자료를 인박스에 넣는다 (#171). best-effort — savepoint\n안에서 돌기 때문에 자료 삽입이 실패해도 목표 생성은 그대로 성공한다.",
         "operationId": "create_goal_goals_post",
         "parameters": [
           {
@@ -5657,10 +5760,10 @@
         ]
       }
     },
-    "/goals/{goal_id}/decompose": {
-      "post": {
-        "description": "Goal Structuring 호출 → `goal_nodes` 트리.\n\nIssue #22 본 PR 은 mock stub 응답 (LLM 통합은 PR #33 머지된 main 위 후속 PR).\n실 구현 시 `prompts/planning/goal_decompose.v1.md` + `aiClient.run(...)` + HITL Draft Layer\n(ADR-0005 §2.5.1).",
-        "operationId": "decompose_goal_goals__goal_id__decompose_post",
+    "/goals/{goal_id}/nodes": {
+      "get": {
+        "description": "이 목표의 **실제 분해 트리** — 계획 승인 시 영속된 `goal_nodes` 를 그대로 읽는다.\n\n이 자리에 있던 `POST /{goal_id}/decompose` 는 목표와 무관하게 하드코딩된 데모 트리\n(캡스톤 → 설계/구현/발표)를 돌려줬고 FE 가 그걸 화면에 그렸다. 어떤 목표를 분해해도\n같은 캡스톤 단계가 나왔다 — 안 보여주느니만 못한 상태라 제거하고, 실제 분해를 읽는\n조회로 대체한다. 분해 자체는 First Plan(`planning/goal_decompose` + 마일스톤)이 이미\n수행하고 승인 시 영속한다.\n\n계획을 아직 승인하지 않은 목표는 트리가 없으므로 `nodes=[]` (404 아님 — 목표는 존재하고\n분해만 아직 없는 정상 상태다). `rootNodeId` 도 그때는 null.",
+        "operationId": "list_goal_nodes_goals__goal_id__nodes_get",
         "parameters": [
           {
             "in": "path",
@@ -5710,7 +5813,7 @@
             "description": "Validation Error"
           }
         },
-        "summary": "Decompose Goal",
+        "summary": "List Goal Nodes",
         "tags": [
           "goals"
         ]
@@ -6284,6 +6387,65 @@
         ]
       }
     },
+    "/inbox/resources/{slug}": {
+      "get": {
+        "description": "시스템 항목이 가리키는 정적 자료 본문 (#171).\n\n**인증만 필요하고 소유권 검사는 하지 않는다** — 자료는 사용자별 개인 데이터가 아니라\n레포에 커밋된 정적 공용 콘텐츠라 소유권 개념이 없다. 인증은 라우터 단위로 걸려 있다.\n\n`slug` 는 레지스트리의 dict 키 조회에만 쓰이고 경로와 결합되지 않으므로 경로 순회가\n성립하지 않는다. 규격을 벗어난 slug 는 그냥 404 로 떨어진다.",
+        "operationId": "get_inbox_resource_inbox_resources__slug__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "slug",
+            "required": true,
+            "schema": {
+              "title": "Slug",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InboxResourceDetail"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Inbox Resource",
+        "tags": [
+          "inbox"
+        ]
+      }
+    },
     "/inbox/{inbox_id}": {
       "patch": {
         "description": "userCategory override 또는 status 변경.",
@@ -6348,6 +6510,75 @@
           }
         },
         "summary": "Update Inbox",
+        "tags": [
+          "inbox"
+        ]
+      }
+    },
+    "/inbox/{inbox_id}/adopt-step": {
+      "post": {
+        "description": "자료가 제안한 '한 걸음'을 오늘 할 일로 채택한다 (#171 후속).\n\n자료를 읽고 끝나지 않게 하는 **유일한 출구**다. 여기서 만든 `ActionItem` 은\n`source='inbox'` + `inbox_item_id` 로 자료에 연결되므로, 그 뒤 체크인 → 21시 회고\n→ 실패 사유 → 회복 카드는 **기존 루프가 그대로** 처리한다. 회복을 새로 만들지 않는다\n(AGENTS §1: 회복 시점은 21시 일괄 회고만).\n\n자료 항목은 `promoted` 로 바꾸지 않는다 — 한 걸음을 채택한 것이지 자료를 승격한 게\n아니고, 나중에 다른 걸음을 또 채택하거나 다시 읽을 수 있어야 한다.",
+        "operationId": "adopt_resource_step_inbox__inbox_id__adopt_step_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "inbox_id",
+            "required": true,
+            "schema": {
+              "title": "Inbox Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InboxAdoptStepRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InboxAdoptedStep"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Adopt Resource Step",
         "tags": [
           "inbox"
         ]

--- a/src/components/ResourceViewerSheet.tsx
+++ b/src/components/ResourceViewerSheet.tsx
@@ -16,6 +16,17 @@ interface ResourceViewerSheetProps {
   markdown: string | null; // null = 아직 로딩 중
   error?: string | null;
   onClose: () => void;
+  /**
+   * 자료가 제안하는 '한 걸음' 목록. 읽고 끝나지 않게 실행으로 잇는 출구다.
+   * 비어 있으면 섹션 자체를 그리지 않는다.
+   */
+  steps?: string[];
+  /** 걸음을 고르면 호출. 성공/실패 처리는 호출한 쪽이 한다. */
+  onAdoptStep?: (stepIndex: number) => void;
+  /** 채택 진행 중인 걸음 인덱스. 그 항목만 비활성·문구 변경. */
+  adoptingIndex?: number | null;
+  /** 이미 오늘 담은 걸음. BE 가 중복을 막지 않으므로 화면에서 알려준다. */
+  adoptedIndexes?: number[];
 }
 
 // 코드·표처럼 넓은 요소는 자기 컨테이너에서만 가로 스크롤 — 본문(모바일)이 가로로 밀리지 않게.
@@ -29,7 +40,16 @@ function stripLeadingTitle(md: string, title: string): string {
   return norm(m[1]) === norm(title) ? md.slice(m[0].length) : md;
 }
 
-export function ResourceViewerSheet({ title, markdown, error, onClose }: ResourceViewerSheetProps) {
+export function ResourceViewerSheet({
+  title,
+  markdown,
+  error,
+  onClose,
+  steps = [],
+  onAdoptStep,
+  adoptingIndex = null,
+  adoptedIndexes = [],
+}: ResourceViewerSheetProps) {
   const bodyMd = markdown === null ? null : stripLeadingTitle(markdown, title);
   return (
     <div
@@ -106,6 +126,81 @@ export function ResourceViewerSheet({ title, markdown, error, onClose }: Resourc
             >
               {bodyMd}
             </ReactMarkdown>
+          </div>
+        )}
+
+        {/* 자료의 '한 걸음' — 읽고 끝나는 걸 막는 출구.
+            본문을 다 읽은 자리에 두어야 "그래서 뭘 하지" 에 바로 답이 된다.
+            로딩 중이거나 에러면 그리지 않는다(고를 것이 없으므로). */}
+        {!error && bodyMd !== null && steps.length > 0 && onAdoptStep && (
+          <div style={{ marginTop: 22, paddingTop: 18, borderTop: '1px solid var(--sand-200)' }}>
+            <div style={{ fontSize: 15, fontWeight: 700, color: 'var(--text-1)', marginBottom: 4 }}>
+              이 중 하나 해볼까요?
+            </div>
+            <p style={{ margin: '0 0 12px', fontSize: 12, color: 'var(--text-3)', lineHeight: 1.5 }}>
+              고르면 오늘 할 일로 담아둘게요. 자료는 그대로 남아 있어요.
+            </p>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+              {steps.map((step, i) => {
+                const busy = adoptingIndex === i;
+                const done = adoptedIndexes.includes(i);
+                // 다른 걸음을 채택하는 중엔 전부 잠근다 — 연타로 카드가 여러 개 생기는 걸 막는다.
+                const locked = adoptingIndex !== null && !busy;
+                return (
+                  <button
+                    key={i}
+                    onClick={() => onAdoptStep(i)}
+                    disabled={busy || locked}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'flex-start',
+                      gap: 10,
+                      width: '100%',
+                      padding: '12px 14px',
+                      borderRadius: 12,
+                      border: `1px solid ${done ? 'var(--coral-200)' : 'var(--sand-200)'}`,
+                      background: done ? 'var(--brand-soft)' : 'var(--surface-raised)',
+                      cursor: busy || locked ? 'default' : 'pointer',
+                      opacity: locked ? 0.5 : 1,
+                      fontFamily: 'inherit',
+                      textAlign: 'left',
+                      transition: 'opacity 140ms',
+                    }}
+                  >
+                    <span
+                      className="tnum"
+                      style={{
+                        width: 20,
+                        height: 20,
+                        borderRadius: 9999,
+                        flexShrink: 0,
+                        marginTop: 1,
+                        background: done ? 'var(--brand-surface)' : 'var(--sand-100)',
+                        color: done ? '#FFFCF6' : 'var(--text-3)',
+                        fontSize: 10,
+                        fontWeight: 700,
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        fontFamily: 'var(--font-mono)',
+                      }}
+                    >
+                      {done ? '✓' : i + 1}
+                    </span>
+                    <span style={{ flex: 1, minWidth: 0 }}>
+                      <span style={{ display: 'block', fontSize: 13.5, lineHeight: 1.5, color: 'var(--text-1)', fontWeight: 500 }}>
+                        {step}
+                      </span>
+                      {(busy || done) && (
+                        <span style={{ display: 'block', marginTop: 3, fontSize: 11, color: 'var(--brand-ink)', fontWeight: 600 }}>
+                          {busy ? '담는 중…' : '오늘 할 일에 담았어요'}
+                        </span>
+                      )}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
           </div>
         )}
       </div>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -40,6 +40,8 @@ import type {
   InboxCreateRequest,
   InboxItem,
   InboxResource,
+  InboxAdoptStepRequest,
+  InboxAdoptedStep,
   InboxUpdateRequest,
   InterviewSession,
   NotificationSettings,
@@ -477,6 +479,17 @@ export const inboxApi = {
   // 추천 자료 본문(마크다운) 조회 (#163, backend#171). 미존재 slug 는 404.
   resource: (slug: string) =>
     request<InboxResource>(`/inbox/resources/${encodeURIComponent(slug)}`),
+
+  // 자료의 걸음 하나를 오늘 할 일로 채택 (#187, backend#202).
+  // 채택해도 자료 카드는 인박스에 그대로 남는다 — 다른 걸음을 또 고르거나 다시 읽을 수 있어야 해서.
+  // 같은 걸음을 여러 번 채택하면 카드가 여러 개 생긴다(BE 가 의도적으로 막지 않음).
+  adoptStep: (inboxId: string, stepIndex: number) =>
+    request<InboxAdoptedStep>(`/inbox/${inboxId}/adopt-step`, {
+      method: 'POST',
+      body: { stepIndex } satisfies InboxAdoptStepRequest,
+      // 같은 걸음을 두 번 눌러도 카드가 두 개 생기지 않게 한다.
+      idempotencyKey: `adopt-${inboxId}-${stepIndex}`,
+    }),
 };
 
 // ── Habits (S27) ──────────────────────────────────────────────

--- a/src/screens/InboxScreen.tsx
+++ b/src/screens/InboxScreen.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useRef, useState } from 'react';
 import { Sparkle, ArrowUp, Archive, TreeStructure, ListChecks, ArrowCounterClockwise, ArrowRight, BookOpen } from '@phosphor-icons/react';
-import { friendlyError, inboxApi } from '../lib/api';
+import { ApiError, friendlyError, inboxApi } from '../lib/api';
 import { Segmented } from '../components/Segmented';
 import { ResourceViewerSheet } from '../components/ResourceViewerSheet';
 import { InboxItemCard, InboxAction } from '../components/InboxItemCard';
 import { SkeletonBlock } from '../components/SkeletonBlock';
 import { ErrorBanner } from '../components/ErrorBanner';
+import { Toast } from '../components/Toast';
 import { useNavigation } from '../contexts/NavigationContext';
 import type { InboxItem, InboxStatus } from '../types/api';
 import { categoryLabel } from '../data';
@@ -47,7 +48,21 @@ export function InboxScreen() {
   const inputRef = useRef<HTMLInputElement>(null);
   const { setScreen, setTab } = useNavigation();
   // 추천 자료 뷰어(#163) — markdown null = 로딩 중.
-  const [resource, setResource] = useState<{ title: string; markdown: string | null; error: string | null } | null>(null);
+  const [resource, setResource] = useState<{
+    inboxId: string;
+    title: string;
+    markdown: string | null;
+    error: string | null;
+    steps: string[];
+  } | null>(null);
+  // 채택 진행 중인 걸음 인덱스 + 이미 담은 것들. BE 가 중복을 막지 않아 화면에서 알려준다.
+  const [toast, setToast] = useState<{ msg: string; tone: 'neutral' | 'error' } | null>(null);
+  const showToast = (msg: string, tone: 'neutral' | 'error' = 'neutral') => {
+    setToast({ msg, tone });
+    setTimeout(() => setToast(null), 2600);
+  };
+  const [adoptingIndex, setAdoptingIndex] = useState<number | null>(null);
+  const [adoptedIndexes, setAdoptedIndexes] = useState<number[]>([]);
 
   const fetchList = (status?: string) => {
     setIsLoading(true);
@@ -152,12 +167,54 @@ export function InboxScreen() {
   const openResource = async (it: InboxItem) => {
     const slug = it.resourceSlug;
     if (!slug) return;
-    setResource({ title: it.rawText, markdown: null, error: null });
+    setAdoptingIndex(null);
+    setAdoptedIndexes([]);
+    setResource({ inboxId: it.inboxId, title: it.rawText, markdown: null, error: null, steps: [] });
     try {
       const res = await inboxApi.resource(slug);
-      setResource({ title: res.title || it.rawText, markdown: res.markdown, error: null });
+      setResource({
+        inboxId: it.inboxId,
+        title: res.title || it.rawText,
+        markdown: res.markdown,
+        error: null,
+        steps: res.steps ?? [],
+      });
     } catch (err: unknown) {
-      setResource({ title: it.rawText, markdown: null, error: friendlyError(err, '자료를 불러오지 못했어요.') });
+      setResource({
+        inboxId: it.inboxId,
+        title: it.rawText,
+        markdown: null,
+        error: friendlyError(err, '자료를 불러오지 못했어요.'),
+        steps: [],
+      });
+    }
+  };
+
+  // 자료의 걸음 하나를 오늘 할 일로 담는다 (#187).
+  // 채택해도 자료 카드는 인박스에 남는다 — 목록을 새로고침하지 않는다.
+  const adoptStep = async (stepIndex: number) => {
+    if (!resource || adoptingIndex !== null) return;
+    setAdoptingIndex(stepIndex);
+    try {
+      const adopted = await inboxApi.adoptStep(resource.inboxId, stepIndex);
+      setAdoptedIndexes((xs) => (xs.includes(stepIndex) ? xs : [...xs, stepIndex]));
+      showToast(`오늘 할 일에 담았어요 — ${adopted.title}`);
+    } catch (err: unknown) {
+      // 시트는 닫지 않는다 — 사용자가 자료를 계속 읽거나 다른 걸음을 고를 수 있어야 한다.
+      //
+      // 422 는 계약상 "이 항목은 자료가 아님"(field=inboxId) 또는 "없는 걸음"(field=stepIndex)
+      // 인데, 공용 문구가 '입력값을 확인해 주세요' 라 여기선 맞지 않는다 — 사용자가 입력한 게
+      // 없고 목록에서 고르기만 했다. 상황에 맞는 문구로 바꾼다.
+      const isStale =
+        err instanceof ApiError && (err.status === 404 || err.status === 422);
+      showToast(
+        isStale
+          ? '이 자료는 지금 담을 수 없어요. 자료를 다시 열어봐 주세요.'
+          : friendlyError(err, '오늘 할 일로 담지 못했어요. 잠시 후 다시 시도해 주세요.'),
+        'error',
+      );
+    } finally {
+      setAdoptingIndex(null);
     }
   };
 
@@ -315,9 +372,22 @@ export function InboxScreen() {
         <ResourceViewerSheet
           title={resource.title}
           markdown={resource.markdown}
+          steps={resource.steps}
+          onAdoptStep={adoptStep}
+          adoptingIndex={adoptingIndex}
+          adoptedIndexes={adoptedIndexes}
           error={resource.error}
           onClose={() => setResource(null)}
         />
+      )}
+
+      {/* 걸음 채택 결과 — 시트가 열린 채로도 보이도록 시트보다 위에 둔다(zIndex 80 > 60).
+          시트가 열려 있을 땐 위쪽에 띄운다. 아래에 두면 방금 고른 걸음 바로 다음 항목을
+          가려서, 연달아 고르려는 사람이 무엇을 누르는지 못 본다. */}
+      {toast && (
+        <Toast tone={toast.tone} bottom={resource ? 620 : 96}>
+          {toast.msg}
+        </Toast>
       )}
     </div>
   );

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -308,6 +308,19 @@ export interface InboxResource {
   slug: string;
   title: string;
   markdown: string;
+  // 자료가 제안하는 '한 걸음' 목록(backend#202). 읽고 끝나지 않게 실행으로 잇는 출구.
+  steps: string[];
+}
+
+// POST /inbox/{inboxId}/adopt-step — 자료의 걸음 하나를 오늘 할 일로 채택.
+export interface InboxAdoptStepRequest {
+  stepIndex: number;
+}
+export interface InboxAdoptedStep {
+  actionId: string;
+  title: string;
+  targetDate: string; // YYYY-MM-DD
+  resourceSlug: string;
 }
 
 export interface InboxUpdateRequest {

--- a/src/types/openapi.d.ts
+++ b/src/types/openapi.d.ts
@@ -4,6 +4,23 @@
  */
 
 export interface paths {
+    "/health": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Health */
+        get: operations["health_health_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/auth/google": {
         parameters: {
             query?: never;
@@ -18,6 +35,26 @@ export interface paths {
          * @description Google id_token 검증 → user upsert → JWT 발급.
          */
         post: operations["login_with_google_auth_google_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/refresh": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Refresh Access Token
+         * @description refresh → 새 access. refresh 회전 X (refresh 자체 재발급 안 함).
+         */
+        post: operations["refresh_access_token_auth_refresh_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -64,73 +101,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/auth/refresh": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Refresh Access Token
-         * @description refresh → 새 access. refresh 회전 X (refresh 자체 재발급 안 함).
-         */
-        post: operations["refresh_access_token_auth_refresh_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/calendar/connect": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Connect Calendar
-         * @description Google Calendar 연결 — **베타 이후 지원 (P1)**.
-         *
-         *     Issue #17 MVP 결정: 캘린더 OAuth 는 P1 로 미룸. FE 는 S05 수동 입력으로 진행.
-         */
-        post: operations["connect_calendar_calendar_connect_post"];
-        /**
-         * Disconnect Calendar
-         * @description Google Calendar 연결 해제 — **베타 이후 지원 (P1)**.
-         */
-        delete: operations["disconnect_calendar_calendar_connect_delete"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/calendar/events/approve-insert": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Approve Insert
-         * @description [stub] 사용자 승인 이벤트 일괄 삽입. Idempotency-Key 필수 (미들웨어가 강제).
-         */
-        post: operations["approve_insert_calendar_events_approve_insert_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/calendar/freebusy": {
+    "/onboarding/status": {
         parameters: {
             query?: never;
             header?: never;
@@ -138,410 +109,12 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Get Freebusy
-         * @description [stub] read-only freebusy 조회. from·to 는 조회 범위 (스텁은 고정 구간 반환).
+         * Get Onboarding Status
+         * @description 현재 사용자의 onboarding 상태 + 다음 가야 할 화면 hint.
          */
-        get: operations["get_freebusy_calendar_freebusy_get"];
+        get: operations["get_onboarding_status_onboarding_status_get"];
         put?: never;
         post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/calendar/sync-preview": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Sync Preview
-         * @description [stub] 계획 → 캘린더 이벤트 미리보기 + 충돌 체크.
-         */
-        post: operations["sync_preview_calendar_sync_preview_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/fixed-schedules": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List Schedules
-         * @description 내 활성 고정 일정 전체 (시작 시각 오름차순).
-         */
-        get: operations["list_schedules_fixed_schedules_get"];
-        put?: never;
-        /**
-         * Create Schedule
-         * @description 신규 고정 일정.
-         *
-         *     부수 효과: 사용자가 `ONBOARDING_CALENDAR` 또는 `ONBOARDING_MANUAL_SCHEDULE`
-         *     단계에 있으면 `ONBOARDING_POLICIES` 로 전이 (멱등).
-         */
-        post: operations["create_schedule_fixed_schedules_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/fixed-schedules/{schedule_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        /**
-         * Delete Schedule
-         * @description 고정 일정 soft delete (`archived_at`). hard delete 금지 (AGENTS.md §2).
-         */
-        delete: operations["delete_schedule_fixed_schedules__schedule_id__delete"];
-        options?: never;
-        head?: never;
-        /**
-         * Update Schedule
-         * @description 고정 일정 부분 수정 — 입력된 필드만 갱신.
-         */
-        patch: operations["update_schedule_fixed_schedules__schedule_id__patch"];
-        trace?: never;
-    };
-    "/goals": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List Goals
-         * @description 내 목표 — tier 별 그룹 (focus / maintain / parked).
-         */
-        get: operations["list_goals_goals_get"];
-        put?: never;
-        /**
-         * Create Goal
-         * @description 신규 목표 — tier 한도 (Focus ≤3 / Maintain ≤5) enforce.
-         */
-        post: operations["create_goal_goals_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/goals/{goal_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        /**
-         * Delete Goal
-         * @description 목표 soft delete (`archived_at` + `status=archived`).
-         */
-        delete: operations["delete_goal_goals__goal_id__delete"];
-        options?: never;
-        head?: never;
-        /**
-         * Update Goal
-         * @description 목표 부분 수정. tier 변경 시 한도 재검사.
-         */
-        patch: operations["update_goal_goals__goal_id__patch"];
-        trace?: never;
-    };
-    "/goals/{goal_id}/decompose": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Decompose Goal
-         * @description Goal Structuring 호출 → `goal_nodes` 트리.
-         *
-         *     Issue #22 본 PR 은 mock stub 응답 (LLM 통합은 PR #33 머지된 main 위 후속 PR).
-         *     실 구현 시 `prompts/planning/goal_decompose.v1.md` + `aiClient.run(...)` + HITL Draft Layer
-         *     (ADR-0005 §2.5.1).
-         */
-        post: operations["decompose_goal_goals__goal_id__decompose_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/goals/{goal_id}/park": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Park Goal
-         * @description Focus → Parked 전환. Parked 는 한도 자유.
-         */
-        post: operations["park_goal_goals__goal_id__park_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/habit-instances": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List Instances
-         * @description 그 주의 모든 활성 habit 인스턴스. weekStart 누락 시 이번 주(KST 월요일).
-         */
-        get: operations["list_instances_habit_instances_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/habit-instances/{instance_id}/check": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Check Instance
-         * @description 1회 달성 카운트 증가. user_id scope 는 habit 조인으로 자동 검증.
-         */
-        post: operations["check_instance_habit_instances__instance_id__check_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/habits": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List Habits
-         * @description 내 활성 습관 전체.
-         */
-        get: operations["list_habits_habits_get"];
-        put?: never;
-        /**
-         * Create Habit
-         * @description 신규 습관 + 이번 주 instance 자동 생성 (cron 도입 전 임시).
-         */
-        post: operations["create_habit_habits_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/habits/{habit_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        /**
-         * Delete Habit
-         * @description 습관 soft delete (`archived_at`).
-         */
-        delete: operations["delete_habit_habits__habit_id__delete"];
-        options?: never;
-        head?: never;
-        /**
-         * Update Habit
-         * @description 습관 부분 수정 — 제목 · 빈도. 빈도 변경 시 `target_count` 도 동기화.
-         */
-        patch: operations["update_habit_habits__habit_id__patch"];
-        trace?: never;
-    };
-    "/health": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Health */
-        get: operations["health_health_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/inbox": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List Inbox
-         * @description 내 inbox 항목. `?status=captured|classified|promoted|archived` 필터.
-         *
-         *     `status` 미지정 시 활성 항목(archived 제외)만. `status=archived` 는 보관함(soft-deleted)
-         *     조회 — `POST /inbox/{id}/restore` 로 되살릴 수 있다.
-         */
-        get: operations["list_inbox_inbox_get"];
-        put?: never;
-        /**
-         * Create Inbox
-         * @description 1줄 캡처 + AI category 추정 (LLM 1회, 8s timeout, 실패 시 룰 fallback).
-         */
-        post: operations["create_inbox_inbox_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/inbox/{inbox_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        /**
-         * Update Inbox
-         * @description userCategory override 또는 status 변경.
-         */
-        patch: operations["update_inbox_inbox__inbox_id__patch"];
-        trace?: never;
-    };
-    "/inbox/{inbox_id}/archive": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Archive Inbox
-         * @description Inbox 항목 soft delete (`archived_at` + `status=archived`).
-         */
-        post: operations["archive_inbox_inbox__inbox_id__archive_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/inbox/{inbox_id}/convert-to-action": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Convert To Action
-         * @description Inbox → ActionItem(source=inbox) 변환. inbox.status=promoted.
-         */
-        post: operations["convert_to_action_inbox__inbox_id__convert_to_action_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/inbox/{inbox_id}/convert-to-goal": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Convert To Goal
-         * @description Inbox → Goal 변환 (tier=maintain default, 한도 enforce). inbox.status=promoted.
-         */
-        post: operations["convert_to_goal_inbox__inbox_id__convert_to_goal_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/inbox/{inbox_id}/restore": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Restore Inbox
-         * @description 보관 취소 — `archived_at` 클리어 + status 를 활성(classified/captured)으로 복원.
-         *
-         *     보관함(`status=archived`)에서만 의미. 이미 활성이면 멱등(현재 상태 그대로 반환).
-         *     존재하지 않으면 404 `INBOX_NOT_FOUND`. hard delete 는 없으므로 언제든 되살릴 수 있다.
-         */
-        post: operations["restore_inbox_inbox__inbox_id__restore_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -567,6 +140,26 @@ export interface paths {
          *     동시성 lock(ADR-0005 §7.6) 안에서 검사+생성해 다중 디바이스 race 를 막는다.
          */
         post: operations["start_session_interview_sessions_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/interview/slot-catalog": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Slot Catalog
+         * @description 슬롯 카탈로그 — 클라이언트가 라벨·입력형식·보기(options) 렌더링에 사용.
+         */
+        get: operations["get_slot_catalog_interview_slot_catalog_get"];
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -615,28 +208,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/interview/sessions/{session_id}/finish": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Finish Session
-         * @description [충분해요] 조기 종료 — 남은 슬롯은 안전 default 로 채우고 outcome 빌드.
-         *
-         *     동시성 lock(ADR-0005 §7.6): 동시 종료/답 제출로 인한 state race 방지.
-         */
-        post: operations["finish_session_interview_sessions__session_id__finish_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/interview/sessions/{session_id}/next-question": {
         parameters: {
             query?: never;
@@ -659,53 +230,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/interview/slot-catalog": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Slot Catalog
-         * @description 슬롯 카탈로그 — 클라이언트가 라벨·입력형식·보기(options) 렌더링에 사용.
-         */
-        get: operations["get_slot_catalog_interview_slot_catalog_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/notifications/settings": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Settings
-         * @description 내 알림 설정. 없으면 default 로 1행 자동 생성.
-         */
-        get: operations["get_settings_notifications_settings_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        /**
-         * Update Settings
-         * @description 알림 시간 / 토글 수정. morning 06~10·evening 19~23 범위 검증.
-         *
-         *     부수 효과: `ONBOARDING_NOTIFICATIONS` → `ACTIVE` 로 전이 (멱등).
-         */
-        patch: operations["update_settings_notifications_settings_patch"];
-        trace?: never;
-    };
-    "/notifications/subscribe": {
+    "/interview/sessions/{session_id}/finish": {
         parameters: {
             query?: never;
             header?: never;
@@ -715,728 +240,16 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Subscribe
-         * @description Web Push 구독 등록 — `push_subscription` JSONB 저장 (재구독은 덮어쓰기).
+         * Finish Session
+         * @description [충분해요] 조기 종료 — 남은 슬롯은 안전 default 로 채우고 outcome 빌드.
          *
-         *     저장 형태는 pywebpush 가 그대로 받는 `{endpoint, keys: {p256dh, auth}}`.
-         *     응답은 실 설정 행 기준 — pushSubscribed 는 저장 결과에서 파생된다.
+         *     동시성 lock(ADR-0005 §7.6): 동시 종료/답 제출로 인한 state race 방지.
          */
-        post: operations["subscribe_notifications_subscribe_post"];
-        /**
-         * Unsubscribe
-         * @description Web Push 구독 해제 — 멱등 (구독이 없어도 204).
-         */
-        delete: operations["unsubscribe_notifications_subscribe_delete"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/notifications/vapid-public-key": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Vapid Public Key
-         * @description FE 가 `pushManager.subscribe(applicationServerKey)` 에 쓸 VAPID public key.
-         *
-         *     서버가 **자기 private key 의 짝**을 직접 알려줘 키 불일치를 원천 차단한다. FE 가
-         *     public key 를 하드코딩·빌드타임 주입하면, 서버가 키를 rotate 하는 순간 구독은 옛 키에
-         *     묶인 채 발송이 전부 push 서비스 403 으로 실패한다(조용히 — 구독 자체는 성공하므로).
-         *     런타임에 받아가면 진실 소스가 서버 하나로 모여 rotate 에도 자동으로 따라온다.
-         *
-         *     미설정이면 `publicKey=null` — FE 는 구독을 만들지 않는다(스키마 docstring 참조).
-         *     이 경로는 notifications 라우터에 속해 인증 필수(#16 DoD) — 구독 흐름 자체가 로그인 후다.
-         */
-        get: operations["get_vapid_public_key_notifications_vapid_public_key_get"];
-        put?: never;
-        post?: never;
+        post: operations["finish_session_interview_sessions__session_id__finish_post"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
-        trace?: never;
-    };
-    "/onboarding/status": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Onboarding Status
-         * @description 현재 사용자의 onboarding 상태 + 다음 가야 할 화면 hint.
-         */
-        get: operations["get_onboarding_status_onboarding_status_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/plans/generate": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Generate Plan
-         * @description 첫 주간/horizon 계획 생성 — First Plan orchestrator(LangGraph) 실행 → Draft 저장.
-         *
-         *     흐름: VALIDATING(tier 게이트) → decompose(LLM) → schedule(룰) → review(LLM) → Draft 저장.
-         *     Focus≤3 / Maintain≤5 초과 시 LLM 분해 전에 422 `GOAL_TIER_LIMIT_EXCEEDED`.
-         *     Draft 를 `plan_drafts`(72h 만료)에 저장하고 실제 `planId` 를 반환. 항상 `is_draft=true`.
-         *
-         *     동시성 lock(ADR-0005 §7.6): 다중 디바이스 동시 생성으로 인한 state race 방지.
-         */
-        post: operations["generate_plan_plans_generate_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/plans/milestones": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Generate Milestones
-         * @description Stage A(#milestones) — 목표를 중간 목표 3~5개로. 사용자가 확인·편집 후 generate 로 넘긴다.
-         *
-         *     입력은 generate 와 동일(interviewSessionId/outcome + density). LLM 1콜 + 룰 폴백이라 가볍다.
-         */
-        post: operations["generate_milestones_plans_milestones_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/plans/replan": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Generate Replan
-         * @description 주간 리포트를 작성하고, 남은 작업 + 수락한 회복을 **다음 주부터 마감까지** 다시 배치.
-         *
-         *     - 대상: 다음 주 이후 미착수 블록의 액션 + 활성 블록 없는 planned 백로그(수락한 회복 포함).
-         *       과거·시작/완료·user_edit 블록은 불변. 실패 원본은 미래 블록이 없어 자동 제외.
-         *     - busy = 확정(시작/완료·user_edit) 블록 + DB 시간정책 + **고정일정(#112 정합)**.
-         *     - 각 새 블록에 '교체할 옛 블록 id'(replacesBlockId)를 실어, 승인이 blanket-cancel 없이
-         *       그 블록만 현재 상태로 재조정 취소하게 한다(#117). 산출물은 Draft — 자동 적용 금지.
-         */
-        post: operations["generate_replan_plans_replan_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/plans/replan/{plan_id}/approve": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Approve Replan
-         * @description 재계획 Draft 승인 → **action 단위 재조정**으로 미래 블록 교체(#117 재작업).
-         *
-         *     #115 스케줄러가 긴 액션을 **여러 세션 블록**으로 쪼개므로, 재조정은 개별 블록이 아니라
-         *     **액션당 '옛 블록 집합'(payload `oldBlocks`)** 을 통째 다룬다 — 옛 블록 1개만 취소하면
-         *     나머지가 유령으로 남거나 새 세션이 드롭되던 문제 방지(리뷰 대응). 액션마다 현재 DB 상태로:
-         *     - 옛 블록 집합 중 하나라도 `started/finished`(사용자 착수) → 이 액션 **전체 보존**(skip).
-         *     - 활성(`scheduled`) 옛 블록이 하나도 없음(그새 전부 취소·삭제) → 중복 방지 skip.
-         *     - 그 외 → 활성 옛 블록 **전부 취소** + 새 세션 블록 **전부 생성**.
-         *     - 백로그(옛 블록 없음): 그새 그 action 이 활성 블록을 얻었으면 생성 skip.
-         *     - action 이 그새 아카이브/삭제됐으면(예: #113 First Plan 교체) 전체 skip(좀비 블록 방지).
-         *
-         *     Draft 로드·검사~쓰기를 `user_agent_lock`(xact-scoped) 안에서 단일 commit 으로 원자화한다
-         *     (동시 더블 승인 봉합, #113 패턴). 과거·시작/완료·user_edit 블록은 불변. 항상 Draft→HITL.
-         */
-        post: operations["approve_replan_plans_replan__plan_id__approve_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/plans/weekly": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Weekly Plan
-         * @description 주간 블록 그리드 (S14). weekStart 생략 시 이번 주 월요일 기준.
-         */
-        get: operations["get_weekly_plan_plans_weekly_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/plans/{plan_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Plan
-         * @description 저장된 First Plan Draft 미리보기 — LLM 재호출 없이 스냅샷 재구성.
-         *
-         *     재계획(`kind='replan'`) Draft 는 payload 모양이 달라(goal_nodes 가 없다) 여기서 다루지
-         *     않는다 — 가드가 없으면 `_draft_to_response` 가 `KeyError: 'goal_nodes'` 로 500 을 낸다.
-         *     승인 endpoint 의 반대편 가드(approve_replan 의 `kind != "replan"` 검사)와 대칭.
-         */
-        get: operations["get_plan_plans__plan_id__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/plans/{plan_id}/approve": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Approve Plan
-         * @description First Plan Draft 승인 → SAVING (goal 트리 단일 가드 트랜잭션 영속화, ADR-0005 §2.5.1).
-         *
-         *     `plan_id` 로 저장된 Draft 를 로드해 goals/goal_nodes/action_items/scheduled_blocks 를
-         *     단일 트랜잭션으로 영속화(+최대 3회 재시도). `policy_guarded_transaction`(PR #30 재사용)이
-         *     절대 시간 정책 위반 시 롤백 → 422 `PLAN_POLICY_VIOLATION`, 그 외 실패는 롤백 후 500
-         *     `PLAN_SAVE_FAILED`. 만료된 Draft 는 410 `PLAN_DRAFT_EXPIRED`. 이미 승인된 Draft 는 멱등.
-         *
-         *     승인 = 교체: 같은 target_date 의 이전 AI 계획 산출물 중 사용자가 손대지 않은
-         *     카드(source=goal·status=planned, user_edit 블록 없는 것)와 그 블록을 soft 정리
-         *     (archived/cancelled)하고, heaviest goal 의 기존 분해 트리도 보관한 뒤 새 계획을
-         *     영속화한다 — 재생성→재승인 반복으로 같은 날짜에 카드/블록/노드가 겹겹이 누적되던
-         *     문제 방지 (`first_plan_adapter.supersede_previous_plan`).
-         *
-         *     동시성(더블클릭·다중 디바이스 동시 승인): advisory lock 은 **트랜잭션 스코프**
-         *     (`pg_advisory_xact_lock`) 라 commit/rollback 마다 풀린다. 그래서 시도(attempt)마다
-         *     lock 을 새로 잡고, Draft 로드·만료·멱등 검사 → 영속화 → Draft 승인 마킹·온보딩
-         *     전이(`on_success` — 가드 트랜잭션 내부)까지를 **한 트랜잭션 단일 commit** 으로 묶는다.
-         *     lock 이 풀리는 순간엔 항상 status=approved 가 이미 커밋돼 있어, 대기하던 요청은
-         *     멱등 응답으로 빠진다. 재시도(ADR-0005 §2.5.1, 3회)는 이 라우터 루프가 담당한다
-         *     (adapter 내부 재시도는 rollback 으로 lock 을 잃은 채 돌게 되므로 `max_retries=1`).
-         *
-         *     부수 효과: 첫 계획 승인 = 온보딩 완료 → onboarding_state 를 `ACTIVE` 로 전이(멱등,
-         *     어느 온보딩 단계에서든). 원설계(FIRST_PLAN → NOTIFICATIONS)는 실제 FE 흐름에서 상태가
-         *     WELCOME 에 고정돼 새로고침 시 재-온보딩되던 문제가 있어 승인에서 ACTIVE 로 마감
-         *     (api-contract §3).
-         *     응답은 명시 승인이므로 `is_draft=false` (ADR-0005 §7.2).
-         */
-        post: operations["approve_plan_plans__plan_id__approve_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/plans/{plan_id}/blocks/{block_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        /**
-         * Edit Block
-         * @description 블록 15분 snap 이동 + 목표(category)/제목 수정 (S15).
-         *
-         *     충돌 422 `PLAN_BLOCK_CONFLICT` / 정책 422 `POLICY_VIOLATION`. `category`/`title` 을 주면
-         *     블록이 매달린 action_item 을 갱신한다(같은 액션의 모든 세션 블록 공유). 정책 검사는
-         *     **변경된 category** 로 수행하고, 변경 반영은 성공 commit 시에만 영속된다(422 면 롤백).
-         */
-        patch: operations["edit_block_plans__plan_id__blocks__block_id__patch"];
-        trace?: never;
-    };
-    "/plans/{plan_id}/discard": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Discard Plan
-         * @description 계획 초안 폐기 — "이 계획 말고 다시 인터뷰할래" 경로.
-         *
-         *     지금까지는 초안을 버릴 방법이 없어서 사용자가 새로고침으로 화면을 끊었고, 초안은 만료
-         *     (3일)까지 승인 대기 상태로 남았다. 명시적으로 버리면 그 자리에서 종착 상태가 된다.
-         *
-         *     초안은 애초에 비영속(계획 블록은 승인 전 DB 에 안 들어간다)이라 되돌릴 것이 없다 —
-         *     상태 전이만 하면 된다. 이미 승인된 초안은 되돌리는 게 아니므로 409 로 막는다.
-         *     멱등: 이미 폐기·만료된 초안에 다시 호출해도 204.
-         */
-        post: operations["discard_plan_plans__plan_id__discard_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/policy-snapshot/current": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Current Policy
-         * @description 현재 활성 PolicySnapshot (#83) — 없으면 404 (FE 는 카운트-only 폴백 유지).
-         */
-        get: operations["get_current_policy_policy_snapshot_current_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/privacy/consent": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Consent
-         * @description 동의 현황 — consent_type 별 최신 기록 (필수/마케팅/연구).
-         */
-        get: operations["get_consent_privacy_consent_get"];
-        put?: never;
-        /**
-         * Create Consent
-         * @description 동의/철회 — append-only 새 기록 추가 후 갱신된 현황 반환.
-         *
-         *     `consentType` 외 값은 Pydantic Literal → 422 `COMMON_VALIDATION_ERROR`.
-         */
-        post: operations["create_consent_privacy_consent_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/recovery/decisions": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Decide Recovery
-         * @description 사용자 선택 저장 (Idempotency-Key 필수 — §1.7 미들웨어 enforce).
-         *
-         *     - `accepted` → 선택 카드 accepted, 나머지 pending 은 rejected.
-         *       그룹이 DOWNSCOPE/CARRY_OVER 면 새 ActionItem(source=recovery_*) 생성 — 원본
-         *       카드 status 는 변경하지 않는다 (혈통: parent_action_item_id).
-         *     - `skipped` → 모든 pending 카드 skipped ("오늘은 쉬기").
-         */
-        post: operations["decide_recovery_recovery_decisions_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/recovery/proposals/generate": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Generate Recovery Proposals
-         * @description 실패 컨텍스트 기반 회복 옵션 2~4개 생성 (LLM thinking 0 + ≤ 12s, 룰 fallback — ADR-0003 addendum).
-         *
-         *     이미 pending 카드가 있으면 재생성하지 않고 그대로 반환한다 (중복 INSERT 방지).
-         */
-        post: operations["generate_recovery_proposals_recovery_proposals_generate_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/reflection/batch": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Batch Reflect
-         * @description 저녁 회고 일괄 처리 (S17) — 오늘+어제+그제 미체크 카드를 한 번에 종결.
-         *
-         *     각 항목 = 미체크(in_progress) 실행 1건의 최종 결과(4칩) + 선택적 실패 사유(0~2개).
-         *     check-in(`POST /today/check-ins`)과 동일한 전이(execution 종결 + 블록 finished
-         *     + action_item.status)를 재현하고, failed/partial_done 항목엔 실패 사유를 함께 기록한다.
-         *     **전량 사전 검증 후 한 트랜잭션으로 적용** — 하나라도 무효면 전체 롤백(부분 적용 없음).
-         *     Idempotency-Key 는 미들웨어가 강제([모두 완료] 중복 탭 방지). 빈 배열은 no-op.
-         */
-        post: operations["batch_reflect_reflection_batch_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/reflection/failure-tags": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List Failure Tags
-         * @description S18 칩 마스터 — 13종 (is_active=true, sort_order 순).
-         */
-        get: operations["list_failure_tags_reflection_failure_tags_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/reflection/failure-tags/{execution_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Tag Failure Reasons
-         * @description 실패 사유 태깅 (0~2개) + memo at-rest 암호화 (#19-B).
-         *
-         *     이 태그가 Recovery 룰 엔진(§12)의 `primary_trigger_tags` 매칭 입력이 된다.
-         */
-        post: operations["tag_failure_reasons_reflection_failure_tags__execution_id__post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/reflection/pending": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List Pending Reflections
-         * @description S17 저녁 회고 — 최근 3일(오늘+어제+그제) 미체크(in_progress) 실행 목록 (#83).
-         *
-         *     시작만 하고 체크인하지 않은 실행을 소급 회고(POST /reflection/batch)하도록 모은다.
-         *     아직 결과 미정이라 completionStatus 는 null.
-         */
-        get: operations["list_pending_reflections_reflection_pending_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/replan/{execution_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Replan Diff
-         * @description S20 before/after diff (Draft Layer) — 수락한 회복의 일정 변화 프리뷰 (#20-B).
-         *
-         *     before = 원본 실패 카드의 계획 시각, after = 회복 카드의 제안 시각.
-         *     이미 approve 로 블록이 배치됐으면 `alreadyApproved=true`.
-         *
-         *     **승인 후에는 실제 배치된 블록이 단일 진실**이다 — 과거 배치 보정(#174)이 `now` 에
-         *     의존하므로, 승인 뒤에도 매번 재계산하면 프리뷰가 실제 블록과 어긋난다. 미승인 프리뷰는
-         *     정의상 "지금 승인하면 여기"라 조회 시각에 따라 달라진다.
-         */
-        get: operations["get_replan_diff_replan__execution_id__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/replan/{execution_id}/approve": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Approve Replan
-         * @description S20 최종 적용 (Idempotency-Key 필수 — §1.7 미들웨어 enforce).
-         *
-         *     회복 ActionItem 을 `scheduled_block`(source='recovery') 으로 배치한다. 멱등:
-         *     이미 배치돼 있으면 같은 block 을 반환(중복 INSERT 방지). 원본 `action_item.status`
-         *     는 변경하지 않는다 (AGENTS.md §2 — Resilience 지표 전제).
-         */
-        post: operations["approve_replan_replan__execution_id__approve_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/reviews/habit-penalty": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List Habit Penalty
-         * @description 3주 연속 미달(50% 미만) habit 의 빈도 재설계 제안 후보 (S22).
-         */
-        get: operations["list_habit_penalty_reviews_habit_penalty_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/reviews/habit-penalty/{habit_id}/accept": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Accept Habit Penalty
-         * @description 빈도 재설계 수락 → frequency 다운 (Idempotency-Key 필수 — §1.7 미들웨어).
-         */
-        post: operations["accept_habit_penalty_reviews_habit_penalty__habit_id__accept_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/reviews/weekly": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Weekly Review
-         * @description 이번 주(또는 지정 주차) 리뷰. precomputed 우선, 없으면 즉석 계산(쓰기 없음).
-         */
-        get: operations["get_weekly_review_reviews_weekly_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/reviews/weekly/generate": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Generate Weekly Review
-         * @description 주간 리뷰 강제 재생성 + 영속화 (디버그/관리자). 같은 주 덮어쓰기.
-         */
-        post: operations["generate_weekly_review_reviews_weekly_generate_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/settings": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Settings
-         * @description 내 설정 메타 — tone / language / timezone + 알림 요약.
-         *
-         *     읽기 전용 — 알림 설정 행이 없으면 `notifications=null` (행을 생성하지 않는다).
-         */
-        get: operations["get_settings_settings_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/settings/anonymize": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Anonymize
-         * @description 즉시 익명화 — 2단계 확인.
-         *
-         *     - `confirmationToken` 없으면 step1: 확인 토큰 발급(미적용).
-         *     - `confirmationToken` 있으면 step2: 검증 후 `_encrypted` 필드 마스킹 + 이름 마스킹 +
-         *       `is_anonymized`/`anonymized_at` set. hard delete 아님(행 보존).
-         */
-        post: operations["anonymize_settings_anonymize_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/settings/profile": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Profile
-         * @description 지속형 프로필 메모리 — 에너지/시간(behavioral) + 톤/빈도(interaction) + 회복 선호.
-         *
-         *     인터뷰가 아직 안 채웠으면 해당 항목 null (행/키를 생성하지 않는다).
-         */
-        get: operations["get_profile_settings_profile_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        /**
-         * Update Profile
-         * @description 프로필 메모리 부분 수정 — 지정 필드만 갱신(미지정 유지). 행/키 없으면 생성.
-         *
-         *     enum 검증은 스키마 Literal (그 외 값 → 422 `COMMON_VALIDATION_ERROR`).
-         *     회복 선호(downscopeUnitMin·restOk)는 `users.focus_mode_preferences`(JSONB)에 병합 저장.
-         */
-        patch: operations["update_profile_settings_profile_patch"];
-        trace?: never;
-    };
-    "/settings/tone-mode": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        /**
-         * Update Tone Mode
-         * @description 톤 모드 변경 — gentle / strict / encouraging.
-         *
-         *     값 검증은 스키마 Literal (그 외 값 → 422 `COMMON_VALIDATION_ERROR`).
-         *     onboarding 상태 전이는 없다 (톤은 설정 화면에서 자유 변경).
-         */
-        patch: operations["update_tone_mode_settings_tone_mode_patch"];
         trace?: never;
     };
     "/time-policies": {
@@ -1511,6 +324,781 @@ export interface paths {
         patch: operations["update_policy_time_policies__policy_id__patch"];
         trace?: never;
     };
+    "/goals": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Goals
+         * @description 내 목표 — tier 별 그룹 (focus / maintain / parked).
+         */
+        get: operations["list_goals_goals_get"];
+        put?: never;
+        /**
+         * Create Goal
+         * @description 신규 목표 — tier 한도 (Focus ≤3 / Maintain ≤5) enforce.
+         *
+         *     생성 직후 그 카테고리의 추천 자료를 인박스에 넣는다 (#171). best-effort — savepoint
+         *     안에서 돌기 때문에 자료 삽입이 실패해도 목표 생성은 그대로 성공한다.
+         */
+        post: operations["create_goal_goals_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/goals/{goal_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Delete Goal
+         * @description 목표 soft delete (`archived_at` + `status=archived`).
+         */
+        delete: operations["delete_goal_goals__goal_id__delete"];
+        options?: never;
+        head?: never;
+        /**
+         * Update Goal
+         * @description 목표 부분 수정. tier 변경 시 한도 재검사.
+         */
+        patch: operations["update_goal_goals__goal_id__patch"];
+        trace?: never;
+    };
+    "/goals/{goal_id}/nodes": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Goal Nodes
+         * @description 이 목표의 **실제 분해 트리** — 계획 승인 시 영속된 `goal_nodes` 를 그대로 읽는다.
+         *
+         *     이 자리에 있던 `POST /{goal_id}/decompose` 는 목표와 무관하게 하드코딩된 데모 트리
+         *     (캡스톤 → 설계/구현/발표)를 돌려줬고 FE 가 그걸 화면에 그렸다. 어떤 목표를 분해해도
+         *     같은 캡스톤 단계가 나왔다 — 안 보여주느니만 못한 상태라 제거하고, 실제 분해를 읽는
+         *     조회로 대체한다. 분해 자체는 First Plan(`planning/goal_decompose` + 마일스톤)이 이미
+         *     수행하고 승인 시 영속한다.
+         *
+         *     계획을 아직 승인하지 않은 목표는 트리가 없으므로 `nodes=[]` (404 아님 — 목표는 존재하고
+         *     분해만 아직 없는 정상 상태다). `rootNodeId` 도 그때는 null.
+         */
+        get: operations["list_goal_nodes_goals__goal_id__nodes_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/goals/{goal_id}/park": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Park Goal
+         * @description Focus → Parked 전환. Parked 는 한도 자유.
+         */
+        post: operations["park_goal_goals__goal_id__park_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/habits": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Habits
+         * @description 내 활성 습관 전체.
+         */
+        get: operations["list_habits_habits_get"];
+        put?: never;
+        /**
+         * Create Habit
+         * @description 신규 습관 + 이번 주 instance 자동 생성 (cron 도입 전 임시).
+         */
+        post: operations["create_habit_habits_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/habits/{habit_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Delete Habit
+         * @description 습관 soft delete (`archived_at`).
+         */
+        delete: operations["delete_habit_habits__habit_id__delete"];
+        options?: never;
+        head?: never;
+        /**
+         * Update Habit
+         * @description 습관 부분 수정 — 제목 · 빈도. 빈도 변경 시 `target_count` 도 동기화.
+         */
+        patch: operations["update_habit_habits__habit_id__patch"];
+        trace?: never;
+    };
+    "/habit-instances": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Instances
+         * @description 그 주의 모든 활성 habit 인스턴스. weekStart 누락 시 이번 주(KST 월요일).
+         */
+        get: operations["list_instances_habit_instances_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/habit-instances/{instance_id}/check": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Check Instance
+         * @description 1회 달성 카운트 증가. user_id scope 는 habit 조인으로 자동 검증.
+         */
+        post: operations["check_instance_habit_instances__instance_id__check_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/inbox": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Inbox
+         * @description 내 inbox 항목. `?status=captured|classified|promoted|archived` 필터.
+         *
+         *     `status` 미지정 시 활성 항목(archived 제외)만. `status=archived` 는 보관함(soft-deleted)
+         *     조회 — `POST /inbox/{id}/restore` 로 되살릴 수 있다.
+         */
+        get: operations["list_inbox_inbox_get"];
+        put?: never;
+        /**
+         * Create Inbox
+         * @description 1줄 캡처 + AI category 추정 (LLM 1회, 8s timeout, 실패 시 룰 fallback).
+         */
+        post: operations["create_inbox_inbox_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/inbox/resources/{slug}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Inbox Resource
+         * @description 시스템 항목이 가리키는 정적 자료 본문 (#171).
+         *
+         *     **인증만 필요하고 소유권 검사는 하지 않는다** — 자료는 사용자별 개인 데이터가 아니라
+         *     레포에 커밋된 정적 공용 콘텐츠라 소유권 개념이 없다. 인증은 라우터 단위로 걸려 있다.
+         *
+         *     `slug` 는 레지스트리의 dict 키 조회에만 쓰이고 경로와 결합되지 않으므로 경로 순회가
+         *     성립하지 않는다. 규격을 벗어난 slug 는 그냥 404 로 떨어진다.
+         */
+        get: operations["get_inbox_resource_inbox_resources__slug__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/inbox/{inbox_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Update Inbox
+         * @description userCategory override 또는 status 변경.
+         */
+        patch: operations["update_inbox_inbox__inbox_id__patch"];
+        trace?: never;
+    };
+    "/inbox/{inbox_id}/convert-to-goal": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Convert To Goal
+         * @description Inbox → Goal 변환 (tier=maintain default, 한도 enforce). inbox.status=promoted.
+         */
+        post: operations["convert_to_goal_inbox__inbox_id__convert_to_goal_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/inbox/{inbox_id}/convert-to-action": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Convert To Action
+         * @description Inbox → ActionItem(source=inbox) 변환. inbox.status=promoted.
+         */
+        post: operations["convert_to_action_inbox__inbox_id__convert_to_action_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/inbox/{inbox_id}/adopt-step": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Adopt Resource Step
+         * @description 자료가 제안한 '한 걸음'을 오늘 할 일로 채택한다 (#171 후속).
+         *
+         *     자료를 읽고 끝나지 않게 하는 **유일한 출구**다. 여기서 만든 `ActionItem` 은
+         *     `source='inbox'` + `inbox_item_id` 로 자료에 연결되므로, 그 뒤 체크인 → 21시 회고
+         *     → 실패 사유 → 회복 카드는 **기존 루프가 그대로** 처리한다. 회복을 새로 만들지 않는다
+         *     (AGENTS §1: 회복 시점은 21시 일괄 회고만).
+         *
+         *     자료 항목은 `promoted` 로 바꾸지 않는다 — 한 걸음을 채택한 것이지 자료를 승격한 게
+         *     아니고, 나중에 다른 걸음을 또 채택하거나 다시 읽을 수 있어야 한다.
+         */
+        post: operations["adopt_resource_step_inbox__inbox_id__adopt_step_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/inbox/{inbox_id}/archive": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Archive Inbox
+         * @description Inbox 항목 soft delete (`archived_at` + `status=archived`).
+         */
+        post: operations["archive_inbox_inbox__inbox_id__archive_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/inbox/{inbox_id}/restore": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Restore Inbox
+         * @description 보관 취소 — `archived_at` 클리어 + status 를 활성(classified/captured)으로 복원.
+         *
+         *     보관함(`status=archived`)에서만 의미. 이미 활성이면 멱등(현재 상태 그대로 반환).
+         *     존재하지 않으면 404 `INBOX_NOT_FOUND`. hard delete 는 없으므로 언제든 되살릴 수 있다.
+         */
+        post: operations["restore_inbox_inbox__inbox_id__restore_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/plans/milestones": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Generate Milestones
+         * @description Stage A(#milestones) — 목표를 중간 목표 3~5개로. 사용자가 확인·편집 후 generate 로 넘긴다.
+         *
+         *     입력은 generate 와 동일(interviewSessionId/outcome + density). LLM 1콜 + 룰 폴백이라 가볍다.
+         */
+        post: operations["generate_milestones_plans_milestones_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/plans/generate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Generate Plan
+         * @description 첫 주간/horizon 계획 생성 — First Plan orchestrator(LangGraph) 실행 → Draft 저장.
+         *
+         *     흐름: VALIDATING(tier 게이트) → decompose(LLM) → schedule(룰) → review(LLM) → Draft 저장.
+         *     Focus≤3 / Maintain≤5 초과 시 LLM 분해 전에 422 `GOAL_TIER_LIMIT_EXCEEDED`.
+         *     Draft 를 `plan_drafts`(72h 만료)에 저장하고 실제 `planId` 를 반환. 항상 `is_draft=true`.
+         *
+         *     동시성 lock(ADR-0005 §7.6): 다중 디바이스 동시 생성으로 인한 state race 방지.
+         */
+        post: operations["generate_plan_plans_generate_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/plans/weekly": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Weekly Plan
+         * @description 주간 블록 그리드 (S14). weekStart 생략 시 이번 주 월요일 기준.
+         */
+        get: operations["get_weekly_plan_plans_weekly_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/plans/{plan_id}/blocks/{block_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Edit Block
+         * @description 블록 15분 snap 이동 + 목표(category)/제목 수정 (S15).
+         *
+         *     충돌 422 `PLAN_BLOCK_CONFLICT` / 정책 422 `POLICY_VIOLATION`. `category`/`title` 을 주면
+         *     블록이 매달린 action_item 을 갱신한다(같은 액션의 모든 세션 블록 공유). 정책 검사는
+         *     **변경된 category** 로 수행하고, 변경 반영은 성공 commit 시에만 영속된다(422 면 롤백).
+         */
+        patch: operations["edit_block_plans__plan_id__blocks__block_id__patch"];
+        trace?: never;
+    };
+    "/plans/{plan_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Plan
+         * @description 저장된 First Plan Draft 미리보기 — LLM 재호출 없이 스냅샷 재구성.
+         *
+         *     재계획(`kind='replan'`) Draft 는 payload 모양이 달라(goal_nodes 가 없다) 여기서 다루지
+         *     않는다 — 가드가 없으면 `_draft_to_response` 가 `KeyError: 'goal_nodes'` 로 500 을 낸다.
+         *     승인 endpoint 의 반대편 가드(approve_replan 의 `kind != "replan"` 검사)와 대칭.
+         */
+        get: operations["get_plan_plans__plan_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/plans/{plan_id}/discard": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Discard Plan
+         * @description 계획 초안 폐기 — "이 계획 말고 다시 인터뷰할래" 경로.
+         *
+         *     지금까지는 초안을 버릴 방법이 없어서 사용자가 새로고침으로 화면을 끊었고, 초안은 만료
+         *     (3일)까지 승인 대기 상태로 남았다. 명시적으로 버리면 그 자리에서 종착 상태가 된다.
+         *
+         *     초안은 애초에 비영속(계획 블록은 승인 전 DB 에 안 들어간다)이라 되돌릴 것이 없다 —
+         *     상태 전이만 하면 된다. 이미 승인된 초안은 되돌리는 게 아니므로 409 로 막는다.
+         *     멱등: 이미 폐기·만료된 초안에 다시 호출해도 204.
+         */
+        post: operations["discard_plan_plans__plan_id__discard_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/plans/{plan_id}/approve": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Approve Plan
+         * @description First Plan Draft 승인 → SAVING (goal 트리 단일 가드 트랜잭션 영속화, ADR-0005 §2.5.1).
+         *
+         *     `plan_id` 로 저장된 Draft 를 로드해 goals/goal_nodes/action_items/scheduled_blocks 를
+         *     단일 트랜잭션으로 영속화(+최대 3회 재시도). `policy_guarded_transaction`(PR #30 재사용)이
+         *     절대 시간 정책 위반 시 롤백 → 422 `PLAN_POLICY_VIOLATION`, 그 외 실패는 롤백 후 500
+         *     `PLAN_SAVE_FAILED`. 만료된 Draft 는 410 `PLAN_DRAFT_EXPIRED`. 이미 승인된 Draft 는 멱등.
+         *
+         *     승인 = 교체: 같은 target_date 의 이전 AI 계획 산출물 중 사용자가 손대지 않은
+         *     카드(source=goal·status=planned, user_edit 블록 없는 것)와 그 블록을 soft 정리
+         *     (archived/cancelled)하고, heaviest goal 의 기존 분해 트리도 보관한 뒤 새 계획을
+         *     영속화한다 — 재생성→재승인 반복으로 같은 날짜에 카드/블록/노드가 겹겹이 누적되던
+         *     문제 방지 (`first_plan_adapter.supersede_previous_plan`).
+         *
+         *     동시성(더블클릭·다중 디바이스 동시 승인): advisory lock 은 **트랜잭션 스코프**
+         *     (`pg_advisory_xact_lock`) 라 commit/rollback 마다 풀린다. 그래서 시도(attempt)마다
+         *     lock 을 새로 잡고, Draft 로드·만료·멱등 검사 → 영속화 → Draft 승인 마킹·온보딩
+         *     전이(`on_success` — 가드 트랜잭션 내부)까지를 **한 트랜잭션 단일 commit** 으로 묶는다.
+         *     lock 이 풀리는 순간엔 항상 status=approved 가 이미 커밋돼 있어, 대기하던 요청은
+         *     멱등 응답으로 빠진다. 재시도(ADR-0005 §2.5.1, 3회)는 이 라우터 루프가 담당한다
+         *     (adapter 내부 재시도는 rollback 으로 lock 을 잃은 채 돌게 되므로 `max_retries=1`).
+         *
+         *     부수 효과: 첫 계획 승인 = 온보딩 완료 → onboarding_state 를 `ACTIVE` 로 전이(멱등,
+         *     어느 온보딩 단계에서든). 원설계(FIRST_PLAN → NOTIFICATIONS)는 실제 FE 흐름에서 상태가
+         *     WELCOME 에 고정돼 새로고침 시 재-온보딩되던 문제가 있어 승인에서 ACTIVE 로 마감
+         *     (api-contract §3).
+         *     응답은 명시 승인이므로 `is_draft=false` (ADR-0005 §7.2).
+         */
+        post: operations["approve_plan_plans__plan_id__approve_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/plans/replan": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Generate Replan
+         * @description 주간 리포트를 작성하고, 남은 작업 + 수락한 회복을 **다음 주부터 마감까지** 다시 배치.
+         *
+         *     - 대상: 다음 주 이후 미착수 블록의 액션 + 활성 블록 없는 planned 백로그(수락한 회복 포함).
+         *       과거·시작/완료·user_edit 블록은 불변. 실패 원본은 미래 블록이 없어 자동 제외.
+         *     - busy = 확정(시작/완료·user_edit) 블록 + DB 시간정책 + **고정일정(#112 정합)**.
+         *     - 각 새 블록에 '교체할 옛 블록 id'(replacesBlockId)를 실어, 승인이 blanket-cancel 없이
+         *       그 블록만 현재 상태로 재조정 취소하게 한다(#117). 산출물은 Draft — 자동 적용 금지.
+         */
+        post: operations["generate_replan_plans_replan_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/plans/replan/{plan_id}/approve": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Approve Replan
+         * @description 재계획 Draft 승인 → **action 단위 재조정**으로 미래 블록 교체(#117 재작업).
+         *
+         *     #115 스케줄러가 긴 액션을 **여러 세션 블록**으로 쪼개므로, 재조정은 개별 블록이 아니라
+         *     **액션당 '옛 블록 집합'(payload `oldBlocks`)** 을 통째 다룬다 — 옛 블록 1개만 취소하면
+         *     나머지가 유령으로 남거나 새 세션이 드롭되던 문제 방지(리뷰 대응). 액션마다 현재 DB 상태로:
+         *     - 옛 블록 집합 중 하나라도 `started/finished`(사용자 착수) → 이 액션 **전체 보존**(skip).
+         *     - 활성(`scheduled`) 옛 블록이 하나도 없음(그새 전부 취소·삭제) → 중복 방지 skip.
+         *     - 그 외 → 활성 옛 블록 **전부 취소** + 새 세션 블록 **전부 생성**.
+         *     - 백로그(옛 블록 없음): 그새 그 action 이 활성 블록을 얻었으면 생성 skip.
+         *     - action 이 그새 아카이브/삭제됐으면(예: #113 First Plan 교체) 전체 skip(좀비 블록 방지).
+         *
+         *     Draft 로드·검사~쓰기를 `user_agent_lock`(xact-scoped) 안에서 단일 commit 으로 원자화한다
+         *     (동시 더블 승인 봉합, #113 패턴). 과거·시작/완료·user_edit 블록은 불변. 항상 Draft→HITL.
+         */
+        post: operations["approve_replan_plans_replan__plan_id__approve_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/calendar/connect": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Connect Calendar
+         * @description Google Calendar 연결 — **베타 이후 지원 (P1)**.
+         *
+         *     Issue #17 MVP 결정: 캘린더 OAuth 는 P1 로 미룸. FE 는 S05 수동 입력으로 진행.
+         */
+        post: operations["connect_calendar_calendar_connect_post"];
+        /**
+         * Disconnect Calendar
+         * @description Google Calendar 연결 해제 — **베타 이후 지원 (P1)**.
+         */
+        delete: operations["disconnect_calendar_calendar_connect_delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/calendar/freebusy": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Freebusy
+         * @description [stub] read-only freebusy 조회. from·to 는 조회 범위 (스텁은 고정 구간 반환).
+         */
+        get: operations["get_freebusy_calendar_freebusy_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/calendar/sync-preview": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Sync Preview
+         * @description [stub] 계획 → 캘린더 이벤트 미리보기 + 충돌 체크.
+         */
+        post: operations["sync_preview_calendar_sync_preview_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/calendar/events/approve-insert": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Approve Insert
+         * @description [stub] 사용자 승인 이벤트 일괄 삽입. Idempotency-Key 필수 (미들웨어가 강제).
+         */
+        post: operations["approve_insert_calendar_events_approve_insert_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/fixed-schedules": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Schedules
+         * @description 내 활성 고정 일정 전체 (시작 시각 오름차순).
+         */
+        get: operations["list_schedules_fixed_schedules_get"];
+        put?: never;
+        /**
+         * Create Schedule
+         * @description 신규 고정 일정.
+         *
+         *     부수 효과: 사용자가 `ONBOARDING_CALENDAR` 또는 `ONBOARDING_MANUAL_SCHEDULE`
+         *     단계에 있으면 `ONBOARDING_POLICIES` 로 전이 (멱등).
+         */
+        post: operations["create_schedule_fixed_schedules_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/fixed-schedules/{schedule_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Delete Schedule
+         * @description 고정 일정 soft delete (`archived_at`). hard delete 금지 (AGENTS.md §2).
+         */
+        delete: operations["delete_schedule_fixed_schedules__schedule_id__delete"];
+        options?: never;
+        head?: never;
+        /**
+         * Update Schedule
+         * @description 고정 일정 부분 수정 — 입력된 필드만 갱신.
+         */
+        patch: operations["update_schedule_fixed_schedules__schedule_id__patch"];
+        trace?: never;
+    };
+    "/today/agenda": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Today Agenda
+         * @description 오늘 어젠다 단일 조회 — daily_brief + cards + habits + fixed (모두 read).
+         */
+        get: operations["today_agenda_today_agenda_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/today/actions/{action_id}": {
         parameters: {
             query?: never;
@@ -1548,26 +1136,6 @@ export interface paths {
          *     (source='user_edit'). 같은 카드의 in_progress 실행이 있으면 409.
          */
         post: operations["start_action_today_actions__action_id__start_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/today/agenda": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Today Agenda
-         * @description 오늘 어젠다 단일 조회 — daily_brief + cards + habits + fixed (모두 read).
-         */
-        get: operations["today_agenda_today_agenda_get"];
-        put?: never;
-        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -1642,6 +1210,500 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/reflection/pending": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Pending Reflections
+         * @description S17 저녁 회고 — 최근 3일(오늘+어제+그제) 미체크(in_progress) 실행 목록 (#83).
+         *
+         *     시작만 하고 체크인하지 않은 실행을 소급 회고(POST /reflection/batch)하도록 모은다.
+         *     아직 결과 미정이라 completionStatus 는 null.
+         */
+        get: operations["list_pending_reflections_reflection_pending_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/reflection/failure-tags": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Failure Tags
+         * @description S18 칩 마스터 — 13종 (is_active=true, sort_order 순).
+         */
+        get: operations["list_failure_tags_reflection_failure_tags_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/reflection/failure-tags/{execution_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Tag Failure Reasons
+         * @description 실패 사유 태깅 (0~2개) + memo at-rest 암호화 (#19-B).
+         *
+         *     이 태그가 Recovery 룰 엔진(§12)의 `primary_trigger_tags` 매칭 입력이 된다.
+         */
+        post: operations["tag_failure_reasons_reflection_failure_tags__execution_id__post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/reflection/batch": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Batch Reflect
+         * @description 저녁 회고 일괄 처리 (S17) — 오늘+어제+그제 미체크 카드를 한 번에 종결.
+         *
+         *     각 항목 = 미체크(in_progress) 실행 1건의 최종 결과(4칩) + 선택적 실패 사유(0~2개).
+         *     check-in(`POST /today/check-ins`)과 동일한 전이(execution 종결 + 블록 finished
+         *     + action_item.status)를 재현하고, failed/partial_done 항목엔 실패 사유를 함께 기록한다.
+         *     **전량 사전 검증 후 한 트랜잭션으로 적용** — 하나라도 무효면 전체 롤백(부분 적용 없음).
+         *     Idempotency-Key 는 미들웨어가 강제([모두 완료] 중복 탭 방지). 빈 배열은 no-op.
+         */
+        post: operations["batch_reflect_reflection_batch_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/recovery/proposals/generate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Generate Recovery Proposals
+         * @description 실패 컨텍스트 기반 회복 옵션 2~4개 생성 (LLM thinking 0 + ≤ 12s, 룰 fallback — ADR-0003 addendum).
+         *
+         *     이미 pending 카드가 있으면 재생성하지 않고 그대로 반환한다 (중복 INSERT 방지).
+         */
+        post: operations["generate_recovery_proposals_recovery_proposals_generate_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/recovery/decisions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Decide Recovery
+         * @description 사용자 선택 저장 (Idempotency-Key 필수 — §1.7 미들웨어 enforce).
+         *
+         *     - `accepted` → 선택 카드 accepted, 나머지 pending 은 rejected.
+         *       그룹이 DOWNSCOPE/CARRY_OVER 면 새 ActionItem(source=recovery_*) 생성 — 원본
+         *       카드 status 는 변경하지 않는다 (혈통: parent_action_item_id).
+         *     - `skipped` → 모든 pending 카드 skipped ("오늘은 쉬기").
+         */
+        post: operations["decide_recovery_recovery_decisions_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/replan/{execution_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Replan Diff
+         * @description S20 before/after diff (Draft Layer) — 수락한 회복의 일정 변화 프리뷰 (#20-B).
+         *
+         *     before = 원본 실패 카드의 계획 시각, after = 회복 카드의 제안 시각.
+         *     이미 approve 로 블록이 배치됐으면 `alreadyApproved=true`.
+         *
+         *     **승인 후에는 실제 배치된 블록이 단일 진실**이다 — 과거 배치 보정(#174)이 `now` 에
+         *     의존하므로, 승인 뒤에도 매번 재계산하면 프리뷰가 실제 블록과 어긋난다. 미승인 프리뷰는
+         *     정의상 "지금 승인하면 여기"라 조회 시각에 따라 달라진다.
+         */
+        get: operations["get_replan_diff_replan__execution_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/replan/{execution_id}/approve": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Approve Replan
+         * @description S20 최종 적용 (Idempotency-Key 필수 — §1.7 미들웨어 enforce).
+         *
+         *     회복 ActionItem 을 `scheduled_block`(source='recovery') 으로 배치한다. 멱등:
+         *     이미 배치돼 있으면 같은 block 을 반환(중복 INSERT 방지). 원본 `action_item.status`
+         *     는 변경하지 않는다 (AGENTS.md §2 — Resilience 지표 전제).
+         */
+        post: operations["approve_replan_replan__execution_id__approve_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/reviews/weekly": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Weekly Review
+         * @description 이번 주(또는 지정 주차) 리뷰. precomputed 우선, 없으면 즉석 계산(쓰기 없음).
+         */
+        get: operations["get_weekly_review_reviews_weekly_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/reviews/weekly/generate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Generate Weekly Review
+         * @description 주간 리뷰 강제 재생성 + 영속화 (디버그/관리자). 같은 주 덮어쓰기.
+         */
+        post: operations["generate_weekly_review_reviews_weekly_generate_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/reviews/habit-penalty": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Habit Penalty
+         * @description 3주 연속 미달(50% 미만) habit 의 빈도 재설계 제안 후보 (S22).
+         */
+        get: operations["list_habit_penalty_reviews_habit_penalty_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/reviews/habit-penalty/{habit_id}/accept": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Accept Habit Penalty
+         * @description 빈도 재설계 수락 → frequency 다운 (Idempotency-Key 필수 — §1.7 미들웨어).
+         */
+        post: operations["accept_habit_penalty_reviews_habit_penalty__habit_id__accept_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/policy-snapshot/current": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Current Policy
+         * @description 현재 활성 PolicySnapshot (#83) — 없으면 404 (FE 는 카운트-only 폴백 유지).
+         */
+        get: operations["get_current_policy_policy_snapshot_current_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/notifications/settings": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Settings
+         * @description 내 알림 설정. 없으면 default 로 1행 자동 생성.
+         */
+        get: operations["get_settings_notifications_settings_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Update Settings
+         * @description 알림 시간 / 토글 수정. morning 06~10·evening 19~23 범위 검증.
+         *
+         *     부수 효과: `ONBOARDING_NOTIFICATIONS` → `ACTIVE` 로 전이 (멱등).
+         */
+        patch: operations["update_settings_notifications_settings_patch"];
+        trace?: never;
+    };
+    "/notifications/vapid-public-key": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Vapid Public Key
+         * @description FE 가 `pushManager.subscribe(applicationServerKey)` 에 쓸 VAPID public key.
+         *
+         *     서버가 **자기 private key 의 짝**을 직접 알려줘 키 불일치를 원천 차단한다. FE 가
+         *     public key 를 하드코딩·빌드타임 주입하면, 서버가 키를 rotate 하는 순간 구독은 옛 키에
+         *     묶인 채 발송이 전부 push 서비스 403 으로 실패한다(조용히 — 구독 자체는 성공하므로).
+         *     런타임에 받아가면 진실 소스가 서버 하나로 모여 rotate 에도 자동으로 따라온다.
+         *
+         *     미설정이면 `publicKey=null` — FE 는 구독을 만들지 않는다(스키마 docstring 참조).
+         *     이 경로는 notifications 라우터에 속해 인증 필수(#16 DoD) — 구독 흐름 자체가 로그인 후다.
+         */
+        get: operations["get_vapid_public_key_notifications_vapid_public_key_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/notifications/subscribe": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Subscribe
+         * @description Web Push 구독 등록 — `push_subscription` JSONB 저장 (재구독은 덮어쓰기).
+         *
+         *     저장 형태는 pywebpush 가 그대로 받는 `{endpoint, keys: {p256dh, auth}}`.
+         *     응답은 실 설정 행 기준 — pushSubscribed 는 저장 결과에서 파생된다.
+         */
+        post: operations["subscribe_notifications_subscribe_post"];
+        /**
+         * Unsubscribe
+         * @description Web Push 구독 해제 — 멱등 (구독이 없어도 204).
+         */
+        delete: operations["unsubscribe_notifications_subscribe_delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/settings": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Settings
+         * @description 내 설정 메타 — tone / language / timezone + 알림 요약.
+         *
+         *     읽기 전용 — 알림 설정 행이 없으면 `notifications=null` (행을 생성하지 않는다).
+         */
+        get: operations["get_settings_settings_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/settings/tone-mode": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Update Tone Mode
+         * @description 톤 모드 변경 — gentle / strict / encouraging.
+         *
+         *     값 검증은 스키마 Literal (그 외 값 → 422 `COMMON_VALIDATION_ERROR`).
+         *     onboarding 상태 전이는 없다 (톤은 설정 화면에서 자유 변경).
+         */
+        patch: operations["update_tone_mode_settings_tone_mode_patch"];
+        trace?: never;
+    };
+    "/settings/profile": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Profile
+         * @description 지속형 프로필 메모리 — 에너지/시간(behavioral) + 톤/빈도(interaction) + 회복 선호.
+         *
+         *     인터뷰가 아직 안 채웠으면 해당 항목 null (행/키를 생성하지 않는다).
+         */
+        get: operations["get_profile_settings_profile_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Update Profile
+         * @description 프로필 메모리 부분 수정 — 지정 필드만 갱신(미지정 유지). 행/키 없으면 생성.
+         *
+         *     enum 검증은 스키마 Literal (그 외 값 → 422 `COMMON_VALIDATION_ERROR`).
+         *     회복 선호(downscopeUnitMin·restOk)는 `users.focus_mode_preferences`(JSONB)에 병합 저장.
+         */
+        patch: operations["update_profile_settings_profile_patch"];
+        trace?: never;
+    };
+    "/settings/anonymize": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Anonymize
+         * @description 즉시 익명화 — 2단계 확인.
+         *
+         *     - `confirmationToken` 없으면 step1: 확인 토큰 발급(미적용).
+         *     - `confirmationToken` 있으면 step2: 검증 후 `_encrypted` 필드 마스킹 + 이름 마스킹 +
+         *       `is_anonymized`/`anonymized_at` set. hard delete 아님(행 보존).
+         */
+        post: operations["anonymize_settings_anonymize_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/privacy/consent": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Consent
+         * @description 동의 현황 — consent_type 별 최신 기록 (필수/마케팅/연구).
+         */
+        get: operations["get_consent_privacy_consent_get"];
+        put?: never;
+        /**
+         * Create Consent
+         * @description 동의/철회 — append-only 새 기록 추가 후 갱신된 현황 반환.
+         *
+         *     `consentType` 외 값은 Pydantic Literal → 422 `COMMON_VALIDATION_ERROR`.
+         */
+        post: operations["create_consent_privacy_consent_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -1661,42 +1723,42 @@ export interface components {
         ActionDetail: {
             /** Actionid */
             actionId: string;
+            /** Title */
+            title: string;
             /** Category */
             category: string;
+            /** Status */
+            status: string;
+            /** Priority */
+            priority: number;
             /** Estimatedminutes */
             estimatedMinutes: number;
+            /** Targetdate */
+            targetDate: string;
+            /** Source */
+            source: string;
+            /** Whynow */
+            whyNow: string | null;
             /** Firststep */
             firstStep: string | null;
             /** Goalid */
             goalId: string | null;
-            /** Priority */
-            priority: number;
-            /** Source */
-            source: string;
-            /** Status */
-            status: string;
-            /** Targetdate */
-            targetDate: string;
-            /** Title */
-            title: string;
-            /** Whynow */
-            whyNow: string | null;
         };
         /**
          * ActionItemDraft
          * @description leaf 노드에 매달리는 실행 항목 — SMART + tiny_first_step.
          */
         ActionItemDraft: {
-            /** Category */
-            category: string;
-            /** Estimatedminutes */
-            estimatedMinutes: number;
-            /** Firststep */
-            firstStep: string;
             /** Nodeid */
             nodeId: string;
             /** Title */
             title: string;
+            /** Estimatedminutes */
+            estimatedMinutes: number;
+            /** Category */
+            category: string;
+            /** Firststep */
+            firstStep: string;
         };
         /**
          * AgendaCard
@@ -1705,52 +1767,52 @@ export interface components {
         AgendaCard: {
             /** Actionid */
             actionId: string;
-            /** Category */
-            category: string;
-            /** Estimatedminutes */
-            estimatedMinutes: number;
-            /** Firststep */
-            firstStep: string | null;
-            /** Priority */
-            priority: number;
-            /** Source */
-            source: string;
-            /** Status */
-            status: string;
             /** Title */
             title: string;
+            /** Category */
+            category: string;
+            /** Status */
+            status: string;
+            /** Priority */
+            priority: number;
+            /** Estimatedminutes */
+            estimatedMinutes: number;
+            /** Source */
+            source: string;
             /** Whynow */
             whyNow: string | null;
+            /** Firststep */
+            firstStep: string | null;
         };
         /**
          * AgendaFixedSchedule
          * @description S10 고정 일정 row — 오늘 요일에 걸린 것.
          */
         AgendaFixedSchedule: {
-            /** Endtime */
-            endTime: string;
             /** Scheduleid */
             scheduleId: string;
-            /** Starttime */
-            startTime: string;
             /** Title */
             title: string;
+            /** Starttime */
+            startTime: string;
+            /** Endtime */
+            endTime: string;
         };
         /**
          * AgendaHabit
          * @description S10 습관 row — 이번 주 habit_instance 진행.
          */
         AgendaHabit: {
-            /** Donecount */
-            doneCount: number;
-            /** Habitid */
-            habitId: string;
             /** Instanceid */
             instanceId: string;
-            /** Targetcount */
-            targetCount: number;
+            /** Habitid */
+            habitId: string;
             /** Title */
             title: string;
+            /** Targetcount */
+            targetCount: number;
+            /** Donecount */
+            doneCount: number;
         };
         /**
          * AnonymizeRequest
@@ -1770,21 +1832,21 @@ export interface components {
          *     - `anonymized` — 적용 완료. `anonymizedAt`/`maskedCount` 채움.
          */
         AnonymizeResponse: {
-            /** Anonymizedat */
-            anonymizedAt?: string | null;
-            /** Confirmationtoken */
-            confirmationToken?: string | null;
-            /** Expiresat */
-            expiresAt?: string | null;
-            /** Maskedcount */
-            maskedCount?: number | null;
-            /** Message */
-            message: string;
             /**
              * Status
              * @enum {string}
              */
             status: "confirmation_required" | "anonymized";
+            /** Message */
+            message: string;
+            /** Confirmationtoken */
+            confirmationToken?: string | null;
+            /** Expiresat */
+            expiresAt?: string | null;
+            /** Anonymizedat */
+            anonymizedAt?: string | null;
+            /** Maskedcount */
+            maskedCount?: number | null;
         };
         /**
          * ApproveInsertResult
@@ -1814,34 +1876,34 @@ export interface components {
          */
         AvailabilityProfile: {
             activityWindow: components["schemas"]["TimeRange"];
-            /** Fixedblockhints */
-            fixedBlockHints?: string[];
-            /** Notouchwindows */
-            noTouchWindows?: components["schemas"]["NoTouchWindow"][];
             /** Peakwindow */
             peakWindow: string[];
+            /** Notouchwindows */
+            noTouchWindows?: components["schemas"]["NoTouchWindow"][];
+            /** Fixedblockhints */
+            fixedBlockHints?: string[];
         };
         /**
          * BehavioralProfileView
          * @description behavioral_profiles 의 사용자 편집 대상 필드.
          */
         BehavioralProfileView: {
-            /** Attentionspan */
-            attentionSpan: number;
             /**
              * Energycycle
              * @enum {string}
              */
             energyCycle: "morning" | "afternoon" | "evening" | "night" | "varies";
-            /** Preferredendtime */
-            preferredEndTime?: string | null;
-            /** Preferredstarttime */
-            preferredStartTime?: string | null;
+            /** Attentionspan */
+            attentionSpan: number;
             /**
              * Timechunkpreference
              * @enum {string}
              */
             timeChunkPreference: "10" | "20" | "30" | "60" | "90";
+            /** Preferredstarttime */
+            preferredStartTime?: string | null;
+            /** Preferredendtime */
+            preferredEndTime?: string | null;
         };
         /**
          * BlockEditRequest
@@ -1852,12 +1914,12 @@ export interface components {
          *     세션 블록에 반영되며, 미지원 category 는 'other' 로 정규화한다. 미지정 필드는 유지.
          */
         BlockEditRequest: {
-            /** Category */
-            category?: string | null;
-            /** Endat */
-            endAt?: string | null;
             /** Startat */
             startAt: string;
+            /** Endat */
+            endAt?: string | null;
+            /** Category */
+            category?: string | null;
             /** Title */
             title?: string | null;
         };
@@ -1866,30 +1928,30 @@ export interface components {
          * @description 편집 결과 — 스냅 적용된 최종 블록.
          */
         BlockEditResponse: {
-            /** Actionid */
-            actionId: string;
             /** Blockid */
             blockId: string;
-            /** Blockstatus */
-            blockStatus: string;
+            /** Actionid */
+            actionId: string;
+            /** Title */
+            title: string;
             /** Category */
             category: string;
-            /**
-             * Endat
-             * Format: date-time
-             */
-            endAt: string;
             /** Goalid */
             goalId?: string | null;
-            /** Source */
-            source: string;
             /**
              * Startat
              * Format: date-time
              */
             startAt: string;
-            /** Title */
-            title: string;
+            /**
+             * Endat
+             * Format: date-time
+             */
+            endAt: string;
+            /** Blockstatus */
+            blockStatus: string;
+            /** Source */
+            source: string;
         };
         /**
          * BusyInterval
@@ -1897,15 +1959,15 @@ export interface components {
          */
         BusyInterval: {
             /**
-             * End
-             * Format: date-time
-             */
-            end: string;
-            /**
              * Start
              * Format: date-time
              */
             start: string;
+            /**
+             * End
+             * Format: date-time
+             */
+            end: string;
         };
         /**
          * CalendarConnectRequest
@@ -1920,10 +1982,10 @@ export interface components {
          * @description 캘린더 연결 상태 — POST /calendar/connect 응답.
          */
         CalendarConnection: {
-            /** Connected */
-            connected: boolean;
             /** Provider */
             provider: string;
+            /** Connected */
+            connected: boolean;
             /** Scopes */
             scopes: string[];
         };
@@ -1932,51 +1994,51 @@ export interface components {
          * @description sync-preview 의 캘린더 이벤트 후보.
          */
         CalendarEventPreview: {
-            /** Conflict */
-            conflict: boolean;
-            /**
-             * End
-             * Format: date-time
-             */
-            end: string;
+            /** Title */
+            title: string;
             /**
              * Start
              * Format: date-time
              */
             start: string;
-            /** Title */
-            title: string;
+            /**
+             * End
+             * Format: date-time
+             */
+            end: string;
+            /** Conflict */
+            conflict: boolean;
         };
         /**
          * CheckInRequest
          * @description POST /today/check-ins 요청 — Quick Check-in 4칩 (S13/S17).
          */
         CheckInRequest: {
+            /** Executionid */
+            executionId: string;
             /**
              * Completionstatus
              * @enum {string}
              */
             completionStatus: "done" | "partial_done" | "failed" | "over_done";
-            /** Executionid */
-            executionId: string;
-            /** Userfeedback */
-            userFeedback?: string | null;
             /** Userrating */
             userRating?: number | null;
+            /** Userfeedback */
+            userFeedback?: string | null;
         };
         /**
          * CheckInResponse
          * @description 체크인 결과. `needs_failure_tags=True` 면 FE 는 S18(실패 사유)로 이동.
          */
         CheckInResponse: {
-            /** Actionid */
-            actionId: string;
-            /** Actualdurationminutes */
-            actualDurationMinutes: number | null;
-            /** Completionstatus */
-            completionStatus: string;
             /** Executionid */
             executionId: string;
+            /** Actionid */
+            actionId: string;
+            /** Completionstatus */
+            completionStatus: string;
+            /** Actualdurationminutes */
+            actualDurationMinutes: number | null;
             /** Needsfailuretags */
             needsFailureTags: boolean;
         };
@@ -2024,12 +2086,12 @@ export interface components {
          * @description DB 헬스 정보 (health 응답에 포함).
          */
         DbStatus: {
-            /** Error */
-            error?: string | null;
-            /** Latency Ms */
-            latency_ms?: number | null;
             /** Ok */
             ok: boolean;
+            /** Latency Ms */
+            latency_ms?: number | null;
+            /** Error */
+            error?: string | null;
         };
         /**
          * ExecutionEventResponse
@@ -2039,21 +2101,21 @@ export interface components {
          *     execution.pause_total_minutes 에 누적한다. execution 자체는 in_progress 유지.
          */
         ExecutionEventResponse: {
-            /** Actionitemid */
-            actionItemId: string;
-            /** Endedat */
-            endedAt: string | null;
             /** Executionid */
             executionId: string;
-            /** Pausetotalminutes */
-            pauseTotalMinutes: number;
+            /** Actionitemid */
+            actionItemId: string;
             /**
              * Startedat
              * Format: date-time
              */
             startedAt: string;
+            /** Endedat */
+            endedAt: string | null;
             /** Status */
             status: string;
+            /** Pausetotalminutes */
+            pauseTotalMinutes: number;
         };
         /**
          * ExecutionStartResponse
@@ -2062,41 +2124,41 @@ export interface components {
          *     scheduled_block 이 없으면 즉석(ad-hoc) 블록을 생성해 연결한다 (source='user_edit').
          */
         ExecutionStartResponse: {
+            /** Executionid */
+            executionId: string;
             /** Actionid */
             actionId: string;
+            /** Completionstatus */
+            completionStatus: string;
             /**
              * Actualstartat
              * Format: date-time
              */
             actualStartAt: string;
-            /** Completionstatus */
-            completionStatus: string;
-            /** Executionid */
-            executionId: string;
         };
         /**
          * FailureTagMaster
          * @description GET /reflection/failure-tags 응답 row — S18 칩의 원본 (13종, is_active=true).
          */
         FailureTagMaster: {
-            /** Description */
-            description: string | null;
-            /** Labelko */
-            labelKo: string;
-            /** Sortorder */
-            sortOrder: number;
             /** Tagcode */
             tagCode: string;
+            /** Labelko */
+            labelKo: string;
+            /** Description */
+            description: string | null;
+            /** Sortorder */
+            sortOrder: number;
         };
         /**
          * FailureTagRequest
          * @description POST /reflection/failure-tags/{executionId} — 실패 사유 0~2개 + 메모.
          */
         FailureTagRequest: {
-            /** Memo */
-            memo?: string | null;
             /** Tagcodes */
             tagCodes: string[];
+            /** Memo */
+            memo?: string | null;
         };
         /**
          * FailureTagResponse
@@ -2105,10 +2167,10 @@ export interface components {
         FailureTagResponse: {
             /** Executionid */
             executionId: string;
-            /** Hasmemo */
-            hasMemo: boolean;
             /** Tagcodes */
             tagCodes: string[];
+            /** Hasmemo */
+            hasMemo: boolean;
         };
         /**
          * FirstPlanApproveResponse
@@ -2117,27 +2179,27 @@ export interface components {
          *     #62: `plan_id` 로 저장된 Draft 를 로드해 goal 트리까지 영속화한 결과 카운트.
          */
         FirstPlanApproveResponse: {
-            /** Activatedactionitems */
-            activatedActionItems: number;
-            /**
-             * Activatedat
-             * Format: date-time
-             */
-            activatedAt: string;
-            /** Activatedblocks */
-            activatedBlocks: number;
-            /** Activatedgoalnodes */
-            activatedGoalNodes: number;
-            /** Activatedgoals */
-            activatedGoals: number;
+            /** Planid */
+            planId: string;
             /**
              * Isdraft
              * @default false
              * @constant
              */
             isDraft: false;
-            /** Planid */
-            planId: string;
+            /** Activatedgoals */
+            activatedGoals: number;
+            /** Activatedgoalnodes */
+            activatedGoalNodes: number;
+            /** Activatedactionitems */
+            activatedActionItems: number;
+            /** Activatedblocks */
+            activatedBlocks: number;
+            /**
+             * Activatedat
+             * Format: date-time
+             */
+            activatedAt: string;
         };
         /**
          * FirstPlanGenerateRequest
@@ -2148,25 +2210,25 @@ export interface components {
          *     검증은 라우터/오케스트레이터 VALIDATING 단계에서 수행.
          */
         FirstPlanGenerateRequest: {
-            /**
-             * Density
-             * @default standard
-             * @enum {string}
-             */
-            density: "light" | "standard" | "intense";
             /** Interviewsessionid */
             interviewSessionId?: string | null;
+            outcome?: components["schemas"]["InterviewOutcome"] | null;
             /** Milestones */
             milestones?: components["schemas"]["MilestoneDraft"][] | null;
-            outcome?: components["schemas"]["InterviewOutcome"] | null;
+            /** Targetdate */
+            targetDate?: string | null;
             /**
              * Scope
              * @default horizon
              * @enum {string}
              */
             scope: "week" | "horizon";
-            /** Targetdate */
-            targetDate?: string | null;
+            /**
+             * Density
+             * @default standard
+             * @enum {string}
+             */
+            density: "light" | "standard" | "intense";
         };
         /**
          * FirstPlanResponse
@@ -2175,82 +2237,82 @@ export interface components {
          *     `is_draft=True` 고정, `ai_source` 는 오케스트레이터 `used_fallback` 에 따라 라우터가 set.
          */
         FirstPlanResponse: {
-            /** Actionitems */
-            actionItems: components["schemas"]["ActionItemDraft"][];
+            /**
+             * Isdraft
+             * @default true
+             */
+            isDraft: boolean;
             /**
              * Aisource
              * @default llm
              * @enum {string}
              */
             aiSource: "llm" | "rule";
+            /** Planid */
+            planId: string;
+            /** Targetdate */
+            targetDate: string;
+            /** Horizon */
+            horizon: string | null;
+            /** Goalnodes */
+            goalNodes: components["schemas"]["GoalNodeDraft"][];
+            /** Actionitems */
+            actionItems: components["schemas"]["ActionItemDraft"][];
             /** Blocks */
             blocks: components["schemas"]["ScheduledBlockPreview"][];
+            /** Warnings */
+            warnings?: string[];
+            /** Policyviolations */
+            policyViolations?: components["schemas"]["PolicyViolation"][];
             /**
              * Generatedat
              * Format: date-time
              */
             generatedAt: string;
-            /** Goalnodes */
-            goalNodes: components["schemas"]["GoalNodeDraft"][];
-            /** Horizon */
-            horizon: string | null;
-            /**
-             * Isdraft
-             * @default true
-             */
-            isDraft: boolean;
-            /** Planid */
-            planId: string;
-            /** Policyviolations */
-            policyViolations?: components["schemas"]["PolicyViolation"][];
-            /** Targetdate */
-            targetDate: string;
-            /** Warnings */
-            warnings?: string[];
         };
         /**
          * FixedSchedule
          * @description 고정 일정 — GET/POST/PATCH 응답.
          */
         FixedSchedule: {
-            /** Daysofweek */
-            daysOfWeek: string[];
-            /** Endtime */
-            endTime: string;
             /** Scheduleid */
             scheduleId: string;
-            /** Starttime */
-            startTime: string;
             /** Title */
             title: string;
+            /** Daysofweek */
+            daysOfWeek: string[];
+            /** Starttime */
+            startTime: string;
+            /** Endtime */
+            endTime: string;
         };
         /**
          * FixedScheduleCreateRequest
          * @description POST /fixed-schedules 요청.
          */
         FixedScheduleCreateRequest: {
-            /** Daysofweek */
-            daysOfWeek: string[];
-            /** Endtime */
-            endTime: string;
-            /** Starttime */
-            startTime: string;
             /** Title */
             title: string;
+            /** Daysofweek */
+            daysOfWeek: string[];
+            /** Starttime */
+            startTime: string;
+            /** Endtime */
+            endTime: string;
         };
         /**
          * FixedScheduleUpdateRequest
          * @description PATCH /fixed-schedules/{id} 요청 — 부분 수정.
          */
         FixedScheduleUpdateRequest: {
-            /** Daysofweek */
-            daysOfWeek?: string[] | null;
-            /** Endtime */
-            endTime?: string | null;
-            /** Starttime */
-            startTime?: string | null;
             /** Title */
             title?: string | null;
+            /** Daysofweek */
+            daysOfWeek?: string[] | null;
+            /** Starttime */
+            startTime?: string | null;
+            /** Endtime */
+            endTime?: string | null;
         };
         /**
          * FreeBusy
@@ -2265,77 +2327,75 @@ export interface components {
          * @description 목표 — GET 응답 항목, POST/PATCH/park 응답.
          */
         Goal: {
-            /** Category */
-            category: string;
-            /** Deadline */
-            deadline: string | null;
-            /** Estimatedminutes */
-            estimatedMinutes: number | null;
             /** Goalid */
             goalId: string;
+            /** Title */
+            title: string;
+            /** Category */
+            category: string;
             /** Goaltier */
             goalTier: string;
             /** Prioritylevel */
             priorityLevel: number;
+            /** Deadline */
+            deadline: string | null;
+            /** Estimatedminutes */
+            estimatedMinutes: number | null;
             /** Status */
             status: string;
-            /** Title */
-            title: string;
         };
         /**
          * GoalCandidate
          * @description 핵심 목표 후보 (goals.* 슬롯군). First Plan 의 goal_node 분해 입력.
          */
         GoalCandidate: {
-            /** Approachnote */
-            approachNote?: string | null;
+            /** Title */
+            title: string;
             /** Category */
             category: string;
-            /** Confidence */
-            confidence: number;
-            /** Currentlevel */
-            currentLevel?: string | null;
-            /** Deadline */
-            deadline?: string | null;
-            /** Frequencyperweek */
-            frequencyPerWeek?: number | null;
             /**
              * Isheaviest
              * @default false
              */
             isHeaviest: boolean;
-            /** Materialsnote */
-            materialsNote?: string | null;
-            /** Preferredtime */
-            preferredTime?: string | null;
-            /** Sessionlengthmin */
-            sessionLengthMin?: number | null;
+            /** Deadline */
+            deadline?: string | null;
+            /** Whynow */
+            whyNow?: string | null;
             /** Successimage */
             successImage?: string | null;
+            /** Currentlevel */
+            currentLevel?: string | null;
+            /** Weeklyhours */
+            weeklyHours?: number | null;
+            /** Sessionlengthmin */
+            sessionLengthMin?: number | null;
+            /** Preferredtime */
+            preferredTime?: string | null;
+            /** Frequencyperweek */
+            frequencyPerWeek?: number | null;
+            /** Approachnote */
+            approachNote?: string | null;
+            /** Materialsnote */
+            materialsNote?: string | null;
             /**
              * Tentativetier
              * @default maintain
              * @enum {string}
              */
             tentativeTier: "focus" | "maintain" | "parked";
-            /** Title */
-            title: string;
-            /** Weeklyhours */
-            weeklyHours?: number | null;
-            /** Whynow */
-            whyNow?: string | null;
+            /** Confidence */
+            confidence: number;
         };
         /**
          * GoalCreateRequest
          * @description POST /goals 요청.
          */
         GoalCreateRequest: {
+            /** Title */
+            title: string;
             /** Category */
             category: string;
-            /** Deadline */
-            deadline?: string | null;
-            /** Estimatedminutes */
-            estimatedMinutes?: number | null;
             /**
              * Goaltier
              * @enum {string}
@@ -2343,44 +2403,50 @@ export interface components {
             goalTier: "focus" | "maintain" | "parked";
             /** Prioritylevel */
             priorityLevel: number;
-            /** Title */
-            title: string;
+            /** Deadline */
+            deadline?: string | null;
+            /** Estimatedminutes */
+            estimatedMinutes?: number | null;
         };
         /**
          * GoalDecomposition
-         * @description POST /goals/{id}/decompose 응답 — Goal Structuring 결과.
+         * @description GET /goals/{id}/nodes 응답 — 계획 승인 시 영속된 실제 분해 트리.
+         *
+         *     계획을 아직 승인하지 않은 목표는 트리가 없다 → `nodes=[]`, `root_node_id=None`.
          */
         GoalDecomposition: {
             /** Goalid */
             goalId: string;
+            /** Rootnodeid */
+            rootNodeId: string | null;
             /** Nodes */
             nodes: components["schemas"]["GoalNode"][];
-            /** Rootnodeid */
-            rootNodeId: string;
         };
         /**
          * GoalNode
          * @description decompose 응답의 노드 (api-contract §6).
          */
         GoalNode: {
-            /** Depth */
-            depth: number;
             /** Nodeid */
             nodeId: string;
             /** Parentid */
             parentId: string | null;
             /** Title */
             title: string;
+            /** Depth */
+            depth: number;
         };
         /**
          * GoalNodeDraft
          * @description 분해된 goal_node 한 개 (root → branch → leaf 트리).
          */
         GoalNodeDraft: {
-            /** Isleaf */
-            isLeaf: boolean;
             /** Nodeid */
             nodeId: string;
+            /** Parentid */
+            parentId: string | null;
+            /** Title */
+            title: string;
             /**
              * Nodetype
              * @enum {string}
@@ -2388,24 +2454,22 @@ export interface components {
             nodeType: "root" | "branch" | "leaf";
             /** Orderindex */
             orderIndex: number;
-            /** Parentid */
-            parentId: string | null;
-            /** Title */
-            title: string;
+            /** Isleaf */
+            isLeaf: boolean;
         };
         /**
          * GoalUpdateRequest
          * @description PATCH /goals/{id} 요청 — 제목·마감·우선순위·tier 변경.
          */
         GoalUpdateRequest: {
-            /** Deadline */
-            deadline?: string | null;
-            /** Goaltier */
-            goalTier?: ("focus" | "maintain" | "parked") | null;
-            /** Prioritylevel */
-            priorityLevel?: number | null;
             /** Title */
             title?: string | null;
+            /** Deadline */
+            deadline?: string | null;
+            /** Prioritylevel */
+            priorityLevel?: number | null;
+            /** Goaltier */
+            goalTier?: ("focus" | "maintain" | "parked") | null;
         };
         /**
          * GoalsByTier
@@ -2440,57 +2504,57 @@ export interface components {
          * @description 습관 — GET/POST/PATCH 응답 항목.
          */
         Habit: {
+            /** Habitid */
+            habitId: string;
+            /** Title */
+            title: string;
             /** Category */
             category: string;
             /** Frequencyperweek */
             frequencyPerWeek: number;
-            /** Habitid */
-            habitId: string;
             /** Minutespersession */
             minutesPerSession: number;
-            /** Prioritylevel */
-            priorityLevel: number;
             /** Timepreference */
             timePreference: string;
-            /** Title */
-            title: string;
+            /** Prioritylevel */
+            priorityLevel: number;
         };
         /**
          * HabitCreateRequest
          * @description POST /habits 요청.
          */
         HabitCreateRequest: {
+            /** Title */
+            title: string;
             /** Category */
             category: string;
             /** Frequencyperweek */
             frequencyPerWeek: number;
             /** Minutespersession */
             minutesPerSession: number;
-            /** Prioritylevel */
-            priorityLevel: number;
             /**
              * Timepreference
              * @enum {string}
              */
             timePreference: "morning" | "afternoon" | "evening" | "anytime";
-            /** Title */
-            title: string;
+            /** Prioritylevel */
+            priorityLevel: number;
         };
         /**
          * HabitInstance
          * @description 주별 Habit 인스턴스 — GET /habit-instances 응답 항목.
          */
         HabitInstance: {
-            /** Donecount */
-            doneCount: number;
-            /** Habitid */
-            habitId: string;
             /** Instanceid */
             instanceId: string;
-            /** Targetcount */
-            targetCount: number;
+            /** Habitid */
+            habitId: string;
             /** Weekstart */
             weekStart: string;
+            /** Targetcount */
+            targetCount: number;
+            /** Donecount */
+            doneCount: number;
         };
         /**
          * HabitPenaltyAcceptResponse
@@ -2499,30 +2563,30 @@ export interface components {
         HabitPenaltyAcceptResponse: {
             /** Habitid */
             habitId: string;
-            /** Message */
-            message: string;
-            /** Newfrequency */
-            newFrequency: number;
             /** Previousfrequency */
             previousFrequency: number;
+            /** Newfrequency */
+            newFrequency: number;
+            /** Message */
+            message: string;
         };
         /**
          * HabitPenaltyCandidate
          * @description 3주 연속 미달로 빈도 재설계를 제안할 habit.
          */
         HabitPenaltyCandidate: {
-            /** Currentfrequency */
-            currentFrequency: number;
             /** Habitid */
             habitId: string;
-            /** Message */
-            message: string;
-            /** Recentweeks */
-            recentWeeks?: components["schemas"]["HabitWeekStat"][];
-            /** Suggestedfrequency */
-            suggestedFrequency: number;
             /** Title */
             title: string;
+            /** Currentfrequency */
+            currentFrequency: number;
+            /** Suggestedfrequency */
+            suggestedFrequency: number;
+            /** Recentweeks */
+            recentWeeks?: components["schemas"]["HabitWeekStat"][];
+            /** Message */
+            message: string;
         };
         /**
          * HabitPenaltyListResponse
@@ -2537,10 +2601,10 @@ export interface components {
          * @description PATCH /habits/{id} 요청 — 제목·빈도 (api-contract §7).
          */
         HabitUpdateRequest: {
-            /** Frequencyperweek */
-            frequencyPerWeek?: number | null;
             /** Title */
             title?: string | null;
+            /** Frequencyperweek */
+            frequencyPerWeek?: number | null;
         };
         /**
          * HabitWeekStat
@@ -2563,9 +2627,15 @@ export interface components {
          *     분리할 때 도입.
          */
         HealthResponse: {
+            /**
+             * Status
+             * @description ok or degraded
+             */
+            status: string;
             /** App */
             app: string;
-            db: components["schemas"]["DbStatus"];
+            /** Version */
+            version: string;
             /** Env */
             env: string;
             /**
@@ -2573,25 +2643,44 @@ export interface components {
              * Format: date-time
              */
             server_time?: string;
-            /**
-             * Status
-             * @description ok or degraded
-             */
-            status: string;
-            /** Version */
-            version: string;
+            db: components["schemas"]["DbStatus"];
         };
         /**
          * IdentityContext
          * @description 정체성 (identity.* 슬롯군).
          */
         IdentityContext: {
-            /** Major */
-            major?: string | null;
             /** Role */
             role: string;
             /** Season */
             season: string;
+            /** Major */
+            major?: string | null;
+        };
+        /**
+         * InboxAdoptStepRequest
+         * @description POST /inbox/{id}/adopt-step — 자료의 몇 번째 한 걸음을 채택할지.
+         */
+        InboxAdoptStepRequest: {
+            /** Stepindex */
+            stepIndex: number;
+        };
+        /**
+         * InboxAdoptedStep
+         * @description 채택 결과 — 오늘 할 일로 만들어진 카드.
+         *
+         *     자료 항목 자체는 `promoted` 로 바뀌지 않는다. 한 걸음을 채택한 것이지 자료를
+         *     승격한 게 아니고, 사용자가 나중에 다른 걸음을 또 채택하거나 다시 읽을 수 있다.
+         */
+        InboxAdoptedStep: {
+            /** Actionid */
+            actionId: string;
+            /** Title */
+            title: string;
+            /** Targetdate */
+            targetDate: string;
+            /** Resourceslug */
+            resourceSlug: string;
         };
         /**
          * InboxCreateRequest
@@ -2608,30 +2697,58 @@ export interface components {
          *     `raw_text` 는 응답에서 복호화된 평문. DB 는 `raw_text_encrypted` (AES-256-GCM).
          */
         InboxItem: {
-            /** Aicategoryguess */
-            aiCategoryGuess: string | null;
             /** Inboxid */
             inboxId: string;
+            /** Rawtext */
+            rawText: string;
+            /** Aicategoryguess */
+            aiCategoryGuess: string | null;
+            /** Usercategory */
+            userCategory: string | null;
+            /** Status */
+            status: string;
             /** Promotedgoalid */
             promotedGoalId: string | null;
             /** Promotedto */
             promotedTo?: ("goal" | "action") | null;
-            /** Rawtext */
-            rawText: string;
-            /** Status */
-            status: string;
-            /** Usercategory */
-            userCategory: string | null;
+            /**
+             * Source
+             * @default user
+             * @enum {string}
+             */
+            source: "user" | "system";
+            /** Resourceslug */
+            resourceSlug?: string | null;
+        };
+        /**
+         * InboxResourceDetail
+         * @description GET /inbox/resources/{slug} — 시스템 항목이 가리키는 정적 자료 본문.
+         *
+         *     `markdown` 은 frontmatter 를 걷어낸 본문이다(파일 원문이 아니다). FE 는 첫 H1 이
+         *     `title` 과 같을 때만 본문에서 덜어내므로 **둘 다 가공 없이** 실어야 한다.
+         *
+         *     `steps` 는 이 자료가 제안하는 한 걸음들 — 사용자가 골라 오늘 할 일로 채택한다
+         *     (`POST /inbox/{id}/adopt-step`). 자료가 읽고 끝나지 않게 하는 유일한 출구다.
+         */
+        InboxResourceDetail: {
+            /** Slug */
+            slug: string;
+            /** Title */
+            title: string;
+            /** Markdown */
+            markdown: string;
+            /** Steps */
+            steps: string[];
         };
         /**
          * InboxUpdateRequest
          * @description PATCH /inbox/{id} — userCategory override 또는 status 변경.
          */
         InboxUpdateRequest: {
-            /** Status */
-            status?: ("captured" | "classified" | "archived" | "promoted") | null;
             /** Usercategory */
             userCategory?: ("study" | "project" | "health" | "routine" | "schedule" | "other") | null;
+            /** Status */
+            status?: ("captured" | "classified" | "archived" | "promoted") | null;
         };
         /**
          * InteractionStyleView
@@ -2639,25 +2756,25 @@ export interface components {
          */
         InteractionStyleView: {
             /**
-             * Explanationdepth
-             * @enum {string}
-             */
-            explanationDepth: "brief" | "normal" | "detailed";
-            /**
              * Recoverytone
              * @enum {string}
              */
             recoveryTone: "gentle" | "normal" | "encouraging";
             /**
-             * Reminderfrequency
-             * @enum {string}
-             */
-            reminderFrequency: "minimal" | "standard" | "active";
-            /**
              * Suggestionstyle
              * @enum {string}
              */
             suggestionStyle: "soft" | "neutral" | "firm";
+            /**
+             * Explanationdepth
+             * @enum {string}
+             */
+            explanationDepth: "brief" | "normal" | "detailed";
+            /**
+             * Reminderfrequency
+             * @enum {string}
+             */
+            reminderFrequency: "minimal" | "standard" | "active";
         };
         /**
          * InterviewOutcome
@@ -2670,6 +2787,24 @@ export interface components {
          *     명시한다. 깨지는 변경 시 bump.
          */
         InterviewOutcome: {
+            /** Sessionid */
+            sessionId: string;
+            /**
+             * Schemaversion
+             * @default 1.0
+             * @constant
+             */
+            schemaVersion: "1.0";
+            /**
+             * Generatedat
+             * Format: date-time
+             */
+            generatedAt: string;
+            /**
+             * Endreason
+             * @enum {string}
+             */
+            endReason: "completed" | "turn_limit" | "early_user" | "abandoned";
             /** Ambiguityfinal */
             ambiguityFinal: number;
             /**
@@ -2678,31 +2813,13 @@ export interface components {
              * @enum {string}
              */
             analysisSource: "llm" | "rule";
-            availability: components["schemas"]["AvailabilityProfile"];
+            identity: components["schemas"]["IdentityContext"];
             /** Coregoals */
             coreGoals: components["schemas"]["GoalCandidate"][];
-            /**
-             * Endreason
-             * @enum {string}
-             */
-            endReason: "completed" | "turn_limit" | "early_user" | "abandoned";
-            /**
-             * Generatedat
-             * Format: date-time
-             */
-            generatedAt: string;
+            availability: components["schemas"]["AvailabilityProfile"];
+            preferences: components["schemas"]["PreferenceProfile"];
             /** Horizon */
             horizon?: string | null;
-            identity: components["schemas"]["IdentityContext"];
-            preferences: components["schemas"]["PreferenceProfile"];
-            /**
-             * Schemaversion
-             * @default 1.0
-             * @constant
-             */
-            schemaVersion: "1.0";
-            /** Sessionid */
-            sessionId: string;
             /** Unresolvedslots */
             unresolvedSlots?: string[];
         };
@@ -2715,17 +2832,17 @@ export interface components {
          *     `outcome`(First Plan 시드)이 함께 실린다. 진행 중에는 둘 다 null.
          */
         InterviewSession: {
-            /** Ambiguityscore */
-            ambiguityScore: number;
-            currentQuestion: components["schemas"]["Question"] | null;
-            /** Endreason */
-            endReason: string | null;
-            outcome?: components["schemas"]["InterviewOutcome"] | null;
             /** Sessionid */
             sessionId: string;
-            summary?: components["schemas"]["InterviewSummary"] | null;
+            /** Ambiguityscore */
+            ambiguityScore: number;
             /** Totalturns */
             totalTurns: number;
+            /** Endreason */
+            endReason: string | null;
+            currentQuestion: components["schemas"]["Question"] | null;
+            summary?: components["schemas"]["InterviewSummary"] | null;
+            outcome?: components["schemas"]["InterviewOutcome"] | null;
         };
         /**
          * InterviewSummary
@@ -2737,16 +2854,16 @@ export interface components {
          *     8s timeout / rate limit 시 슬롯에서 결정적으로 빌드한 룰 요약으로 fallback.
          */
         InterviewSummary: {
-            /** Confirmquestion */
-            confirmQuestion: string;
-            /** Goalsummary */
-            goalSummary: string;
             /** Headline */
             headline: string;
-            /** Preferencesummary */
-            preferenceSummary: string;
+            /** Goalsummary */
+            goalSummary: string;
             /** Timesummary */
             timeSummary: string;
+            /** Preferencesummary */
+            preferenceSummary: string;
+            /** Confirmquestion */
+            confirmQuestion: string;
         };
         JsonValue: unknown;
         /**
@@ -2765,41 +2882,41 @@ export interface components {
          *     마일스톤을 branch 로 고정하고 그 안에서만 세션(leaf)을 만든다.
          */
         MilestoneDraft: {
+            /** Title */
+            title: string;
             /**
              * Summary
              * @default
              */
             summary: string;
-            /** Title */
-            title: string;
         };
         /**
          * MilestoneListResponse
          * @description POST /plans/milestones 응답 — 사용자 확인용 마일스톤 초안(Stage A).
          */
         MilestoneListResponse: {
+            /** Milestones */
+            milestones: components["schemas"]["MilestoneDraft"][];
             /**
              * Aisource
              * @default llm
              * @enum {string}
              */
             aiSource: "llm" | "rule";
-            /** Milestones */
-            milestones: components["schemas"]["MilestoneDraft"][];
         };
         /**
          * MorningBrief
          * @description S10 상단 Morning Brief 카드 (daily_briefs). 없으면 agenda.brief=null.
          */
         MorningBrief: {
-            /** Adjustmenthints */
-            adjustmentHints: string[];
-            /** Bigrockactionid */
-            bigRockActionId: string | null;
-            /** Fallbackused */
-            fallbackUsed: boolean;
             /** Headline */
             headline: string;
+            /** Bigrockactionid */
+            bigRockActionId: string | null;
+            /** Adjustmenthints */
+            adjustmentHints: string[];
+            /** Fallbackused */
+            fallbackUsed: boolean;
         };
         /**
          * NoTouchWindow
@@ -2808,19 +2925,19 @@ export interface components {
         NoTouchWindow: {
             /** Daysofweek */
             daysOfWeek: string[];
+            window: components["schemas"]["TimeRange"];
             /** Label */
             label?: string | null;
-            window: components["schemas"]["TimeRange"];
         };
         /**
          * NotificationSettings
          * @description 알림 설정 — GET/PATCH /notifications/settings 응답. 사용자당 1건.
          */
         NotificationSettings: {
-            /** Eveningreflectiontime */
-            eveningReflectionTime: string;
             /** Morningbrieftime */
             morningBriefTime: string;
+            /** Eveningreflectiontime */
+            eveningReflectionTime: string;
             /** Precardenabled */
             preCardEnabled: boolean;
             /** Pushsubscribed */
@@ -2833,10 +2950,10 @@ export interface components {
          *     시간은 HH:MM 형식 검증만 스키마에서. 06~10·19~23 범위는 라우터에서 검사.
          */
         NotificationSettingsUpdateRequest: {
-            /** Eveningreflectiontime */
-            eveningReflectionTime?: string | null;
             /** Morningbrieftime */
             morningBriefTime?: string | null;
+            /** Eveningreflectiontime */
+            eveningReflectionTime?: string | null;
             /** Precardenabled */
             preCardEnabled?: boolean | null;
         };
@@ -2847,10 +2964,10 @@ export interface components {
          *     상세 설정·수정은 §15 `/notifications/settings`. 본 요약은 설정 화면 개요용.
          */
         NotificationSummary: {
-            /** Eveningreflectiontime */
-            eveningReflectionTime: string;
             /** Morningbrieftime */
             morningBriefTime: string;
+            /** Eveningreflectiontime */
+            eveningReflectionTime: string;
             /** Precardenabled */
             preCardEnabled: boolean;
         };
@@ -2872,6 +2989,10 @@ export interface components {
          *     폴백을 유지한다.
          */
         PolicySnapshotResponse: {
+            /** Version */
+            version: number;
+            /** Source */
+            source: string;
             /** Behavioralprofile */
             behavioralProfile: {
                 [key: string]: unknown;
@@ -2884,21 +3005,17 @@ export interface components {
             interactionStyle: {
                 [key: string]: unknown;
             };
-            /** Reasonforupdate */
-            reasonForUpdate: string | null;
             /** Recoverypolicy */
             recoveryPolicy: {
                 [key: string]: unknown;
             };
-            /** Source */
-            source: string;
+            /** Reasonforupdate */
+            reasonForUpdate: string | null;
             /**
              * Validfrom
              * Format: date-time
              */
             validFrom: string;
-            /** Version */
-            version: number;
         };
         /**
          * PolicyViolation
@@ -2917,8 +3034,10 @@ export interface components {
          *     First Plan 이 behavioral_profile / interaction_style 컨텍스트로 사용.
          */
         PreferenceProfile: {
-            /** Breakpattern */
-            breakPattern?: string | null;
+            /** Recoverytone */
+            recoveryTone: string;
+            /** Restok */
+            restOk: boolean;
             /**
              * Downscopeunitmin
              * @default 10
@@ -2926,10 +3045,8 @@ export interface components {
             downscopeUnitMin: number;
             /** Focusdurationmin */
             focusDurationMin?: number | null;
-            /** Recoverytone */
-            recoveryTone: string;
-            /** Restok */
-            restOk: boolean;
+            /** Breakpattern */
+            breakPattern?: string | null;
             /** Weeklyenergy */
             weeklyEnergy?: string | null;
         };
@@ -2941,16 +3058,16 @@ export interface components {
          *     `downscopeUnitMin`/`restOk` 는 회복 선호 — `users.focus_mode_preferences`(JSONB) 출처.
          */
         ProfileResponse: {
-            /** Activityend */
-            activityEnd?: string | null;
-            /** Activitystart */
-            activityStart?: string | null;
             behavioral: components["schemas"]["BehavioralProfileView"] | null;
+            interaction: components["schemas"]["InteractionStyleView"] | null;
             /** Downscopeunitmin */
             downscopeUnitMin?: number | null;
-            interaction: components["schemas"]["InteractionStyleView"] | null;
             /** Restok */
             restOk?: boolean | null;
+            /** Activitystart */
+            activityStart?: string | null;
+            /** Activityend */
+            activityEnd?: string | null;
         };
         /**
          * ProfileUpdateRequest
@@ -2959,28 +3076,28 @@ export interface components {
          *     enum 외 값은 Pydantic Literal → 422 `COMMON_VALIDATION_ERROR`.
          */
         ProfileUpdateRequest: {
-            /** Activityend */
-            activityEnd?: string | null;
-            /** Activitystart */
-            activityStart?: string | null;
-            /** Attentionspan */
-            attentionSpan?: number | null;
-            /** Downscopeunitmin */
-            downscopeUnitMin?: number | null;
             /** Energycycle */
             energyCycle?: ("morning" | "afternoon" | "evening" | "night" | "varies") | null;
-            /** Explanationdepth */
-            explanationDepth?: ("brief" | "normal" | "detailed") | null;
-            /** Recoverytone */
-            recoveryTone?: ("gentle" | "normal" | "encouraging") | null;
-            /** Reminderfrequency */
-            reminderFrequency?: ("minimal" | "standard" | "active") | null;
-            /** Restok */
-            restOk?: boolean | null;
-            /** Suggestionstyle */
-            suggestionStyle?: ("soft" | "neutral" | "firm") | null;
+            /** Attentionspan */
+            attentionSpan?: number | null;
             /** Timechunkpreference */
             timeChunkPreference?: ("10" | "20" | "30" | "60" | "90") | null;
+            /** Recoverytone */
+            recoveryTone?: ("gentle" | "normal" | "encouraging") | null;
+            /** Suggestionstyle */
+            suggestionStyle?: ("soft" | "neutral" | "firm") | null;
+            /** Explanationdepth */
+            explanationDepth?: ("brief" | "normal" | "detailed") | null;
+            /** Reminderfrequency */
+            reminderFrequency?: ("minimal" | "standard" | "active") | null;
+            /** Downscopeunitmin */
+            downscopeUnitMin?: number | null;
+            /** Restok */
+            restOk?: boolean | null;
+            /** Activitystart */
+            activityStart?: string | null;
+            /** Activityend */
+            activityEnd?: string | null;
         };
         /**
          * PushSubscribeRequest
@@ -3008,30 +3125,24 @@ export interface components {
          *     자유서술 슬롯(goals.list·success_image·time.fixed_blocks 등)에서 탭/참고용으로 채워진다.
          */
         Question: {
+            /** Slotkey */
+            slotKey: string;
+            /** Text */
+            text: string;
             /** Answertype */
             answerType: string;
             /** Options */
             options: string[];
-            /** Slotkey */
-            slotKey: string;
             /** Suggestedanswers */
             suggestedAnswers?: string[];
-            /** Text */
-            text: string;
         };
         /**
          * RecoveryCard
          * @description 회복 옵션 카드 1장 — recovery_attempts 1행과 대응 (user_decision='pending').
          */
         RecoveryCard: {
-            /** Allowrestmode */
-            allowRestMode: boolean;
             /** Attemptid */
             attemptId: string;
-            /** Labelko */
-            labelKo: string;
-            /** Minrecoveryunitminutes */
-            minRecoveryUnitMinutes: number;
             /**
              * Optiongroup
              * @enum {string}
@@ -3039,8 +3150,14 @@ export interface components {
             optionGroup: "DOWNSCOPE" | "RESCHEDULE" | "CARRY_OVER" | "PARK";
             /** Strategytype */
             strategyType: string;
+            /** Labelko */
+            labelKo: string;
             /** Suggestedactiontext */
             suggestedActionText: string;
+            /** Minrecoveryunitminutes */
+            minRecoveryUnitMinutes: number;
+            /** Allowrestmode */
+            allowRestMode: boolean;
             /** Triggertag */
             triggerTag: string | null;
         };
@@ -3056,40 +3173,40 @@ export interface components {
          *     - `decision="skipped"` → 모든 pending 카드 skipped ("오늘은 쉬기").
          */
         RecoveryDecisionRequest: {
-            /** Acceptedattemptid */
-            acceptedAttemptId?: string | null;
+            /** Executionid */
+            executionId: string;
             /**
              * Decision
              * @enum {string}
              */
             decision: "accepted" | "edited" | "skipped";
-            /** Decisionreason */
-            decisionReason?: string | null;
+            /** Acceptedattemptid */
+            acceptedAttemptId?: string | null;
             /** Editedactiontext */
             editedActionText?: string | null;
-            /** Executionid */
-            executionId: string;
+            /** Decisionreason */
+            decisionReason?: string | null;
         };
         /**
          * RecoveryDecisionResponse
          * @description 결정 결과 — 명시 승인 endpoint 이므로 `is_draft=False` (ADR-0005 §7.2).
          */
         RecoveryDecisionResponse: {
-            /** Acceptedattemptid */
-            acceptedAttemptId: string | null;
             /** Executionid */
             executionId: string;
+            /** Acceptedattemptid */
+            acceptedAttemptId: string | null;
+            /** Rejectedattemptids */
+            rejectedAttemptIds: string[];
+            /** Skippedattemptids */
+            skippedAttemptIds: string[];
+            /** Resultingactionitemid */
+            resultingActionItemId: string | null;
             /**
              * Isdraft
              * @default false
              */
             isDraft: boolean;
-            /** Rejectedattemptids */
-            rejectedAttemptIds: string[];
-            /** Resultingactionitemid */
-            resultingActionItemId: string | null;
-            /** Skippedattemptids */
-            skippedAttemptIds: string[];
         };
         /**
          * RecoveryGenerateRequest
@@ -3105,20 +3222,20 @@ export interface components {
          */
         RecoveryProposalsResponse: {
             /**
+             * Isdraft
+             * @default true
+             */
+            isDraft: boolean;
+            /**
              * Aisource
              * @default llm
              * @enum {string}
              */
             aiSource: "llm" | "rule";
-            /** Cards */
-            cards: components["schemas"]["RecoveryCard"][];
             /** Executionid */
             executionId: string;
-            /**
-             * Isdraft
-             * @default true
-             */
-            isDraft: boolean;
+            /** Cards */
+            cards: components["schemas"]["RecoveryCard"][];
         };
         /**
          * ReflectionBatchItem
@@ -3128,13 +3245,13 @@ export interface components {
          *     (그 외 값과 함께 오면 422). `memo` 는 서버가 at-rest 암호화한다.
          */
         ReflectionBatchItem: {
+            /** Executionid */
+            executionId: string;
             /**
              * Completionstatus
              * @enum {string}
              */
             completionStatus: "done" | "partial_done" | "failed" | "over_done";
-            /** Executionid */
-            executionId: string;
             /** Failuretags */
             failureTags?: string[];
             /** Memo */
@@ -3155,12 +3272,12 @@ export interface components {
          * @description 일괄 처리 결과 요약.
          */
         ReflectionBatchResponse: {
-            /** Needsfailuretags */
-            needsFailureTags: string[];
             /** Processedcount */
             processedCount: number;
             /** Taggedcount */
             taggedCount: number;
+            /** Needsfailuretags */
+            needsFailureTags: string[];
         };
         /**
          * ReflectionPendingItem
@@ -3171,12 +3288,12 @@ export interface components {
          *     정해지지 않았으므로 completion_status 는 null.
          */
         ReflectionPendingItem: {
-            /** Actionitemid */
-            actionItemId: string;
-            /** Completionstatus */
-            completionStatus: string | null;
             /** Executionid */
             executionId: string;
+            /** Actionitemid */
+            actionItemId: string;
+            /** Title */
+            title: string;
             /**
              * Scheduleddate
              * Format: date
@@ -3184,8 +3301,8 @@ export interface components {
             scheduledDate: string;
             /** Scheduledtime */
             scheduledTime: string | null;
-            /** Title */
-            title: string;
+            /** Completionstatus */
+            completionStatus: string | null;
         };
         /**
          * RefreshRequest
@@ -3203,27 +3320,27 @@ export interface components {
          *     이미 배치돼 있으면 같은 block 을 반환한다. 원본 `action_item.status` 불변.
          */
         ReplanApproveResponse: {
-            /** Actionitemid */
-            actionItemId: string;
-            /**
-             * Endat
-             * Format: date-time
-             */
-            endAt: string;
             /** Executionid */
             executionId: string;
-            /**
-             * Isdraft
-             * @default false
-             */
-            isDraft: boolean;
             /** Scheduledblockid */
             scheduledBlockId: string;
+            /** Actionitemid */
+            actionItemId: string;
             /**
              * Startat
              * Format: date-time
              */
             startAt: string;
+            /**
+             * Endat
+             * Format: date-time
+             */
+            endAt: string;
+            /**
+             * Isdraft
+             * @default false
+             */
+            isDraft: boolean;
         };
         /**
          * ReplanBlock
@@ -3235,6 +3352,18 @@ export interface components {
         ReplanBlock: {
             /** Actionitemid */
             actionItemId: string;
+            /** Title */
+            title: string;
+            /**
+             * Targetdate
+             * Format: date
+             */
+            targetDate: string;
+            /**
+             * Startat
+             * Format: date-time
+             */
+            startAt: string;
             /**
              * Endat
              * Format: date-time
@@ -3242,18 +3371,6 @@ export interface components {
             endAt: string;
             /** Estimatedminutes */
             estimatedMinutes: number;
-            /**
-             * Startat
-             * Format: date-time
-             */
-            startAt: string;
-            /**
-             * Targetdate
-             * Format: date
-             */
-            targetDate: string;
-            /** Title */
-            title: string;
         };
         /**
          * ReplanBlockPreview
@@ -3266,8 +3383,15 @@ export interface components {
         ReplanBlockPreview: {
             /** Actionid */
             actionId: string;
+            /** Title */
+            title: string;
             /** Category */
             category: string;
+            /**
+             * Start
+             * Format: date-time
+             */
+            start: string;
             /**
              * End
              * Format: date-time
@@ -3275,13 +3399,6 @@ export interface components {
             end: string;
             /** Replacesblockid */
             replacesBlockId?: string | null;
-            /**
-             * Start
-             * Format: date-time
-             */
-            start: string;
-            /** Title */
-            title: string;
         };
         /**
          * ReplanDiffResponse
@@ -3291,31 +3408,31 @@ export interface components {
          *     배치된 상태(멱등 재조회).
          */
         ReplanDiffResponse: {
-            after: components["schemas"]["ReplanBlock"];
-            /**
-             * Aisource
-             * @default llm
-             * @enum {string}
-             */
-            aiSource: "llm" | "rule";
-            /**
-             * Alreadyapproved
-             * @default false
-             */
-            alreadyApproved: boolean;
-            before: components["schemas"]["ReplanBlock"];
-            /** Executionid */
-            executionId: string;
             /**
              * Isdraft
              * @default true
              */
             isDraft: boolean;
             /**
+             * Aisource
+             * @default llm
+             * @enum {string}
+             */
+            aiSource: "llm" | "rule";
+            /** Executionid */
+            executionId: string;
+            /**
              * Optiongroup
              * @enum {string}
              */
             optionGroup: "DOWNSCOPE" | "RESCHEDULE" | "CARRY_OVER" | "PARK";
+            before: components["schemas"]["ReplanBlock"];
+            after: components["schemas"]["ReplanBlock"];
+            /**
+             * Alreadyapproved
+             * @default false
+             */
+            alreadyApproved: boolean;
         };
         /**
          * ReplanResponse
@@ -3323,44 +3440,51 @@ export interface components {
          */
         ReplanResponse: {
             /**
+             * Isdraft
+             * @default true
+             */
+            isDraft: boolean;
+            /**
              * Aisource
              * @default llm
              * @enum {string}
              */
             aiSource: "llm" | "rule";
+            /** Planid */
+            planId: string;
+            /** Windowstart */
+            windowStart: string;
+            /** Horizon */
+            horizon: string | null;
             /** Blocks */
             blocks: components["schemas"]["ReplanBlockPreview"][];
+            /** Warnings */
+            warnings?: string[];
             /**
              * Generatedat
              * Format: date-time
              */
             generatedAt: string;
-            /** Horizon */
-            horizon: string | null;
-            /**
-             * Isdraft
-             * @default true
-             */
-            isDraft: boolean;
-            /** Planid */
-            planId: string;
-            /** Warnings */
-            warnings?: string[];
-            /** Windowstart */
-            windowStart: string;
         };
         /**
          * ScheduledBlockPreview
          * @description 미리보기용 스케줄 블록 — DB scheduled_blocks 대응(미영속). 시각은 KST 응답.
          */
         ScheduledBlockPreview: {
-            /** Category */
-            category: string;
+            /**
+             * Start
+             * Format: date-time
+             */
+            start: string;
             /**
              * End
              * Format: date-time
              */
             end: string;
+            /** Title */
+            title: string;
+            /** Category */
+            category: string;
             /**
              * Origin
              * @enum {string}
@@ -3368,13 +3492,6 @@ export interface components {
             origin: "habit" | "goal";
             /** Originid */
             originId?: string | null;
-            /**
-             * Start
-             * Format: date-time
-             */
-            start: string;
-            /** Title */
-            title: string;
         };
         /**
          * SettingsResponse
@@ -3385,98 +3502,98 @@ export interface components {
          *     - `notifications` 는 아직 설정 행이 없으면 null (GET 은 행을 생성하지 않는다).
          */
         SettingsResponse: {
+            /** Tonemode */
+            toneMode: ("gentle" | "strict" | "encouraging") | null;
             /**
              * Language
              * @default ko
              */
             language: string;
-            notifications: components["schemas"]["NotificationSummary"] | null;
             /** Timezone */
             timezone: string;
-            /** Tonemode */
-            toneMode: ("gentle" | "strict" | "encouraging") | null;
+            notifications: components["schemas"]["NotificationSummary"] | null;
         };
         /**
          * SlotAnswerRequest
          * @description POST /interview/sessions/{id}/answers 요청 — 슬롯 답 UPSERT.
          */
         SlotAnswerRequest: {
-            /** Clientturn */
-            clientTurn: number;
             /** Slotkey */
             slotKey: string;
             value: components["schemas"]["JsonValue"];
+            /** Clientturn */
+            clientTurn: number;
         };
         /**
          * SlotCatalogEntry
          * @description 슬롯 카탈로그 한 항목 — GET /interview/slot-catalog.
          */
         SlotCatalogEntry: {
-            /** Answertype */
-            answerType: string;
-            /** Category */
-            category: string;
-            /** Isrequired */
-            isRequired: boolean;
-            /** Label */
-            label: string;
-            /** Options */
-            options?: string[];
             /** Slotkey */
             slotKey: string;
+            /** Label */
+            label: string;
+            /** Answertype */
+            answerType: string;
+            /** Isrequired */
+            isRequired: boolean;
+            /** Category */
+            category: string;
+            /** Options */
+            options?: string[];
         };
         /**
          * SyncPreview
          * @description POST /calendar/sync-preview 응답.
          */
         SyncPreview: {
-            /** Conflictcount */
-            conflictCount: number;
             /** Events */
             events: components["schemas"]["CalendarEventPreview"][];
+            /** Conflictcount */
+            conflictCount: number;
         };
         /**
          * TimePolicy
          * @description 시간 정책 — GET/POST/PATCH 응답. payload 는 policy_type 별로 형태가 다름.
          */
         TimePolicy: {
-            /** Isactive */
-            isActive: boolean;
-            /** Payload */
-            payload: {
-                [key: string]: components["schemas"]["JsonValue"];
-            };
             /** Policyid */
             policyId: string;
             /** Policytype */
             policyType: string;
+            /** Payload */
+            payload: {
+                [key: string]: components["schemas"]["JsonValue"];
+            };
+            /** Isactive */
+            isActive: boolean;
         };
         /**
          * TimePolicyCreateRequest
          * @description POST /time-policies 요청.
          */
         TimePolicyCreateRequest: {
-            /** Payload */
-            payload: {
-                [key: string]: components["schemas"]["JsonValue"];
-            };
             /**
              * Policytype
              * @enum {string}
              */
             policyType: "sleep" | "lunch" | "break_min" | "no_touch" | "late_night_block" | "custom";
+            /** Payload */
+            payload: {
+                [key: string]: components["schemas"]["JsonValue"];
+            };
         };
         /**
          * TimePolicyUpdateRequest
          * @description PATCH /time-policies/{id} 요청 — 부분 수정.
          */
         TimePolicyUpdateRequest: {
-            /** Isactive */
-            isActive?: boolean | null;
             /** Payload */
             payload?: {
                 [key: string]: components["schemas"]["JsonValue"];
             } | null;
+            /** Isactive */
+            isActive?: boolean | null;
         };
         /**
          * TimeRange
@@ -3484,30 +3601,30 @@ export interface components {
          */
         TimeRange: {
             /**
-             * End
-             * @description "HH:MM" KST 로컬
-             */
-            end: string;
-            /**
              * Start
              * @description "HH:MM" KST 로컬
              */
             start: string;
+            /**
+             * End
+             * @description "HH:MM" KST 로컬
+             */
+            end: string;
         };
         /**
          * TodayAgenda
          * @description GET /today/agenda 응답 — 단일 조회 (daily_brief + cards + habits + fixed).
          */
         TodayAgenda: {
+            /** Date */
+            date: string;
             brief: components["schemas"]["MorningBrief"] | null;
             /** Cards */
             cards: components["schemas"]["AgendaCard"][];
-            /** Date */
-            date: string;
-            /** Fixedschedules */
-            fixedSchedules: components["schemas"]["AgendaFixedSchedule"][];
             /** Habits */
             habits: components["schemas"]["AgendaHabit"][];
+            /** Fixedschedules */
+            fixedSchedules: components["schemas"]["AgendaFixedSchedule"][];
         };
         /**
          * ToneModeUpdateRequest
@@ -3527,31 +3644,31 @@ export interface components {
          * @description 사용자 프로필 — GET /auth/me 및 로그인 응답에 포함.
          */
         UserProfile: {
+            /** Userid */
+            userId: string;
             /** Email */
             email: string;
             /** Name */
             name: string;
-            /** Onboardingstate */
-            onboardingState: string;
             /** Timezone */
             timezone: string;
+            /** Onboardingstate */
+            onboardingState: string;
             /** Tonemode */
             toneMode: string;
-            /** Userid */
-            userId: string;
         };
         /** ValidationError */
         ValidationError: {
-            /** Context */
-            ctx?: Record<string, never>;
-            /** Input */
-            input?: unknown;
             /** Location */
             loc: (string | number)[];
             /** Message */
             msg: string;
             /** Error Type */
             type: string;
+            /** Input */
+            input?: unknown;
+            /** Context */
+            ctx?: Record<string, never>;
         };
         /**
          * VapidPublicKeyResponse
@@ -3570,30 +3687,30 @@ export interface components {
          * @description 주간 그리드의 스케줄 블록 한 칸.
          */
         WeeklyBlock: {
-            /** Actionid */
-            actionId: string;
             /** Blockid */
             blockId: string;
-            /** Blockstatus */
-            blockStatus: string;
+            /** Actionid */
+            actionId: string;
+            /** Title */
+            title: string;
             /** Category */
             category: string;
-            /**
-             * Endat
-             * Format: date-time
-             */
-            endAt: string;
             /** Goalid */
             goalId?: string | null;
-            /** Source */
-            source: string;
             /**
              * Startat
              * Format: date-time
              */
             startAt: string;
-            /** Title */
-            title: string;
+            /**
+             * Endat
+             * Format: date-time
+             */
+            endAt: string;
+            /** Blockstatus */
+            blockStatus: string;
+            /** Source */
+            source: string;
         };
         /**
          * WeeklyGenerateRequest
@@ -3613,8 +3730,6 @@ export interface components {
          * @description 하루치 — 그리드/네비게이터 단위.
          */
         WeeklyPlanDay: {
-            /** Blocks */
-            blocks?: components["schemas"]["WeeklyBlock"][];
             /**
              * Date
              * Format: date
@@ -3622,26 +3737,28 @@ export interface components {
             date: string;
             /** Weekday */
             weekday: string;
+            /** Blocks */
+            blocks?: components["schemas"]["WeeklyBlock"][];
         };
         /**
          * WeeklyPlanResponse
          * @description GET /plans/weekly — 7일 블록 그리드 (모바일=1일 그리드+7일 네비게이터).
          */
         WeeklyPlanResponse: {
-            /** Days */
-            days: components["schemas"]["WeeklyPlanDay"][];
             /** Planid */
             planId: string;
-            /**
-             * Weekend
-             * Format: date
-             */
-            weekEnd: string;
             /**
              * Weekstart
              * Format: date
              */
             weekStart: string;
+            /**
+             * Weekend
+             * Format: date
+             */
+            weekEnd: string;
+            /** Days */
+            days: components["schemas"]["WeeklyPlanDay"][];
         };
         /**
          * WeeklyReplanApproveResponse
@@ -3657,74 +3774,74 @@ export interface components {
          *     클라이언트가 깨진다. 'Weekly' 접두사는 그 충돌을 피하기 위한 것 — 지우지 말 것.
          */
         WeeklyReplanApproveResponse: {
-            /**
-             * Activatedat
-             * Format: date-time
-             */
-            activatedAt: string;
-            /** Cancelledblocks */
-            cancelledBlocks: number;
-            /** Createdblocks */
-            createdBlocks: number;
+            /** Planid */
+            planId: string;
             /**
              * Isdraft
              * @default false
              * @constant
              */
             isDraft: false;
-            /** Planid */
-            planId: string;
+            /** Cancelledblocks */
+            cancelledBlocks: number;
+            /** Createdblocks */
+            createdBlocks: number;
             /** Skippedblocks */
             skippedBlocks: number;
+            /**
+             * Activatedat
+             * Format: date-time
+             */
+            activatedAt: string;
         };
         /**
          * WeeklyReviewResponse
          * @description GET /reviews/weekly · generate 응답 — 룰 기반 주간 리뷰 카드 (S21).
          */
         WeeklyReviewResponse: {
-            /** Adherencerate */
-            adherenceRate?: number | null;
-            /** Averagerecoveryminutes */
-            averageRecoveryMinutes?: number | null;
-            /** Avgdelayminutes */
-            avgDelayMinutes?: number | null;
-            /** Categorysuccessrate */
-            categorySuccessRate?: {
-                [key: string]: number;
-            };
-            /** Consistencydays */
-            consistencyDays?: number | null;
-            /** Drainwindow */
-            drainWindow?: string | null;
-            /**
-             * Generatedat
-             * Format: date-time
-             */
-            generatedAt: string;
-            /** Oneliner */
-            oneLiner?: string | null;
-            /** Peakwindow */
-            peakWindow?: string | null;
-            /** Policyupdatecandidates */
-            policyUpdateCandidates?: {
-                [key: string]: unknown;
-            }[];
-            /** Repeatedfailurecount */
-            repeatedFailureCount?: number | null;
-            /** Resiliencerate */
-            resilienceRate?: number | null;
-            /** Restartsuccessrate */
-            restartSuccessRate?: number | null;
-            /**
-             * Weekend
-             * Format: date
-             */
-            weekEnd: string;
             /**
              * Weekstart
              * Format: date
              */
             weekStart: string;
+            /**
+             * Weekend
+             * Format: date
+             */
+            weekEnd: string;
+            /** Adherencerate */
+            adherenceRate?: number | null;
+            /** Consistencydays */
+            consistencyDays?: number | null;
+            /** Resiliencerate */
+            resilienceRate?: number | null;
+            /** Avgdelayminutes */
+            avgDelayMinutes?: number | null;
+            /** Restartsuccessrate */
+            restartSuccessRate?: number | null;
+            /** Repeatedfailurecount */
+            repeatedFailureCount?: number | null;
+            /** Averagerecoveryminutes */
+            averageRecoveryMinutes?: number | null;
+            /** Categorysuccessrate */
+            categorySuccessRate?: {
+                [key: string]: number;
+            };
+            /** Peakwindow */
+            peakWindow?: string | null;
+            /** Drainwindow */
+            drainWindow?: string | null;
+            /** Oneliner */
+            oneLiner?: string | null;
+            /** Policyupdatecandidates */
+            policyUpdateCandidates?: {
+                [key: string]: unknown;
+            }[];
+            /**
+             * Generatedat
+             * Format: date-time
+             */
+            generatedAt: string;
         };
     };
     responses: never;
@@ -3735,6 +3852,26 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
+    health_health_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HealthResponse"];
+                };
+            };
+        };
+    };
     login_with_google_auth_google_post: {
         parameters: {
             query?: never;
@@ -3755,6 +3892,39 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AuthSession"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    refresh_access_token_auth_refresh_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RefreshRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AccessToken"];
                 };
             };
             /** @description Validation Error */
@@ -3830,75 +4000,7 @@ export interface operations {
             };
         };
     };
-    refresh_access_token_auth_refresh_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["RefreshRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AccessToken"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    connect_calendar_calendar_connect_post: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["CalendarConnectRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CalendarConnection"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    disconnect_calendar_calendar_connect_delete: {
+    get_onboarding_status_onboarding_status_get: {
         parameters: {
             query?: never;
             header?: {
@@ -3915,892 +4017,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    approve_insert_calendar_events_approve_insert_post: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ApproveInsertResult"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_freebusy_calendar_freebusy_get: {
-        parameters: {
-            query: {
-                from: string;
-                to: string;
-            };
-            header?: {
-                authorization?: string | null;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FreeBusy"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    sync_preview_calendar_sync_preview_post: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SyncPreview"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    list_schedules_fixed_schedules_get: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FixedSchedule"][];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    create_schedule_fixed_schedules_post: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["FixedScheduleCreateRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FixedSchedule"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    delete_schedule_fixed_schedules__schedule_id__delete: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path: {
-                schedule_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    update_schedule_fixed_schedules__schedule_id__patch: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path: {
-                schedule_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["FixedScheduleUpdateRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FixedSchedule"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    list_goals_goals_get: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["GoalsByTier"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    create_goal_goals_post: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["GoalCreateRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Goal"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    delete_goal_goals__goal_id__delete: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path: {
-                goal_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    update_goal_goals__goal_id__patch: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path: {
-                goal_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["GoalUpdateRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Goal"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    decompose_goal_goals__goal_id__decompose_post: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path: {
-                goal_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["GoalDecomposition"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    park_goal_goals__goal_id__park_post: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path: {
-                goal_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Goal"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    list_instances_habit_instances_get: {
-        parameters: {
-            query?: {
-                weekStart?: string | null;
-            };
-            header?: {
-                authorization?: string | null;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HabitInstance"][];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    check_instance_habit_instances__instance_id__check_post: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path: {
-                instance_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HabitInstance"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    list_habits_habits_get: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Habit"][];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    create_habit_habits_post: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["HabitCreateRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Habit"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    delete_habit_habits__habit_id__delete: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path: {
-                habit_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    update_habit_habits__habit_id__patch: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path: {
-                habit_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["HabitUpdateRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Habit"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    health_health_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HealthResponse"];
-                };
-            };
-        };
-    };
-    list_inbox_inbox_get: {
-        parameters: {
-            query?: {
-                status?: string | null;
-            };
-            header?: {
-                authorization?: string | null;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["InboxItem"][];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    create_inbox_inbox_post: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["InboxCreateRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["InboxItem"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    update_inbox_inbox__inbox_id__patch: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path: {
-                inbox_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["InboxUpdateRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["InboxItem"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    archive_inbox_inbox__inbox_id__archive_post: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path: {
-                inbox_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    convert_to_action_inbox__inbox_id__convert_to_action_post: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path: {
-                inbox_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["InboxItem"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    convert_to_goal_inbox__inbox_id__convert_to_goal_post: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path: {
-                inbox_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["InboxItem"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    restore_inbox_inbox__inbox_id__restore_post: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path: {
-                inbox_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["InboxItem"];
+                    "application/json": components["schemas"]["OnboardingStatus"];
                 };
             };
             /** @description Validation Error */
@@ -4832,6 +4049,37 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["InterviewSession"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_slot_catalog_interview_slot_catalog_get: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SlotCatalogEntry"][];
                 };
             };
             /** @description Validation Error */
@@ -4915,39 +4163,6 @@ export interface operations {
             };
         };
     };
-    finish_session_interview_sessions__session_id__finish_post: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path: {
-                session_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["InterviewSession"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
     next_question_interview_sessions__session_id__next_question_post: {
         parameters: {
             query?: never;
@@ -4981,338 +4196,14 @@ export interface operations {
             };
         };
     };
-    get_slot_catalog_interview_slot_catalog_get: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SlotCatalogEntry"][];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_settings_notifications_settings_get: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["NotificationSettings"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    update_settings_notifications_settings_patch: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["NotificationSettingsUpdateRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["NotificationSettings"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    subscribe_notifications_subscribe_post: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["PushSubscribeRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["NotificationSettings"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    unsubscribe_notifications_subscribe_delete: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_vapid_public_key_notifications_vapid_public_key_get: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["VapidPublicKeyResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_onboarding_status_onboarding_status_get: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["OnboardingStatus"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    generate_plan_plans_generate_post: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["FirstPlanGenerateRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FirstPlanResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    generate_milestones_plans_milestones_post: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["FirstPlanGenerateRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["MilestoneListResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    generate_replan_plans_replan_post: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ReplanResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    approve_replan_plans_replan__plan_id__approve_post: {
+    finish_session_interview_sessions__session_id__finish_post: {
         parameters: {
             query?: never;
             header?: {
                 authorization?: string | null;
             };
             path: {
-                plan_id: string;
+                session_id: string;
             };
             cookie?: never;
         };
@@ -5324,841 +4215,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["WeeklyReplanApproveResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_weekly_plan_plans_weekly_get: {
-        parameters: {
-            query?: {
-                weekStart?: string | null;
-            };
-            header?: {
-                authorization?: string | null;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["WeeklyPlanResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_plan_plans__plan_id__get: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path: {
-                plan_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FirstPlanResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    approve_plan_plans__plan_id__approve_post: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path: {
-                plan_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FirstPlanApproveResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    edit_block_plans__plan_id__blocks__block_id__patch: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path: {
-                plan_id: string;
-                block_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["BlockEditRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["BlockEditResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    discard_plan_plans__plan_id__discard_post: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path: {
-                plan_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_current_policy_policy_snapshot_current_get: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PolicySnapshotResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_consent_privacy_consent_get: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ConsentListResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    create_consent_privacy_consent_post: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ConsentCreateRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ConsentListResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    decide_recovery_recovery_decisions_post: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["RecoveryDecisionRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["RecoveryDecisionResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    generate_recovery_proposals_recovery_proposals_generate_post: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["RecoveryGenerateRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["RecoveryProposalsResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    batch_reflect_reflection_batch_post: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ReflectionBatchRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ReflectionBatchResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    list_failure_tags_reflection_failure_tags_get: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FailureTagMaster"][];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    tag_failure_reasons_reflection_failure_tags__execution_id__post: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path: {
-                execution_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["FailureTagRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FailureTagResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    list_pending_reflections_reflection_pending_get: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ReflectionPendingItem"][];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_replan_diff_replan__execution_id__get: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path: {
-                execution_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ReplanDiffResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    approve_replan_replan__execution_id__approve_post: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path: {
-                execution_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ReplanApproveResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    list_habit_penalty_reviews_habit_penalty_get: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HabitPenaltyListResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    accept_habit_penalty_reviews_habit_penalty__habit_id__accept_post: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path: {
-                habit_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HabitPenaltyAcceptResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_weekly_review_reviews_weekly_get: {
-        parameters: {
-            query?: {
-                weekStart?: string | null;
-            };
-            header?: {
-                authorization?: string | null;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["WeeklyReviewResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    generate_weekly_review_reviews_weekly_generate_post: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["WeeklyGenerateRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["WeeklyReviewResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_settings_settings_get: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SettingsResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    anonymize_settings_anonymize_post: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["AnonymizeRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AnonymizeResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_profile_settings_profile_get: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProfileResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    update_profile_settings_profile_patch: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ProfileUpdateRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProfileResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    update_tone_mode_settings_tone_mode_patch: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ToneModeUpdateRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SettingsResponse"];
+                    "application/json": components["schemas"]["InterviewSession"];
                 };
             };
             /** @description Validation Error */
@@ -6337,6 +4394,1340 @@ export interface operations {
             };
         };
     };
+    list_goals_goals_get: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GoalsByTier"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_goal_goals_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["GoalCreateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Goal"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_goal_goals__goal_id__delete: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                goal_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_goal_goals__goal_id__patch: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                goal_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["GoalUpdateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Goal"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_goal_nodes_goals__goal_id__nodes_get: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                goal_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GoalDecomposition"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    park_goal_goals__goal_id__park_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                goal_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Goal"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_habits_habits_get: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Habit"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_habit_habits_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["HabitCreateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Habit"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_habit_habits__habit_id__delete: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                habit_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_habit_habits__habit_id__patch: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                habit_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["HabitUpdateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Habit"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_instances_habit_instances_get: {
+        parameters: {
+            query?: {
+                weekStart?: string | null;
+            };
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HabitInstance"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    check_instance_habit_instances__instance_id__check_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                instance_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HabitInstance"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_inbox_inbox_get: {
+        parameters: {
+            query?: {
+                status?: string | null;
+            };
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InboxItem"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_inbox_inbox_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["InboxCreateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InboxItem"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_inbox_resource_inbox_resources__slug__get: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InboxResourceDetail"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_inbox_inbox__inbox_id__patch: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                inbox_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["InboxUpdateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InboxItem"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    convert_to_goal_inbox__inbox_id__convert_to_goal_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                inbox_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InboxItem"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    convert_to_action_inbox__inbox_id__convert_to_action_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                inbox_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InboxItem"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    adopt_resource_step_inbox__inbox_id__adopt_step_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                inbox_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["InboxAdoptStepRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InboxAdoptedStep"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    archive_inbox_inbox__inbox_id__archive_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                inbox_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    restore_inbox_inbox__inbox_id__restore_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                inbox_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InboxItem"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    generate_milestones_plans_milestones_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["FirstPlanGenerateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MilestoneListResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    generate_plan_plans_generate_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["FirstPlanGenerateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FirstPlanResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_weekly_plan_plans_weekly_get: {
+        parameters: {
+            query?: {
+                weekStart?: string | null;
+            };
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WeeklyPlanResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    edit_block_plans__plan_id__blocks__block_id__patch: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                plan_id: string;
+                block_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["BlockEditRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BlockEditResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_plan_plans__plan_id__get: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                plan_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FirstPlanResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    discard_plan_plans__plan_id__discard_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                plan_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    approve_plan_plans__plan_id__approve_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                plan_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FirstPlanApproveResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    generate_replan_plans_replan_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ReplanResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    approve_replan_plans_replan__plan_id__approve_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                plan_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WeeklyReplanApproveResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    connect_calendar_calendar_connect_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CalendarConnectRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CalendarConnection"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    disconnect_calendar_calendar_connect_delete: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_freebusy_calendar_freebusy_get: {
+        parameters: {
+            query: {
+                from: string;
+                to: string;
+            };
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FreeBusy"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    sync_preview_calendar_sync_preview_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SyncPreview"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    approve_insert_calendar_events_approve_insert_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApproveInsertResult"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_schedules_fixed_schedules_get: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FixedSchedule"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_schedule_fixed_schedules_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["FixedScheduleCreateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FixedSchedule"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_schedule_fixed_schedules__schedule_id__delete: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                schedule_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_schedule_fixed_schedules__schedule_id__patch: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                schedule_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["FixedScheduleUpdateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FixedSchedule"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    today_agenda_today_agenda_get: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TodayAgenda"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     get_action_detail_today_actions__action_id__get: {
         parameters: {
             query?: never;
@@ -6390,37 +5781,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ExecutionStartResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    today_agenda_today_agenda_get: {
-        parameters: {
-            query?: never;
-            header?: {
-                authorization?: string | null;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["TodayAgenda"];
                 };
             };
             /** @description Validation Error */
@@ -6522,6 +5882,833 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ExecutionEventResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_pending_reflections_reflection_pending_get: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ReflectionPendingItem"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_failure_tags_reflection_failure_tags_get: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FailureTagMaster"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    tag_failure_reasons_reflection_failure_tags__execution_id__post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                execution_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["FailureTagRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FailureTagResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    batch_reflect_reflection_batch_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ReflectionBatchRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ReflectionBatchResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    generate_recovery_proposals_recovery_proposals_generate_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RecoveryGenerateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RecoveryProposalsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    decide_recovery_recovery_decisions_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RecoveryDecisionRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RecoveryDecisionResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_replan_diff_replan__execution_id__get: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                execution_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ReplanDiffResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    approve_replan_replan__execution_id__approve_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                execution_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ReplanApproveResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_weekly_review_reviews_weekly_get: {
+        parameters: {
+            query?: {
+                weekStart?: string | null;
+            };
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WeeklyReviewResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    generate_weekly_review_reviews_weekly_generate_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["WeeklyGenerateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WeeklyReviewResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_habit_penalty_reviews_habit_penalty_get: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HabitPenaltyListResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    accept_habit_penalty_reviews_habit_penalty__habit_id__accept_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                habit_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HabitPenaltyAcceptResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_current_policy_policy_snapshot_current_get: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PolicySnapshotResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_settings_notifications_settings_get: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NotificationSettings"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_settings_notifications_settings_patch: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["NotificationSettingsUpdateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NotificationSettings"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_vapid_public_key_notifications_vapid_public_key_get: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["VapidPublicKeyResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    subscribe_notifications_subscribe_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PushSubscribeRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NotificationSettings"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    unsubscribe_notifications_subscribe_delete: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_settings_settings_get: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SettingsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_tone_mode_settings_tone_mode_patch: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ToneModeUpdateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SettingsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_profile_settings_profile_get: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProfileResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_profile_settings_profile_patch: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ProfileUpdateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProfileResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    anonymize_settings_anonymize_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AnonymizeRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AnonymizeResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_consent_privacy_consent_get: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ConsentListResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_consent_privacy_consent_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ConsentCreateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ConsentListResponse"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
Closes #187

자료가 **읽고 끝나고** 있었습니다. `[열기]`·`[보관]` 뿐이라 좋은 글을 읽고 "그래서 뭘 하지"에서
끊깁니다. BE 가 출구를 냈고(backend#202/#204), FE 에서 걸음 선택만 붙이면 이어집니다.

## API 동기화도 함께

라이브 스펙이 main 보다 앞서 있었습니다 (**73 vs 71 경로**). 덤프해 반영했습니다.

```
+ /inbox/resources/{slug}        ← #163 이 기다리던 것.  WARN 1 → 0
+ /inbox/{inbox_id}/adopt-step   ← 이번 작업
+ /goals/{goal_id}/nodes         구 /decompose 대체 (FE 는 이미 nodes 사용 — 영향 없음)
```

계약 체크 **OK 85 → 86 · WARN 1 → 0 · GONE 0**

## 구현

`ResourceViewerSheet` 본문 아래에 **"이 중 하나 해볼까요?"** 섹션.
걸음을 고르면 `POST /inbox/{id}/adopt-step` → 성공 시 토스트 + 체크 표시.

### 계약의 함정 세 가지를 화면에 반영

| 함정 | 대응 |
|---|---|
| **채택해도 자료 카드가 인박스에 남는다** (`status` 안 바뀜) | 목록을 새로고침하지 않고, 사라질 거라 기대하는 UI 를 만들지 않음 |
| **같은 걸음 여러 번 채택 시 카드가 여러 개** (BE 가 의도적으로 안 막음) | `Idempotency-Key: adopt-<inboxId>-<stepIndex>` 로 연타 차단 + 담은 걸음 체크 표시. 채택 중엔 다른 걸음도 잠금 |
| **`steps` 는 자료(`source=system`)에만 있다** | 사용자 캡처 항목엔 섹션이 안 나옴 |

## 에러 문구

404(보관됨·자료 없음)·422(자료 아님·없는 걸음) → **"이 자료는 지금 담을 수 없어요. 자료를 다시 열어봐 주세요."**

공용 422 문구가 `입력값을 확인해 주세요` 인데, **사용자는 입력한 게 없고 목록에서 고르기만 했습니다** — 상황에 안 맞습니다.
어느 경우든 **시트는 닫지 않습니다** (계속 읽거나 다른 걸음을 고를 수 있어야 해서).

토스트는 시트가 열려 있을 때 위쪽에 띄웁니다. 아래에 두면 방금 고른 걸음 **다음 항목을 가려서**
연달아 고르려는 사람이 무엇을 누르는지 못 봅니다(실측으로 확인).

## 검증 — DoD 전항목

- [x] 자료 카드 → `[열기]` → **걸음 목록 노출**
- [x] 걸음 선택 → `POST /inbox/i2/adopt-step {stepIndex:0}` · `Idempotency-Key: adopt-i2-0` 확인
- [x] 채택 후 **자료 카드 인박스 잔존**
- [x] 404 / 422 → 원시 코드 노출 **0**, 시트 유지, 담김 표시 안 됨
- [x] 13개 화면 회귀 렌더, 런타임 에러 **0**
- [x] `tsc` 0 errors · API 계약 **PASS** · `build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)
