### PR TITLE
fix(inbox): 이미 담은 걸음을 다시 눌렀을 때 조용히 중복되던 것을 알린다

### DIFF
--- a/src/components/ResourceViewerSheet.tsx
+++ b/src/components/ResourceViewerSheet.tsx
@@ -25,8 +25,11 @@ interface ResourceViewerSheetProps {
   onAdoptStep?: (stepIndex: number) => void;
   /** 채택 진행 중인 걸음 인덱스. 그 항목만 비활성·문구 변경. */
   adoptingIndex?: number | null;
-  /** 이미 오늘 담은 걸음. BE 가 중복을 막지 않으므로 화면에서 알려준다. */
-  adoptedIndexes?: number[];
+  /**
+   * 걸음별로 오늘 몇 개 담았는지. BE 는 중복을 막지 않는다(같은 걸음을 두 번 하려는 게
+   * 정당할 수 있어서) — 막는 대신 몇 개 담겼는지와 다시 누르면 어떻게 되는지를 알린다.
+   */
+  adoptedCounts?: Record<number, number>;
 }
 
 // 코드·표처럼 넓은 요소는 자기 컨테이너에서만 가로 스크롤 — 본문(모바일)이 가로로 밀리지 않게.
@@ -48,7 +51,7 @@ export function ResourceViewerSheet({
   steps = [],
   onAdoptStep,
   adoptingIndex = null,
-  adoptedIndexes = [],
+  adoptedCounts = {},
 }: ResourceViewerSheetProps) {
   const bodyMd = markdown === null ? null : stripLeadingTitle(markdown, title);
   return (
@@ -143,7 +146,8 @@ export function ResourceViewerSheet({
             <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
               {steps.map((step, i) => {
                 const busy = adoptingIndex === i;
-                const done = adoptedIndexes.includes(i);
+                const count = adoptedCounts[i] ?? 0;
+                const done = count > 0;
                 // 다른 걸음을 채택하는 중엔 전부 잠근다 — 연타로 카드가 여러 개 생기는 걸 막는다.
                 const locked = adoptingIndex !== null && !busy;
                 return (
@@ -193,7 +197,18 @@ export function ResourceViewerSheet({
                       </span>
                       {(busy || done) && (
                         <span style={{ display: 'block', marginTop: 3, fontSize: 11, color: 'var(--brand-ink)', fontWeight: 600 }}>
-                          {busy ? '담는 중…' : '오늘 할 일에 담았어요'}
+                          {busy
+                            ? '담는 중…'
+                            : count > 1
+                              ? `오늘 할 일에 ${count}개 담았어요`
+                              : '오늘 할 일에 담았어요'}
+                        </span>
+                      )}
+                      {/* 다시 누르면 하나 더 생긴다 — 체크만 두면 '끝났다' 로 읽혀
+                          무심코 눌렀을 때 조용히 중복이 생긴다(#191). */}
+                      {done && !busy && (
+                        <span style={{ display: 'block', marginTop: 2, fontSize: 10.5, color: 'var(--text-3)' }}>
+                          다시 누르면 하나 더 담아요
                         </span>
                       )}
                     </span>

--- a/src/screens/InboxScreen.tsx
+++ b/src/screens/InboxScreen.tsx
@@ -62,7 +62,7 @@ export function InboxScreen() {
     setTimeout(() => setToast(null), 2600);
   };
   const [adoptingIndex, setAdoptingIndex] = useState<number | null>(null);
-  const [adoptedIndexes, setAdoptedIndexes] = useState<number[]>([]);
+  const [adoptedCounts, setAdoptedCounts] = useState<Record<number, number>>({});
 
   const fetchList = (status?: string) => {
     setIsLoading(true);
@@ -168,7 +168,7 @@ export function InboxScreen() {
     const slug = it.resourceSlug;
     if (!slug) return;
     setAdoptingIndex(null);
-    setAdoptedIndexes([]);
+    setAdoptedCounts({});
     setResource({ inboxId: it.inboxId, title: it.rawText, markdown: null, error: null, steps: [] });
     try {
       const res = await inboxApi.resource(slug);
@@ -197,8 +197,14 @@ export function InboxScreen() {
     setAdoptingIndex(stepIndex);
     try {
       const adopted = await inboxApi.adoptStep(resource.inboxId, stepIndex);
-      setAdoptedIndexes((xs) => (xs.includes(stepIndex) ? xs : [...xs, stepIndex]));
-      showToast(`오늘 할 일에 담았어요 — ${adopted.title}`);
+      // BE 는 중복을 막지 않는다 — 누른 만큼 카드가 생긴다. 몇 번째인지 세어 알려준다.
+      const nth = (adoptedCounts[stepIndex] ?? 0) + 1;
+      setAdoptedCounts((m) => ({ ...m, [stepIndex]: nth }));
+      showToast(
+        nth > 1
+          ? `하나 더 담았어요 — 오늘 ${nth}개 · ${adopted.title}`
+          : `오늘 할 일에 담았어요 — ${adopted.title}`,
+      );
     } catch (err: unknown) {
       // 시트는 닫지 않는다 — 사용자가 자료를 계속 읽거나 다른 걸음을 고를 수 있어야 한다.
       //
@@ -375,7 +381,7 @@ export function InboxScreen() {
           steps={resource.steps}
           onAdoptStep={adoptStep}
           adoptingIndex={adoptingIndex}
-          adoptedIndexes={adoptedIndexes}
+          adoptedCounts={adoptedCounts}
           error={resource.error}
           onClose={() => setResource(null)}
         />


### PR DESCRIPTION
## 배경

#191 이 지적한 잘못된 주석은 #192 가 고쳤습니다. 다만 #192 는 본문에 이렇게 남겼습니다.

> `ResourceViewerSheet` 에서 이미 담은 걸음을 한 번 더 누르면 오늘 할 일 카드가 하나 더 생깁니다 … 제품 판단이라 이 PR 에서는 손대지 않았습니다.

그 남겨둔 제품 판단을 이 PR 에서 처리합니다.

## 무엇이 문제인가

체크 표시 + "오늘 할 일에 담았어요" 는 **끝났다**로 읽힙니다. 그런데 실제로는 다시 누르면 오늘 카드가 하나 더 생기고, 토스트 문구가 두 번 다 똑같아서 사용자는 중복이 생긴 걸 오늘 화면에 가서야 압니다.

즉 문제는 "중복이 생긴다"가 아니라 **끝난 것처럼 보이는데 조용히 하나 더 생긴다**는 점입니다.

## 왜 막지 않았나

BE 는 `_IDEMPOTENT_ROUTES` 에 adopt-step 을 넣지 않아 중복을 **의도적으로** 허용합니다 — 같은 걸음을 두 번 하려는 게 정당할 수 있기 때문입니다(같은 자료의 같은 걸음을 오늘 두 번 하겠다는 계획). `disabled` 로 막으면 그 정당한 경우를 없앱니다.

그래서 막는 대신 **무슨 일이 일어나는지 미리 보이게** 했습니다.

## 변경

`adoptedIndexes: number[]` → `adoptedCounts: Record<number, number>`

| 상태 | 표시 |
|---|---|
| 1회 담음 | `오늘 할 일에 담았어요` |
| 2회 이상 | `오늘 할 일에 2개 담았어요` |
| 담긴 뒤 상시 | `다시 누르면 하나 더 담아요` ← 재탭 결과를 미리 알림 |
| 토스트(2회~) | `하나 더 담았어요 — 오늘 2개 · {제목}` |

## 검증

같은 걸음 연속 2회 클릭 실측:

```
adopt 호출        2건   ← BE 가 안 막으므로 정상
라벨              "오늘 할 일에 담았어요" → "오늘 할 일에 2개 담았어요"
토스트 1회        "오늘 할 일에 담았어요 — 걸음 A"
토스트 2회        "하나 더 담았어요 — 오늘 2개 · 걸음 A"
안내 문구         "다시 누르면 하나 더 담아요" 노출
```

- 404/422 에러 처리 유지(원시 코드 노출 없음, 시트 유지)
- 13개 화면 회귀 — 런타임 에러 0
- `npx tsc --noEmit` 0 errors · `check:api` PASS · `npm run build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)