### PR TITLE
fix(today): 히어로 카드를 priority 로 명시적으로 고른다

### DIFF
--- a/src/screens/TodayScreen.tsx
+++ b/src/screens/TodayScreen.tsx
@@ -126,8 +126,15 @@ function actionToTask(a: AgendaCard): Task {
     // 액션 상세(S11)용 — 예전엔 버렸던 whyNow/firstStep 를 살린다.
     whyNow: a.whyNow ?? undefined,
     firstStep: a.firstStep ?? undefined,
+    priority: a.priority,
   };
 }
+
+// 중요한 순서(priority 오름차순, 1이 최우선). 백엔드도 같은 순서로 주지만,
+// 그 배열 순서에 말없이 기대면 중간에 정렬·필터가 하나 끼는 순간 조용히 틀어진다.
+// 값이 없는 카드는 뒤로 — 있는 것보다 앞세울 근거가 없다.
+const byPriority = (a: Task, b: Task) =>
+  (a.priority ?? Number.MAX_SAFE_INTEGER) - (b.priority ?? Number.MAX_SAFE_INTEGER);
 
 // /today/agenda 에는 예약 시각이 없다(AgendaCard 필드에 없음). 시각은 주간 계획의
 // 블록에만 있으므로 actionId 로 조인해서 채운다 — 지어내지 않고 실제 계획값을 쓴다.
@@ -177,7 +184,7 @@ export function MergedTodayScreen({ tasks, onOpen, onMarkDone, onPartial, onFail
         if (cancelled) return;
         setUsingRealAgenda(true);
         setFixedSchedules(agenda.fixedSchedules ?? []);
-        onAgendaLoaded((agenda.cards ?? []).map(actionToTask));
+        onAgendaLoaded((agenda.cards ?? []).map(actionToTask).sort(byPriority));
       },
       () => { /* 네트워크/오류 — 더미 그대로, usingRealAgenda=false */ },
     ).finally(() => { if (!cancelled) setAgendaLoading(false); });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -51,6 +51,8 @@ export interface Task {
   // 액션 상세(S11) — 백엔드 AgendaCard 의 whyNow/firstStep. 있으면 "자세히"로 노출.
   whyNow?: string;
   firstStep?: string;
+  // 백엔드 AgendaCard.priority — 작을수록 중요(1이 최우선). 히어로 카드 선정 기준.
+  priority?: number;
 }
 
 export interface Goal {


### PR DESCRIPTION
## 지금은 우연히 맞습니다

`AgendaCard.priority` 를 화면이 한 번도 읽지 않습니다. 그런데도 히어로 카드가 맞게 뽑히는 이유는 백엔드가 **priority 오름차순으로 정렬해서 주고**, FE 가 그 배열 순서를 그대로 쓰기 때문입니다.

```python
# action_item_repo.py:40
.order_by(ActionItem.priority.asc(), ActionItem.created_at.asc())

# test_today.py — "priority 오름차순 — 1이 먼저"
assert cards[0]["title"] == "캡스톤 설계"   # priority=1
```

문제는 **그 의존이 코드 어디에도 적혀 있지 않다**는 겁니다. `tasks` 사이에 정렬이나 필터가 하나 끼는 순간 히어로가 조용히 엉뚱한 카드를 가리키고, 화면에 "이 순서는 중요도다" 라는 근거가 없어 알아채기도 어렵습니다.

## 고침

```
Task.priority 추가              (작을수록 중요, 1이 최우선)
actionToTask 가 a.priority 를 싣고
onAgendaLoaded 직전에 byPriority 로 정렬
```

- 값이 없는 카드는 **뒤로** — 있는 것보다 앞세울 근거가 없습니다.
- 동점은 안정 정렬이라 서버 순서가 그대로 유지됩니다.
- 백엔드가 계약을 지키는 한 **화면에 보이는 변화는 없습니다.** 어겼을 때만 달라집니다 — 그게 목적입니다.

## 실측 — 서버가 계약을 어긴 순서로 준 경우 (9 → 1 → 5)

```
히어로     "가장 중요한 일" (priority 1)
화면 순서  가장 중요한 일 → 중간 일 → 덜 중요한 일
pageErrors 0
```

정렬 전 코드였다면 배열 첫 번째인 **priority 9 가 히어로**였습니다.

- 13개 화면 회귀 에러 0 · `tsc` 0 errors · `check:api` PASS · `build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)