### PR TITLE
fix(inbox): 담긴 걸음을 탭 수가 아니라 actionId 로 센다 (BE #213 대비)

### DIFF
--- a/src/components/ResourceViewerSheet.tsx
+++ b/src/components/ResourceViewerSheet.tsx
@@ -26,10 +26,19 @@ interface ResourceViewerSheetProps {
   /** 채택 진행 중인 걸음 인덱스. 그 항목만 비활성·문구 변경. */
   adoptingIndex?: number | null;
   /**
-   * 걸음별로 오늘 몇 개 담았는지. BE 는 중복을 막지 않는다(같은 걸음을 두 번 하려는 게
-   * 정당할 수 있어서) — 막는 대신 몇 개 담겼는지와 다시 누르면 어떻게 되는지를 알린다.
+   * 걸음별로 오늘 담긴 카드의 actionId 목록. 탭 수가 아니라 id 를 담는 이유는,
+   * BE 가 dedup 을 넣으면(BE #213) 두 번째 탭이 같은 id 를 되돌려주기 때문이다 —
+   * 그때 개수를 세면 실제로는 1장인데 2개라고 말하게 된다.
+   *
+   * 막지는 않는다. 같은 걸음을 두 번 하려는 게 정당할 수 있어서(BE 도 그래서 안 막는다).
+   * 대신 몇 개 담겼는지와 다시 누르면 어떻게 되는지를 미리 알린다.
    */
-  adoptedCounts?: Record<number, number>;
+  adoptedIds?: Record<number, string[]>;
+  /**
+   * 같은 걸음을 다시 담았을 때 서버가 같은 actionId 를 되돌려준 적이 있는가.
+   * BE 가 dedup 을 넣었다는 관측 — 안내 문구를 사실에 맞춰 뒤집는 데만 쓴다.
+   */
+  dedupObserved?: boolean;
 }
 
 // 코드·표처럼 넓은 요소는 자기 컨테이너에서만 가로 스크롤 — 본문(모바일)이 가로로 밀리지 않게.
@@ -51,7 +60,8 @@ export function ResourceViewerSheet({
   steps = [],
   onAdoptStep,
   adoptingIndex = null,
-  adoptedCounts = {},
+  adoptedIds = {},
+  dedupObserved = false,
 }: ResourceViewerSheetProps) {
   const bodyMd = markdown === null ? null : stripLeadingTitle(markdown, title);
   return (
@@ -146,7 +156,7 @@ export function ResourceViewerSheet({
             <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
               {steps.map((step, i) => {
                 const busy = adoptingIndex === i;
-                const count = adoptedCounts[i] ?? 0;
+                const count = (adoptedIds[i] ?? []).length;
                 const done = count > 0;
                 // 다른 걸음을 채택하는 중엔 전부 잠근다 — 연타로 카드가 여러 개 생기는 걸 막는다.
                 const locked = adoptingIndex !== null && !busy;
@@ -204,11 +214,13 @@ export function ResourceViewerSheet({
                               : '오늘 할 일에 담았어요'}
                         </span>
                       )}
-                      {/* 다시 누르면 하나 더 생긴다 — 체크만 두면 '끝났다' 로 읽혀
-                          무심코 눌렀을 때 조용히 중복이 생긴다(#191). */}
+                      {/* 체크만 두면 '끝났다' 로 읽혀, 무심코 다시 눌렀을 때 조용히 중복이
+                          생긴다(#191). 다시 누르면 어떻게 되는지를 미리 말해준다.
+                          문구는 관측한 사실을 따른다 — dedup 을 한 번이라도 확인했으면
+                          그때부터 "하나만" 이다. BE 배포 시점을 FE 가 알 필요가 없다. */}
                       {done && !busy && (
                         <span style={{ display: 'block', marginTop: 2, fontSize: 10.5, color: 'var(--text-3)' }}>
-                          다시 누르면 하나 더 담아요
+                          {dedupObserved ? '다시 눌러도 하나만 담겨요' : '다시 누르면 하나 더 담아요'}
                         </span>
                       )}
                     </span>

--- a/src/screens/InboxScreen.tsx
+++ b/src/screens/InboxScreen.tsx
@@ -55,14 +55,16 @@ export function InboxScreen() {
     error: string | null;
     steps: string[];
   } | null>(null);
-  // 채택 진행 중인 걸음 인덱스 + 이미 담은 것들. BE 가 중복을 막지 않아 화면에서 알려준다.
   const [toast, setToast] = useState<{ msg: string; tone: 'neutral' | 'error' } | null>(null);
   const showToast = (msg: string, tone: 'neutral' | 'error' = 'neutral') => {
     setToast({ msg, tone });
     setTimeout(() => setToast(null), 2600);
   };
   const [adoptingIndex, setAdoptingIndex] = useState<number | null>(null);
-  const [adoptedCounts, setAdoptedCounts] = useState<Record<number, number>>({});
+  // 걸음별로 담긴 카드의 actionId 목록. 개수만 세면 BE 가 dedup 을 넣는 순간 틀어진다.
+  const [adoptedIds, setAdoptedIds] = useState<Record<number, string[]>>({});
+  // 서버가 같은 카드를 되돌려준 적이 있는가 — BE dedup(#213) 이 배포됐다는 관측.
+  const [dedupObserved, setDedupObserved] = useState(false);
 
   const fetchList = (status?: string) => {
     setIsLoading(true);
@@ -168,7 +170,7 @@ export function InboxScreen() {
     const slug = it.resourceSlug;
     if (!slug) return;
     setAdoptingIndex(null);
-    setAdoptedCounts({});
+    setAdoptedIds({});
     setResource({ inboxId: it.inboxId, title: it.rawText, markdown: null, error: null, steps: [] });
     try {
       const res = await inboxApi.resource(slug);
@@ -197,13 +199,20 @@ export function InboxScreen() {
     setAdoptingIndex(stepIndex);
     try {
       const adopted = await inboxApi.adoptStep(resource.inboxId, stepIndex);
-      // BE 는 중복을 막지 않는다 — 누른 만큼 카드가 생긴다. 몇 번째인지 세어 알려준다.
-      const nth = (adoptedCounts[stepIndex] ?? 0) + 1;
-      setAdoptedCounts((m) => ({ ...m, [stepIndex]: nth }));
+      // 탭 횟수가 아니라 받은 actionId 로 센다. 지금 BE 는 누를 때마다 새 카드를 만들지만
+      // (BE #213), dedup 이 들어오면 같은 actionId 가 되돌아온다 — 그때 "하나 더 담았어요"
+      // 라고 말하면 거짓말이 된다. id 를 세면 어느 쪽이든 화면이 사실과 어긋나지 않는다.
+      const prev = adoptedIds[stepIndex] ?? [];
+      const already = prev.includes(adopted.actionId);
+      const ids = already ? prev : [...prev, adopted.actionId];
+      if (already) setDedupObserved(true);
+      else setAdoptedIds((m) => ({ ...m, [stepIndex]: ids }));
       showToast(
-        nth > 1
-          ? `하나 더 담았어요 — 오늘 ${nth}개 · ${adopted.title}`
-          : `오늘 할 일에 담았어요 — ${adopted.title}`,
+        already
+          ? `이미 오늘 할 일에 있어요 — ${adopted.title}`
+          : ids.length > 1
+            ? `하나 더 담았어요 — 오늘 ${ids.length}개 · ${adopted.title}`
+            : `오늘 할 일에 담았어요 — ${adopted.title}`,
       );
     } catch (err: unknown) {
       // 시트는 닫지 않는다 — 사용자가 자료를 계속 읽거나 다른 걸음을 고를 수 있어야 한다.
@@ -381,7 +390,8 @@ export function InboxScreen() {
           steps={resource.steps}
           onAdoptStep={adoptStep}
           adoptingIndex={adoptingIndex}
-          adoptedCounts={adoptedCounts}
+          adoptedIds={adoptedIds}
+          dedupObserved={dedupObserved}
           error={resource.error}
           onClose={() => setResource(null)}
         />


### PR DESCRIPTION
## 왜 지금 또 고치나

[BE #213](https://github.com/hanium-reaction/reaction-backend/issues/213) 이 어제 올라왔고, **B안(도메인 dedup)** 을 추천합니다.

> `(inbox_item_id, title, target_date)` 로 활성 카드를 먼저 찾아, 있으면 INSERT 하지 않고 그 카드를 200 으로 반환한다.

그게 배포되면 두 번째 탭은 **같은 `actionId`** 를 되돌려주고 카드는 늘지 않습니다. 그런데 직전 #193 은 **탭 수**를 셉니다 — 실제로는 1장인데 "오늘 2개 담았어요" 라고 말하게 됩니다. 고친 문제가 반대 방향으로 되살아나는 셈입니다.

## 고침

받은 `actionId` 로 셉니다. 그러면 BE 가 어느 쪽이든 화면이 사실과 어긋나지 않습니다.

```
adoptedCounts: Record<number, number>  →  adoptedIds: Record<number, string[]>
```

재탭 안내 문구도 **관측을 따릅니다** — 같은 id 를 한 번이라도 받으면 그때부터 "다시 눌러도 하나만 담겨요" 로 바뀝니다. BE 배포 시점을 FE 가 알 필요도, 맞춰 배포할 필요도 없습니다.

## #213 의 FE 권고는 따르지 않았습니다

이슈 본문은 이렇게 적었습니다.

> **FE 는 어느 쪽이든 한 줄 같이 고칠 것**: `disabled={busy || locked || done}`

따르지 않은 이유는 **같은 이슈의 B안과 어긋나기 때문**입니다. B안은 `target_date` 가 다르면 새 카드가 생기도록(= 다음 날 다시 담을 수 있도록) 설계돼 있는데, `done` 으로 막으면 그 정당한 재채택 경로가 UI 에서 죽습니다. BE 가 의도적으로 열어둔 문을 FE 가 닫는 꼴입니다.

막지 않고 **사실대로 말하는** 쪽을 택했습니다. 이견 있으면 알려주세요 — 되돌리기 쉬운 변경입니다.

## 검증 — 두 체제를 각각 흉내내 실측

| | 지금 BE (매번 새 id) | B안 배포 후 (같은 id) |
|---|---|---|
| 토스트 1회 | `오늘 할 일에 담았어요` | `오늘 할 일에 담았어요` |
| 토스트 2회 | `하나 더 담았어요 — 오늘 2개` | `이미 오늘 할 일에 있어요` |
| 걸음 라벨 | `오늘 할 일에 2개 담았어요` | `오늘 할 일에 담았어요` |
| 재탭 안내 | `다시 누르면 하나 더 담아요` | `다시 눌러도 하나만 담겨요` |
| pageErrors | 0 | 0 |

- 404/422 처리 유지(원시 코드 노출 없음, 시트 유지)
- 13개 화면 회귀 — 런타임 에러 0
- `npx tsc --noEmit` 0 errors · `check:api` PASS · `npm run build` 성공

관련: BE #213 · BE #214(취소 수단 부재) · #191 · #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)