### PR TITLE
docs(inbox): adopt-step 의 Idempotency-Key 주석을 실제 동작에 맞게 정정 (#191)

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -508,7 +508,10 @@ export const inboxApi = {
     request<InboxAdoptedStep>(`/inbox/${inboxId}/adopt-step`, {
       method: 'POST',
       body: { stepIndex } satisfies InboxAdoptStepRequest,
-      // 같은 걸음을 두 번 눌러도 카드가 두 개 생기지 않게 한다.
+      // 이 키는 지금 아무것도 막지 못한다 — BE 미들웨어(_IDEMPOTENT_ROUTES)에 adopt-step 이
+      // 없어서 헤더가 그대로 무시된다. 연타로 인한 중복 요청은 UI 의 locked 가드가 막는다.
+      // ⚠️ BE 를 idempotent 로 바꾸려면 이 키에 날짜를 넣어야 한다(adopt-{id}-{idx}-{YYYY-MM-DD}).
+      // 지금처럼 영구 고정 키면 며칠 뒤 같은 걸음을 다시 담으려 해도 영영 막힌다. (#191)
       idempotencyKey: `adopt-${inboxId}-${stepIndex}`,
     }),
 };


### PR DESCRIPTION
Closes #191

## 무엇이 틀렸나

`src/lib/api.ts` 의 `inboxApi.adoptStep` 에서 주석 한 줄이 **실제 동작과 반대**였습니다.

```ts
// 같은 걸음을 여러 번 채택하면 카드가 여러 개 생긴다(BE 가 의도적으로 막지 않음).   ← 맞음
...
// 같은 걸음을 두 번 눌러도 카드가 두 개 생기지 않게 한다.                          ← 틀림
idempotencyKey: `adopt-${inboxId}-${stepIndex}`,
```

같은 함수 안에서 두 주석이 서로 모순이었습니다. 키는 `Idempotency-Key` 헤더로 정상 전송되지만(`api.ts:265`), 백엔드 `_IDEMPOTENT_ROUTES` 에 `adopt-step` 이 없어 미들웨어가 헤더를 그냥 무시합니다. 즉 중복 방지가 전혀 걸려 있지 않습니다.

## 무엇을 고쳤나

동작 자체는 백엔드 설계대로(사용자가 같은 걸음을 두 번 하려는 게 정당할 수 있음)라, **코드는 건드리지 않고 주석만** 고쳤습니다. 이슈의 권고안 그대로입니다.

추가로 이슈가 지적한 잠재 지뢰를 주석에 박아뒀습니다 — 키가 `adopt-{inboxId}-{stepIndex}` 로 영구 고정이라, 나중에 누군가 `adopt-step` 을 `_IDEMPOTENT_ROUTES` 에 추가하면 사용자가 며칠 뒤 같은 걸음을 다시 담으려 해도 영영 막힙니다. 그때는 키에 날짜(`-{YYYY-MM-DD}`)가 필요합니다.

## 남겨둔 제품 판단 (이 PR 범위 밖)

`ResourceViewerSheet` 에서 이미 담은 걸음을 한 번 더 누르면 오늘 할 일 카드가 하나 더 생깁니다(`disabled={busy || locked}` 에 `done` 이 빠져 있음). UI 로 막고 싶다면 `disabled={busy || locked || done}` 한 군데면 되지만, 그러면 시트를 연 동안 같은 걸음을 다시 담을 수 없게 됩니다. 제품 판단이라 이 PR 에서는 손대지 않았습니다.

## 검증

- `npx tsc --noEmit` ✅
- `npm run build` ✅ (built in 21.16s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
