### PR TITLE
fix(inbox): 이미 담은 걸음은 다시 못 누르게 막는다 (BE #213 권고 수용)

### DIFF
--- a/src/components/ResourceViewerSheet.tsx
+++ b/src/components/ResourceViewerSheet.tsx
@@ -26,19 +26,15 @@ interface ResourceViewerSheetProps {
   /** 채택 진행 중인 걸음 인덱스. 그 항목만 비활성·문구 변경. */
   adoptingIndex?: number | null;
   /**
-   * 걸음별로 오늘 담긴 카드의 actionId 목록. 탭 수가 아니라 id 를 담는 이유는,
-   * BE 가 dedup 을 넣으면(BE #213) 두 번째 탭이 같은 id 를 되돌려주기 때문이다 —
-   * 그때 개수를 세면 실제로는 1장인데 2개라고 말하게 된다.
+   * 이미 담은 걸음의 키 집합(`${inboxId}:${stepIndex}`). 담긴 걸음은 다시 누를 수 없다.
    *
-   * 막지는 않는다. 같은 걸음을 두 번 하려는 게 정당할 수 있어서(BE 도 그래서 안 막는다).
-   * 대신 몇 개 담겼는지와 다시 누르면 어떻게 되는지를 미리 알린다.
+   * BE 가 같은 걸음을 몇 번이든 새 카드로 만들고(BE #213), 잘못 생긴 카드를 지울
+   * 엔드포인트도 없다(BE #214). 서버가 멱등해질 때까지는 화면이 막는 수밖에 없다.
+   * 다음 날 다시 담는 건 막히지 않는다 — 이 집합은 세션 안에서만 산다.
    */
-  adoptedIds?: Record<number, string[]>;
-  /**
-   * 같은 걸음을 다시 담았을 때 서버가 같은 actionId 를 되돌려준 적이 있는가.
-   * BE 가 dedup 을 넣었다는 관측 — 안내 문구를 사실에 맞춰 뒤집는 데만 쓴다.
-   */
-  dedupObserved?: boolean;
+  adoptedKeys?: Set<string>;
+  /** 지금 열린 자료의 inboxId. adoptedKeys 조회에만 쓴다. */
+  inboxId?: string;
 }
 
 // 코드·표처럼 넓은 요소는 자기 컨테이너에서만 가로 스크롤 — 본문(모바일)이 가로로 밀리지 않게.
@@ -60,8 +56,8 @@ export function ResourceViewerSheet({
   steps = [],
   onAdoptStep,
   adoptingIndex = null,
-  adoptedIds = {},
-  dedupObserved = false,
+  adoptedKeys,
+  inboxId = '',
 }: ResourceViewerSheetProps) {
   const bodyMd = markdown === null ? null : stripLeadingTitle(markdown, title);
   return (
@@ -156,15 +152,14 @@ export function ResourceViewerSheet({
             <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
               {steps.map((step, i) => {
                 const busy = adoptingIndex === i;
-                const count = (adoptedIds[i] ?? []).length;
-                const done = count > 0;
+                const done = adoptedKeys?.has(`${inboxId}:${i}`) ?? false;
                 // 다른 걸음을 채택하는 중엔 전부 잠근다 — 연타로 카드가 여러 개 생기는 걸 막는다.
                 const locked = adoptingIndex !== null && !busy;
                 return (
                   <button
                     key={i}
                     onClick={() => onAdoptStep(i)}
-                    disabled={busy || locked}
+                    disabled={busy || locked || done}
                     style={{
                       display: 'flex',
                       alignItems: 'flex-start',
@@ -174,7 +169,7 @@ export function ResourceViewerSheet({
                       borderRadius: 12,
                       border: `1px solid ${done ? 'var(--coral-200)' : 'var(--sand-200)'}`,
                       background: done ? 'var(--brand-soft)' : 'var(--surface-raised)',
-                      cursor: busy || locked ? 'default' : 'pointer',
+                      cursor: busy || locked || done ? 'default' : 'pointer',
                       opacity: locked ? 0.5 : 1,
                       fontFamily: 'inherit',
                       textAlign: 'left',
@@ -207,20 +202,7 @@ export function ResourceViewerSheet({
                       </span>
                       {(busy || done) && (
                         <span style={{ display: 'block', marginTop: 3, fontSize: 11, color: 'var(--brand-ink)', fontWeight: 600 }}>
-                          {busy
-                            ? '담는 중…'
-                            : count > 1
-                              ? `오늘 할 일에 ${count}개 담았어요`
-                              : '오늘 할 일에 담았어요'}
-                        </span>
-                      )}
-                      {/* 체크만 두면 '끝났다' 로 읽혀, 무심코 다시 눌렀을 때 조용히 중복이
-                          생긴다(#191). 다시 누르면 어떻게 되는지를 미리 말해준다.
-                          문구는 관측한 사실을 따른다 — dedup 을 한 번이라도 확인했으면
-                          그때부터 "하나만" 이다. BE 배포 시점을 FE 가 알 필요가 없다. */}
-                      {done && !busy && (
-                        <span style={{ display: 'block', marginTop: 2, fontSize: 10.5, color: 'var(--text-3)' }}>
-                          {dedupObserved ? '다시 눌러도 하나만 담겨요' : '다시 누르면 하나 더 담아요'}
+                          {busy ? '담는 중…' : '오늘 할 일에 담았어요'}
                         </span>
                       )}
                     </span>

--- a/src/screens/InboxScreen.tsx
+++ b/src/screens/InboxScreen.tsx
@@ -62,9 +62,9 @@ export function InboxScreen() {
   };
   const [adoptingIndex, setAdoptingIndex] = useState<number | null>(null);
   // 걸음별로 담긴 카드의 actionId 목록. 개수만 세면 BE 가 dedup 을 넣는 순간 틀어진다.
-  const [adoptedIds, setAdoptedIds] = useState<Record<number, string[]>>({});
-  // 서버가 같은 카드를 되돌려준 적이 있는가 — BE dedup(#213) 이 배포됐다는 관측.
-  const [dedupObserved, setDedupObserved] = useState(false);
+  // 이미 담은 걸음. `${inboxId}:${stepIndex}` 로 키를 잡아 시트를 닫았다 다시 열어도 남는다 —
+  // 열 때마다 비우면 시트만 다시 열면 또 담기니, 막는 의미가 없다.
+  const [adoptedKeys, setAdoptedKeys] = useState<Set<string>>(new Set());
 
   const fetchList = (status?: string) => {
     setIsLoading(true);
@@ -170,7 +170,6 @@ export function InboxScreen() {
     const slug = it.resourceSlug;
     if (!slug) return;
     setAdoptingIndex(null);
-    setAdoptedIds({});
     setResource({ inboxId: it.inboxId, title: it.rawText, markdown: null, error: null, steps: [] });
     try {
       const res = await inboxApi.resource(slug);
@@ -199,21 +198,10 @@ export function InboxScreen() {
     setAdoptingIndex(stepIndex);
     try {
       const adopted = await inboxApi.adoptStep(resource.inboxId, stepIndex);
-      // 탭 횟수가 아니라 받은 actionId 로 센다. 지금 BE 는 누를 때마다 새 카드를 만들지만
-      // (BE #213), dedup 이 들어오면 같은 actionId 가 되돌아온다 — 그때 "하나 더 담았어요"
-      // 라고 말하면 거짓말이 된다. id 를 세면 어느 쪽이든 화면이 사실과 어긋나지 않는다.
-      const prev = adoptedIds[stepIndex] ?? [];
-      const already = prev.includes(adopted.actionId);
-      const ids = already ? prev : [...prev, adopted.actionId];
-      if (already) setDedupObserved(true);
-      else setAdoptedIds((m) => ({ ...m, [stepIndex]: ids }));
-      showToast(
-        already
-          ? `이미 오늘 할 일에 있어요 — ${adopted.title}`
-          : ids.length > 1
-            ? `하나 더 담았어요 — 오늘 ${ids.length}개 · ${adopted.title}`
-            : `오늘 할 일에 담았어요 — ${adopted.title}`,
-      );
+      // BE 는 같은 걸음을 몇 번이든 새 카드로 만든다(BE #213) — 그리고 잘못 생긴 카드를
+      // 지울 엔드포인트가 없다(BE #214). 서버가 멱등해질 때까지 화면에서 두 번째 탭을 막는다.
+      setAdoptedKeys((s) => new Set(s).add(`${resource.inboxId}:${stepIndex}`));
+      showToast(`오늘 할 일에 담았어요 — ${adopted.title}`);
     } catch (err: unknown) {
       // 시트는 닫지 않는다 — 사용자가 자료를 계속 읽거나 다른 걸음을 고를 수 있어야 한다.
       //
@@ -390,8 +378,8 @@ export function InboxScreen() {
           steps={resource.steps}
           onAdoptStep={adoptStep}
           adoptingIndex={adoptingIndex}
-          adoptedIds={adoptedIds}
-          dedupObserved={dedupObserved}
+          adoptedKeys={adoptedKeys}
+          inboxId={resource.inboxId}
           error={resource.error}
           onClose={() => setResource(null)}
         />


### PR DESCRIPTION
[BE #213](https://github.com/hanium-reaction/reaction-backend/issues/213) 이 FE 에 요청한 대로 `disabled={busy || locked || done}` 를 넣습니다.

## 앞선 판단을 뒤집는 이유

#194 에서 저는 막지 않았습니다. 근거는 "막으면 BE B안이 열어둔 재채택(다음 날 다시 담기)이 UI 에서 죽는다" 였는데, **그 전제가 틀렸습니다.**

`openResource` 가 시트를 열 때마다 채택 기록을 비웁니다. 즉 `done` 은 **"지금 이 세션에서 담았다"** 는 뜻일 뿐이고 세션이 끝나면 풀립니다. 막아서 실제로 죽는 건 *한 자리에서 같은 걸음을 두 번 담기* 하나뿐입니다.

반대로 **막지 않아 생기는 손해는 실재합니다** — BE 에는 잘못 생긴 카드를 지울 엔드포인트가 **아예 없어서**([BE #214](https://github.com/hanium-reaction/reaction-backend/issues/214)) 오탭 하나가 영구히 남거나, 안 한 실행을 체크인으로 처리해 완료율·`category_success_rate` 를 오염시킵니다. 저울이 한쪽으로 확실히 기웁니다.

## 다시 열어도 유지됩니다

키를 `${inboxId}:${stepIndex}` 로 잡고 `openResource` 에서 비우지 않습니다. **열 때마다 비우면 시트만 다시 열면 또 담기니 막는 의미가 없습니다.** 세션 안에서만 살아서 다음 날 다시 담는 경로는 그대로 열려 있습니다.

## 걷어낸 것

두 번째 탭이 불가능해져 아래가 전부 죽은 코드가 됐습니다.

- `adoptedIds` (actionId 개수 세기) → `adoptedKeys` (담긴 걸음 키 집합)
- `오늘 할 일에 N개 담았어요` / `하나 더 담았어요` 문구
- `다시 누르면 하나 더 담아요` 안내 · `dedupObserved` 관측 플래그

## 검증 — 실측

```
1회 후 adopt 호출      1   버튼 disabled O
2회 강제 클릭 후       1   ← 늘지 않음
시트 닫고 재오픈       disabled 유지, 탭해도 호출 1
다른 걸음              안 막힘 — 담으면 호출 2
pageErrors             0
```

- 404/422 처리 유지(원시 코드 노출 없음, 시트 유지)
- 13개 화면 회귀 — 런타임 에러 0
- `npx tsc --noEmit` 0 errors · `check:api` PASS · `npm run build` 성공

**BE 쪽 서버 멱등(#213 B안)은 여전히 필요합니다.** 이 변경은 화면 세션 안에서만 막습니다 — 새로고침하거나 다른 기기에서 열면 다시 담을 수 있습니다.

관련: BE #213 · BE #214 · #191 · #193 · #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)