### PR TITLE
fix(auth): 실 Google 로그인으로 정합 — stub 을 프로덕션에서 fail-closed 로 (#81)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,14 @@ VITE_API_BASE_URL=http://localhost:8000
 # 실제 발송하려면 백엔드와 동일한 키쌍의 공개키를 넣는다.
 VITE_VAPID_PUBLIC_KEY=
 
-# dev/demo 전용 stub 로그인 허용 여부. prod 배포에서는 false 로 설정해
-# 가짜 Google id token(demo-id-token) 자동 발급을 막는다. 기본(미설정)=허용.
-VITE_ALLOW_STUB_LOGIN=true
+# Google OAuth 클라이언트 ID (#81). 없으면 로그인 화면에 Google 버튼이 안 뜬다.
+# Google Cloud Console > 사용자 인증 정보 > OAuth 2.0 클라이언트 ID (웹 애플리케이션).
+# 승인된 JavaScript 원본에 배포 도메인을 등록해야 버튼이 동작한다.
+VITE_GOOGLE_CLIENT_ID=
+
+# dev/demo 전용 stub 로그인 허용 여부.
+#   미설정 = 개발에서만 허용 (프로덕션 빌드에서는 자동으로 꺼짐 — fail closed)
+#   'true'  = 강제 허용   / 'false' = 강제 차단
+# 프로덕션에서 데모 진입을 열려면 여기 true + 백엔드 AUTH_STUB_MODE=true 가 함께 필요하다.
+# 둘이 어긋나면 로그인이 깨진다.
+VITE_ALLOW_STUB_LOGIN=

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -197,10 +197,31 @@ export function onAuthExpired(handler: AuthExpiredHandler | null): void {
 // stub 자동 로그인을 허용하는가 — AppShell 부트스트랩과 api 레이어 자가치유가
 // 같은 판단을 써야 한다. 예전엔 api 레이어가 VITE_ALLOW_STUB_LOGIN 만 봐서,
 // `?login=1` 로 로그인 화면을 강제해도 자가치유가 먼저 자동 로그인해 무력화됐다.
+/**
+ * 이 빌드에서 stub 계정이 쓸 수 있는가 — 데모 버튼 노출 여부의 기준.
+ *
+ * 미설정일 때의 기본값은 개발에서만 허용한다(fail closed). 예전엔 미설정=허용이라,
+ * 배포에 환경변수 하나를 빠뜨리면 프로덕션에서 가짜 Google 토큰으로 로그인이 열렸다 —
+ * 설정 누락이 보안 구멍이 되는 기본값은 쓰지 않는다.
+ */
+export function stubDemoAvailable(): boolean {
+  const flag = import.meta.env.VITE_ALLOW_STUB_LOGIN;
+  if (flag === 'false') return false;
+  if (flag === 'true') return true;
+  return import.meta.env.DEV;
+}
+
+/**
+ * stub 을 **자동으로** 쓸 수 있는가 — 부팅 시 자동 로그인과 401 자가치유의 기준.
+ *
+ * `?login=1` 은 자동 로그인만 끈다(실제 로그인 화면을 보려는 것). 사용자가 데모 버튼을
+ * 직접 누르는 건 별개라 stubDemoAvailable 로 판단한다 — 둘을 한 함수로 묶으면
+ * `?login=1` 로 로그인 화면을 확인하는 동안 데모 진입까지 막혀 테스트가 어려워진다.
+ */
 export function stubLoginAllowed(): boolean {
   if (typeof window === 'undefined') return false;
-  if (import.meta.env.VITE_ALLOW_STUB_LOGIN === 'false') return false;
-  return new URLSearchParams(window.location.search).get('login') !== '1';
+  if (new URLSearchParams(window.location.search).get('login') === '1') return false;
+  return stubDemoAvailable();
 }
 
 // stub 로그인 idToken — 브라우저별 전용 계정(demo:<deviceId>), `?demo=stub` 이면 시드 계정.

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { Sparkle } from '@phosphor-icons/react';
 import { ErrorBanner } from '../components/ErrorBanner';
+import { stubDemoAvailable } from '../lib/api';
 
 // Google Identity Services 는 CDN 스크립트(index.html)가 window.google 을 채운다.
 // 공식 타입 패키지 없이 최소 shape 만 선언 — 실제로 쓰는 필드만.
@@ -32,6 +33,8 @@ interface LoginScreenProps {
 export function LoginScreen({ onGoogleCredential, onDemoLogin, isBusy, error }: LoginScreenProps) {
   const buttonRef = useRef<HTMLDivElement>(null);
   const [buttonReady, setButtonReady] = useState(false);
+  // 데모 진입 가능 여부는 빌드 설정에서 온다(프로덕션 기본은 차단).
+  const demoAllowed = stubDemoAvailable();
 
   useEffect(() => {
     if (!CLIENT_ID) return;
@@ -115,8 +118,14 @@ export function LoginScreen({ onGoogleCredential, onDemoLogin, isBusy, error }: 
             )}
           </>
         ) : (
-          <div style={{ fontSize: 12, color: 'var(--text-3)', padding: '10px 14px', border: '1px dashed var(--sand-200)', borderRadius: 12 }}>
+          // CLIENT_ID 가 없으면 버튼 자체가 뜨지 않는다 — 왜 못 들어가는지 알려준다.
+          <div style={{ fontSize: 12, color: 'var(--text-2)', padding: '12px 14px', border: '1px dashed var(--sand-300)', borderRadius: 12, lineHeight: 1.6, textAlign: 'center' }}>
             Google 로그인이 아직 설정되지 않았어요.
+            {!demoAllowed && (
+              <div style={{ marginTop: 4, fontSize: 11, color: 'var(--text-3)' }}>
+                관리자가 설정을 마치면 들어올 수 있어요.
+              </div>
+            )}
           </div>
         )}
 
@@ -124,6 +133,9 @@ export function LoginScreen({ onGoogleCredential, onDemoLogin, isBusy, error }: 
           <ErrorBanner>{error}</ErrorBanner>
         )}
 
+        {/* stub 이 꺼져 있으면(프로덕션 기본) 눌러도 백엔드가 거부한다 — 버튼을 두지 않는다.
+            예전엔 항상 보여서, 배포본에서 누르면 "로그인 정보가 올바르지 않아요" 만 떴다. */}
+        {demoAllowed && (
         <button
           onClick={onDemoLogin}
           disabled={isBusy}
@@ -142,6 +154,7 @@ export function LoginScreen({ onGoogleCredential, onDemoLogin, isBusy, error }: 
         >
           {isBusy ? '로그인 중…' : '데모 계정으로 체험하기'}
         </button>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
Related #81 (방향 (B) 실 Google 로그인 확정 — FE 쪽 정합)

## 설정 누락이 보안 구멍이던 기본값을 뒤집습니다

`stubLoginAllowed` 가 `VITE_ALLOW_STUB_LOGIN !== 'false'` 였습니다 — **미설정 = 허용**.
배포에 환경변수 하나를 빠뜨리면 **프로덕션에서 가짜 Google 토큰으로 로그인이 열립니다.**

실제로 지금 배포본이 그 상태였고, 백엔드만 stub 을 거부해서 데모 로그인이 깨져 있었습니다.

| `VITE_ALLOW_STUB_LOGIN` | 동작 |
|---|---|
| 미설정 | **개발에서만 허용** (프로덕션 빌드는 자동 차단 — fail closed) |
| `'true'` | 강제 허용 |
| `'false'` | 강제 차단 |

## 자동 로그인과 수동 데모 진입을 분리

한 함수가 둘을 겸하고 있어서 `?login=1` 이 데모 버튼까지 감췄습니다 —
로그인 화면을 확인하려고 켠 플래그가 데모 진입까지 막아 테스트가 어려워집니다.

```
stubDemoAvailable()   빌드 설정만 본다        → 데모 버튼 노출 기준
stubLoginAllowed()    + ?login=1 이면 false   → 자동 로그인·401 자가치유 기준
```

## 로그인 화면이 실제 설정을 반영합니다

- stub 이 꺼져 있으면 데모 버튼을 **아예 그리지 않습니다.** 예전엔 항상 보여서,
  배포본에서 누르면 `로그인 정보가 올바르지 않아요` 만 떴습니다.
- `CLIENT_ID` 가 없으면 왜 못 들어오는지 한 줄 덧붙입니다.

## 검증

| | 결과 |
|---|---|
| 프로덕션 빌드 | stub 자동 로그인 **0건** · 데모 버튼 **숨김** · Google 버튼 노출 |
| 개발 서버 | 기존 편의 유지 (자동 stub 로그인 동작) |
| 인증 시나리오 | 3종 유지 (로그인 성공 / 401 재로그인 / 부팅 실패) |
| 13개 화면 회귀 | 런타임 에러 **0** |

`tsc` 0 errors · API 계약 **PASS** · `build` 성공

## ⚠️ 남은 것 — 배포 설정 (코드 밖, 사람이 해야 함)

이 PR 만으로는 **#81 의 DoD("평가자가 데모 계정 진입 1회 성공")가 충족되지 않습니다.**

1. **Google Cloud Console** — OAuth 2.0 클라이언트 ID(웹) 발급, 동의화면 구성,
   승인된 JavaScript 원본에 `https://reaction-frontend.vercel.app` 등록
2. **Vercel** — `VITE_GOOGLE_CLIENT_ID` 환경변수 설정 후 재배포
3. **백엔드** — `AUTH_STUB_MODE=false` 유지 (현재 그 상태이므로 변경 불필요)

절차는 `.env.example` 에 적어뒀습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
