### PR TITLE
feat(today): 오늘 이미 잡혀 있는 고정 일정을 보여준다

### DIFF
--- a/src/components/FixedScheduleStrip.tsx
+++ b/src/components/FixedScheduleStrip.tsx
@@ -1,0 +1,74 @@
+import { Lock } from '@phosphor-icons/react';
+import type { AgendaFixedSchedule } from '../types/api';
+
+// 백엔드가 "09:00" 으로도, "09:00:00" 으로도 줄 수 있다. 초는 화면에서 의미가 없다.
+const hhmm = (t: string) => t.slice(0, 5);
+
+interface FixedScheduleStripProps {
+  items: AgendaFixedSchedule[];
+}
+
+/**
+ * 오늘 이미 잡혀 있는 것 — 수업·알바처럼 우리가 옮길 수 없는 시간.
+ *
+ * 오늘 화면이 할 일 카드만 보여주면 "하루가 통째로 비어 있다" 는 인상을 준다.
+ * 실제로는 9시부터 수업인데 앱만 그걸 모르는 상태라, 계획이 현실과 어긋나 보인다.
+ * 그래서 카드보다 먼저, 하루의 테두리로 놓는다.
+ *
+ * 다만 이건 **실행 대상이 아니다** — 완료·실패를 찍을 수 없다. 그래서 카드처럼
+ * 생기면 안 된다. 버튼도 그림자도 없이, 배경에 눌러앉은 띠 하나로 둔다.
+ *
+ * 비어 있으면 아무것도 그리지 않는다. "고정 일정 없음" 을 띄우면 사용자가
+ * 등록하지 않은 것뿐인데 앱이 뭔가 잘못된 것처럼 읽힌다.
+ */
+export function FixedScheduleStrip({ items }: FixedScheduleStripProps) {
+  if (items.length === 0) return null;
+
+  // 백엔드 정렬을 믿지 않는다 — 시간순이 아니면 하루의 순서로 안 읽힌다.
+  const sorted = [...items].sort((a, b) => a.startTime.localeCompare(b.startTime));
+
+  return (
+    <section
+      aria-label="오늘 고정 일정"
+      style={{
+        background: 'var(--sand-100)',
+        border: '1px solid var(--sand-200)',
+        borderRadius: 14,
+        padding: '10px 12px',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 6,
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
+        <Lock size={11} weight="fill" color="var(--text-3)" />
+        <span style={{ fontSize: 11, fontWeight: 700, color: 'var(--text-3)', letterSpacing: '0.01em' }}>
+          오늘 이미 잡혀 있어요
+        </span>
+      </div>
+      {sorted.map((s) => (
+        <div key={s.scheduleId} style={{ display: 'flex', alignItems: 'baseline', gap: 10 }}>
+          <span
+            className="tnum"
+            style={{ fontSize: 11.5, fontWeight: 700, color: 'var(--text-2)', fontFamily: 'var(--font-mono)', flexShrink: 0 }}
+          >
+            {hhmm(s.startTime)}–{hhmm(s.endTime)}
+          </span>
+          <span
+            style={{
+              fontSize: 13,
+              color: 'var(--text-1)',
+              fontWeight: 500,
+              minWidth: 0,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {s.title}
+          </span>
+        </div>
+      ))}
+    </section>
+  );
+}

--- a/src/screens/TodayScreen.tsx
+++ b/src/screens/TodayScreen.tsx
@@ -7,7 +7,7 @@ import {
   Trash,
 } from '@phosphor-icons/react';
 import type { Task, TaskStatus } from '../types';
-import type { AgendaCard, ApiGoal, WeeklyPlanResponse } from '../types/api';
+import type { AgendaCard, AgendaFixedSchedule, ApiGoal, WeeklyPlanResponse } from '../types/api';
 import { FAIL_REASONS, GOAL_CATEGORY_OPTIONS } from '../data';
 import { useNavigation } from '../contexts/NavigationContext';
 import { goalsApi, habitsApi, plansApi, reflectionApi, todayApi } from '../lib/api';
@@ -19,6 +19,7 @@ import { TaskRow } from '../components/TaskRow';
 import { ProgressSheet } from '../components/ProgressSheet';
 import { EmptyState } from '../components/EmptyState';
 import { SkeletonBlock } from '../components/SkeletonBlock';
+import { FixedScheduleStrip } from '../components/FixedScheduleStrip';
 import { Gear, Target, DotsThreeVertical } from '@phosphor-icons/react';
 
 // Today 헤더 우상단 — 목표 관리·설정을 하나의 ⋮ 메뉴로 통합 (아이콘 2개 → 1개).
@@ -162,6 +163,8 @@ export function MergedTodayScreen({ tasks, onOpen, onMarkDone, onPartial, onFail
   const [usingRealAgenda, setUsingRealAgenda] = useState(false);
   // 첫 agenda fetch 가 settle 되기 전엔 더미가 깜빡이지 않도록 스켈레톤만 노출.
   const [agendaLoading, setAgendaLoading] = useState(true);
+  // 오늘 요일에 걸린 고정 일정(수업·알바). 카드가 아니라 하루의 테두리로 쓴다.
+  const [fixedSchedules, setFixedSchedules] = useState<AgendaFixedSchedule[]>([]);
 
   // /today/agenda 연동. 성공 시 actions → Task[] 매핑(빈 배열이어도 연결로 간주)해
   // 부모(ReActionMerged)의 tasks 를 이걸로 교체한다 — openTask/markDone 등이 같은
@@ -173,6 +176,7 @@ export function MergedTodayScreen({ tasks, onOpen, onMarkDone, onPartial, onFail
       (agenda) => {
         if (cancelled) return;
         setUsingRealAgenda(true);
+        setFixedSchedules(agenda.fixedSchedules ?? []);
         onAgendaLoaded((agenda.cards ?? []).map(actionToTask));
       },
       () => { /* 네트워크/오류 — 더미 그대로, usingRealAgenda=false */ },
@@ -389,6 +393,10 @@ export function MergedTodayScreen({ tasks, onOpen, onMarkDone, onPartial, onFail
             <HeaderMenu />
           </div>
         </div>
+
+        {/* 고정 일정은 할 일이 있든 없든 하루의 테두리다 — 카드 분기 바깥에 둔다.
+            "오늘 등록된 일정이 없어요" 아래에 수업 3시간이 떠 있는 게 사실에 맞다. */}
+        {!agendaLoading && <FixedScheduleStrip items={fixedSchedules} />}
 
         {/* 첫 agenda fetch 가 끝나기 전엔 스켈레톤. 비었으면 배너 하나만(에러 or 안내),
             일정이 있으면 hero + row. 예전엔 배너 2개 + 빈 hero 가 겹쳐 3중으로 떴다. */}

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -413,12 +413,22 @@ export interface AgendaCard {
   firstStep: string | null;
 }
 
+// /today/agenda 안의 고정 일정 행. 관리 화면의 FixedSchedule 과 다른 스키마다 —
+// 여긴 이미 '오늘 요일에 걸린 것' 만 골라 오므로 daysOfWeek 가 없다.
+// (FixedSchedule 로 선언돼 있던 것을 바로잡음 — daysOfWeek 를 읽으면 undefined 였다.)
+export interface AgendaFixedSchedule {
+  scheduleId: string;
+  title: string;
+  startTime: string; // HH:MM
+  endTime: string; // HH:MM
+}
+
 export interface TodayAgenda {
   date: string;
   brief: MorningBrief | null;
   cards: AgendaCard[];
   habits: HabitInstance[];
-  fixedSchedules: FixedSchedule[];
+  fixedSchedules: AgendaFixedSchedule[];
 }
 
 export type CompletionStatus = 'done' | 'partial_done' | 'failed' | 'over_done';


### PR DESCRIPTION
## 배경

`/today/agenda` 는 `fixedSchedules` 를 **계속 주고 있었는데 화면이 한 번도 읽지 않았습니다.** 그래서 9시부터 수업인 날에도 오늘 화면은 하루가 통째로 빈 것처럼 보였습니다 — 계획이 현실과 어긋나 보이는 가장 큰 원인이었습니다.

## 타입이 스펙과 어긋나 있었습니다

```
fixedSchedules: FixedSchedule[]  →  AgendaFixedSchedule[]
```

관리 화면의 `FixedSchedule` 로 선언돼 있었는데 실제 스키마는 다릅니다 — agenda 는 이미 **'오늘 요일에 걸린 것'만** 골라 오므로 `daysOfWeek` 가 없습니다. 읽었다면 런타임에 `undefined` 였습니다.

경로 단위인 `check:api` 로는 잡히지 않는 **필드 드리프트**라, `openapi.json` 을 근거로 바로잡았습니다. (`MorningBrief` 때와 같은 종류입니다.)

## 카드가 아니라 하루의 테두리

고정 일정은 **실행 대상이 아닙니다** — 완료·실패를 찍을 수 없습니다. 그래서 카드처럼 생기면 안 됩니다. 버튼도 그림자도 없이 배경에 눌러앉은 띠로 두고, 히어로 카드 **위**(하루의 테두리 자리)에 놓았습니다.

**카드 유무 분기 바깥**에 둡니다. "오늘 등록된 일정이 없어요" 아래에 수업 3시간이 떠 있는 게 사실에 맞습니다 — *할 일이 없는 것*과 *하루가 빈 것*은 다릅니다.

비어 있으면 아무것도 그리지 않습니다. "고정 일정 없음" 을 띄우면 등록을 안 한 것뿐인데 뭔가 잘못된 것처럼 읽힙니다.

## 실측

| 경우 | 결과 |
|---|---|
| 일정 O + 카드 O | 띠 렌더 · `09:00–12:00 운영체제 수업` · 가로 넘침 없음 |
| 일정 O + 카드 X | 띠 렌더 (빈 상태 안내와 공존) |
| 일정 X | **렌더 안 함** |
| 뒤섞인 순서 입력 | 시간순 정렬 O |
| `"18:00:00"` 입력 | 초 제거 O |

- pageErrors 0 · 13개 화면 회귀 에러 0
- `npx tsc --noEmit` 0 errors · `check:api` PASS · `npm run build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)