### PR TITLE
fix(today): 수기 타입이 실제 스키마와 어긋나 브리프가 늘 fallback 이던 문제

### DIFF
--- a/src/screens/MorningBriefScreen.tsx
+++ b/src/screens/MorningBriefScreen.tsx
@@ -62,9 +62,8 @@ export function MorningBriefScreen({ onStart }: MorningBriefScreenProps) {
   const [blocks, setBlocks] = useState<BriefBlock[]>([]);
   const [goalName, setGoalName] = useState<string>('');
   const [weekProgress, setWeekProgress] = useState<number | null>(null);
-  // /today/agenda 의 brief(DailyBrief) — 백엔드가 greeting·adjustmentHints 를 주는데
-  // 아무도 쓰지 않고 있었다. 인사말은 실데이터로 덮고, 조정 안내는 있을 때만 노출한다.
-  // (#159 는 없는 필드 headline 을 참조해 항상 fallback 이었다 — 실제 필드는 greeting.)
+  // /today/agenda 의 brief(MorningBrief) — headline 을 인사말로 쓰고, 조정 안내는 있을 때만.
+  // 수기 타입이 DailyBrief{greeting} 으로 어긋나 있어 한동안 fallback 만 나왔다.
   const [briefGreeting, setBriefGreeting] = useState<string | null>(null);
   const [adjustmentHints, setAdjustmentHints] = useState<string[]>([]);
   // /today/agenda 가 응답했는지 — true 면 blocks 가 실데이터(비어있어도)라 더미 이월 안내를 숨긴다.
@@ -78,7 +77,7 @@ export function MorningBriefScreen({ onStart }: MorningBriefScreenProps) {
       (a) => {
         if (cancelled) return;
         setBlocks((a.cards ?? []).map(cardToBlock));
-        if (a.brief?.greeting) setBriefGreeting(a.brief.greeting);
+        if (a.brief?.headline) setBriefGreeting(a.brief.headline);
         setAdjustmentHints(a.brief?.adjustmentHints ?? []);
         setUsingReal(true);
         setLoading(false);

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -376,11 +376,16 @@ export type ActionItemStatus =
   | 'failed'
   | 'recovery_pending';
 
-export interface DailyBrief {
-  date: string; // YYYY-MM-DD
-  greeting: string;
-  bigRock: string | null;
+// GET /today/agenda 의 brief. 스펙 이름은 MorningBrief 다.
+// 예전 수기 타입은 DailyBrief{date,greeting,bigRock} 이었는데 실제 스키마와 달랐고,
+// 화면이 읽던 brief.greeting 은 백엔드가 보내지 않아 늘 fallback 이었다(죽은 배선).
+export interface MorningBrief {
+  headline: string;
   adjustmentHints: string[];
+  // 오늘의 '큰 돌' 액션 id — 있으면 그 카드로 바로 보낼 수 있다.
+  bigRockActionId?: string | null;
+  // true 면 LLM 이 아니라 룰 기반으로 만든 브리프.
+  fallbackUsed?: boolean | null;
 }
 
 export interface ActionItem {
@@ -410,7 +415,7 @@ export interface AgendaCard {
 
 export interface TodayAgenda {
   date: string;
-  brief: DailyBrief | null;
+  brief: MorningBrief | null;
   cards: AgendaCard[];
   habits: HabitInstance[];
   fixedSchedules: FixedSchedule[];


### PR DESCRIPTION
## 무엇이 틀렸나 — 제가 이틀 전에 잘못 고친 것입니다

| | |
|---|---|
| 수기 타입 | `DailyBrief { date, greeting, bigRock, adjustmentHints }` |
| **실제 스펙** | `MorningBrief { headline, adjustmentHints, bigRockActionId, fallbackUsed }` |

`DailyBrief` 는 **지금 스펙에 아예 없습니다.**

화면은 `brief.greeting` 을 읽고 있었는데 백엔드가 보내지 않는 필드라 **항상 fallback**
(`좋은 아침이에요, {이름}.`)만 나왔습니다. 죽은 배선이었습니다.

**경위** — #159 가 `brief.headline` 을 쓰려던 걸, 제가 당시 수기 타입만 보고 "없는 필드"라며
`greeting` 으로 바꿨습니다. **수기 타입 자체가 드리프트된 상태였고 #159 가 맞았습니다.**

## 왜 계약 체크가 못 잡았나

`check:api` 는 **경로 단위**입니다 — 엔드포인트가 있나 없나만 봅니다.
**스키마 필드가 어긋나는 건 통과합니다.** 실제로 이 상태로 `WARN 0 / PASS` 였습니다.

응답 스키마 **85개 · 필드 388개**를 훑어 "백엔드가 주는데 화면이 안 읽는 필드"를 뽑다가 발견했습니다.

## 조치

```
types/api.ts    DailyBrief → MorningBrief  (스펙 이름·필드로 정합)
MorningBrief    brief.greeting → brief.headline
```

## 검증

- 목킹 렌더 — `headline`·`adjustmentHints` 실데이터 반영 확인 (이전엔 fallback)
- 13개 화면 회귀 렌더, 런타임 에러 **0**
- `tsc` 0 errors · API 계약 **PASS** · `build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)
