### PR TITLE
fix(native): 첫 실행에 푸시 권한을 요구하지 않는다

### DIFF
--- a/src/lib/native.ts
+++ b/src/lib/native.ts
@@ -1,5 +1,10 @@
 import { Capacitor } from '@capacitor/core';
 
+/** 네이티브 셸(iOS/Android WebView) 안에서 돌고 있는가. 웹 브라우저면 false. */
+export function isNativeApp(): boolean {
+  return Capacitor.isNativePlatform();
+}
+
 // 네이티브(iOS/Android) 셸 초기화. 웹에선 no-op(main.tsx 가 웹에선 호출하지 않음).
 // 플러그인은 동적 import 로 불러 웹 초기 번들에 네이티브 전용 코드가 안 실리게 한다.
 export async function initNative(): Promise<void> {
@@ -19,32 +24,37 @@ export async function initNative(): Promise<void> {
   }
 
   // Android 하드웨어 뒤로가기: 히스토리가 있으면 뒤로, 없으면 앱 최소화(강제 종료 대신).
-  App.addListener('backButton', ({ canGoBack }) => {
-    if (canGoBack) window.history.back();
-    else App.minimizeApp();
-  });
+  try {
+    await App.addListener('backButton', ({ canGoBack }) => {
+      if (canGoBack) window.history.back();
+      else void App.minimizeApp();
+    });
+  } catch {
+    /* 뒤로가기 배선 실패는 치명적이지 않다 — 스플래시는 반드시 내려야 한다 */
+  }
 
-  await SplashScreen.hide();
-  void registerPush();
+  // 이건 실패하면 안 된다. 안 내려가면 앱이 통째로 스플래시에 가려진다.
+  try {
+    await SplashScreen.hide();
+  } catch {
+    /* 미지원 환경 */
+  }
 }
 
-// 푸시 등록 — 권한 요청 + 디바이스 토큰 수신. 토큰의 백엔드 등록(APNs/FCM 발송용)은
-// BE 계약(reaction-backend, #157)이 준비되면 배선한다. 지금은 안전하게 로깅만 한다.
-async function registerPush(): Promise<void> {
-  try {
-    const { PushNotifications } = await import('@capacitor/push-notifications');
-    const perm = await PushNotifications.requestPermissions();
-    if (perm.receive !== 'granted') return;
-
-    PushNotifications.addListener('registration', (token) => {
-      // TODO(#157): POST 토큰 → 백엔드(APNs/FCM). 현재는 동작 확인용 로깅만.
-      console.info('[push] device token', token.value.slice(0, 12) + '…');
-    });
-    PushNotifications.addListener('registrationError', (err) => {
-      console.warn('[push] registration error', err);
-    });
-    await PushNotifications.register();
-  } catch (e) {
-    console.warn('[push] init skipped', e);
-  }
+// 푸시 권한은 앱 시작 때 요청하지 않는다.
+//
+// 예전엔 initNative() 가 곧바로 requestPermissions() 를 불렀다. 두 가지가 잘못됐다.
+//
+// 1) OS 권한 팝업은 한 번뿐이다. iOS 는 거절당하면 앱에서 다시 띄울 수 없고
+//    (설정 앱으로 직접 들어가야 한다) Android 13+ 도 사실상 같다. 그 한 번을
+//    아직 아무 화면도 못 본 첫 실행 순간에, 왜 필요한지 설명도 없이 써버렸다.
+// 2) 허용을 받아도 아무 일도 일어나지 않았다 — 받은 토큰을 보낼 곳이 없다.
+//    백엔드 POST /notifications/subscribe 는 웹푸시 모양({endpoint, keys})만
+//    받는데 FCM/APNs 디바이스 토큰은 문자열 하나라 들어갈 자리가 없다.
+//    사용자는 알림을 켰다고 믿지만 아무것도 오지 않는다.
+//
+// 백엔드에 디바이스 토큰 엔드포인트가 생기면(#157) 그때 설정 화면의 토글 —
+// 사용자가 알림을 원한다고 말한 순간 — 에서 요청한다.
+export function nativePushReady(): boolean {
+  return false;
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -12,8 +12,12 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
 );
 
 if (Capacitor.isNativePlatform()) {
-  // 네이티브(iOS/Android) 셸: 스플래시·상태바·뒤로가기·푸시 초기화. (SW 는 네이티브에서 불필요)
-  void import('./lib/native').then((m) => m.initNative());
+  // 네이티브(iOS/Android) 셸: 스플래시·상태바·뒤로가기 초기화. (SW 는 네이티브에서 불필요)
+  // 실패해도 앱은 떠야 한다 — 셸 초기화는 부가 기능이고, 여기서 던지면 처리되지 않은
+  // rejection 이 되어 앱이 뜬 첫 순간에 콘솔이 붉어진다(플러그인 누락·구버전 셸 등).
+  void import('./lib/native')
+    .then((m) => m.initNative())
+    .catch((e) => console.warn('[native] 셸 초기화 건너뜀', e));
 } else {
   // 웹(PWA): service worker 등록 — install prompt + Web Push 발판.
   registerServiceWorker();

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { CaretLeft, CaretRight, Sparkle, BellRinging, BellSlash, Shield, Warning, Check, ArrowClockwise, IdentificationCard } from '@phosphor-icons/react';
 import { ApiError, notificationsApi, privacyApi, settingsApi } from '../lib/api';
+import { isNativeApp, nativePushReady } from '../lib/native';
 import { subscribePush, unsubscribePush, getPushPermission } from '../lib/push';
 import { useNavigation } from '../contexts/NavigationContext';
 import type { ConsentRecord, ConsentType, ToneMode, UserSettings } from '../types/api';
@@ -68,7 +69,13 @@ export function SettingsScreen() {
     }
   };
 
+  // 네이티브 셸에서는 웹푸시(service worker + VAPID)가 동작하지 않는다. 그렇다고
+  // 눌리게 두면 "브라우저가 허용을 거부했어요" 라는, 앱에선 말도 안 되는 문구가 뜬다.
+  // 백엔드에 디바이스 토큰 엔드포인트가 생길 때까지(#157) 정직하게 잠가둔다.
+  const pushUnavailable = isNativeApp() && !nativePushReady();
+
   const togglePush = async () => {
+    if (pushUnavailable) return;
     setPushBusy(true);
     try {
       if (!pushEnabled) {
@@ -187,15 +194,21 @@ export function SettingsScreen() {
           <SectionHeader icon={<BellRinging size={11} weight="fill" />}>알림</SectionHeader>
           <button
             onClick={togglePush}
-            disabled={pushBusy}
-            style={{ display: 'flex', alignItems: 'center', gap: 12, width: '100%', padding: '12px 14px', textAlign: 'left', background: 'var(--surface-raised)', border: `1.5px solid ${pushEnabled ? 'var(--brand)' : 'var(--sand-200)'}`, borderRadius: 12, cursor: pushBusy ? 'wait' : 'pointer', fontFamily: 'inherit', opacity: pushBusy ? 0.6 : 1 }}
+            disabled={pushBusy || pushUnavailable}
+            style={{ display: 'flex', alignItems: 'center', gap: 12, width: '100%', padding: '12px 14px', textAlign: 'left', background: 'var(--surface-raised)', border: `1.5px solid ${pushEnabled ? 'var(--brand)' : 'var(--sand-200)'}`, borderRadius: 12, cursor: pushUnavailable ? 'default' : pushBusy ? 'wait' : 'pointer', fontFamily: 'inherit', opacity: pushBusy || pushUnavailable ? 0.6 : 1 }}
           >
             <div style={{ width: 36, height: 36, borderRadius: 10, background: pushEnabled ? 'var(--brand)' : 'var(--sand-100)', color: pushEnabled ? '#FFFCF6' : 'var(--text-2)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
               {pushEnabled ? <BellRinging size={18} weight="fill" /> : <BellSlash size={18} />}
             </div>
             <div style={{ flex: 1 }}>
-              <div style={{ fontWeight: 700, fontSize: 13, color: 'var(--text-1)' }}>웹 푸시 알림</div>
-              <div style={{ fontSize: 11, color: 'var(--text-3)', marginTop: 2 }}>{pushEnabled ? '모닝 브리프·저녁 회고 알림이 켜져 있어요' : '브라우저 알림을 받으려면 켜주세요'}</div>
+              <div style={{ fontWeight: 700, fontSize: 13, color: 'var(--text-1)' }}>{isNativeApp() ? '푸시 알림' : '웹 푸시 알림'}</div>
+              <div style={{ fontSize: 11, color: 'var(--text-3)', marginTop: 2 }}>
+                {pushUnavailable
+                  ? '앱 알림은 아직 준비 중이에요. 준비되면 여기서 켤 수 있어요.'
+                  : pushEnabled
+                    ? '모닝 브리프·저녁 회고 알림이 켜져 있어요'
+                    : '브라우저 알림을 받으려면 켜주세요'}
+              </div>
             </div>
             <Toggle on={pushEnabled} />
           </button>


### PR DESCRIPTION
#157 결정(**Capacitor 래핑**)에 따라 네이티브 셸(#158)을 점검하다 찾은 문제입니다.

## 한 번뿐인 권한 팝업을, 아무것도 못 준 채 써버리고 있었습니다

`initNative()` 가 시작하자마자 `requestPermissions()` 를 불렀습니다. 두 가지가 잘못됐습니다.

**1. OS 권한 팝업은 한 번뿐입니다.** iOS 는 거절당하면 앱에서 다시 띄울 수 없고(설정 앱으로 직접 들어가야 합니다), Android 13+ 도 사실상 같습니다. 그 한 번을 **아직 아무 화면도 못 본 첫 실행 순간에, 왜 필요한지 설명도 없이** 썼습니다.

**2. 허용을 받아도 아무 일도 일어나지 않습니다.** 받은 토큰을 보낼 곳이 없습니다 —

```
POST /notifications/subscribe → PushSubscribeRequest { endpoint, keys }   # 웹푸시(VAPID) 모양
FCM/APNs 디바이스 토큰        → 문자열 하나                                 # 들어갈 자리가 없음
```

사용자는 알림을 켰다고 믿지만 **아무것도 오지 않습니다.**

> 토큰을 `endpoint` 자리에 우겨넣지 않았습니다. 그러면 백엔드가 그걸 웹푸시 주소로 알고 영원히 실패하는 발송을 시도합니다. 백엔드 계약이 생길 때까지는 켜지 않는 게 맞습니다.

## 설정 화면도 정직하게

네이티브 셸에서 웹푸시(service worker + VAPID)는 동작하지 않습니다. 그런데 토글이 눌리게 두면 **"브라우저가 허용을 거부했어요"** 라는, 앱에선 말도 안 되는 문구가 뜹니다. 잠그고 `앱 알림은 아직 준비 중이에요. 준비되면 여기서 켤 수 있어요.` 로 바꿨습니다.

## 셸 초기화 실패가 앱을 깨지 않게

- `main.tsx` 에 `.catch` 가 없어 `initNative()` 가 던지면 **처리되지 않은 rejection** 이 됐습니다.
- `SplashScreen.hide()` **앞단**(`App.addListener`)이 던지면 스플래시가 안 내려가 **앱이 통째로 가려집니다.**

둘 다 격리했습니다.

## 실측 — `window.androidBridge` 를 넣어 Capacitor 의 실제 안드로이드 판별 경로를 태움

| | 플랫폼 | 토글 문구 | 상태 |
|---|---|---|---|
| 웹 | `web` | 웹 푸시 알림 / 브라우저 알림을 받으려면 켜주세요 | 활성 |
| 네이티브 | `android` | **푸시 알림 / 앱 알림은 아직 준비 중이에요** | **잠김** |

- 하드닝 **전** pageErrors 2건(`"App" plugin is not implemented`) → **후 0건**
- 13개 화면 회귀 에러 0 · `tsc` 0 errors · `check:api` PASS · `build` 성공

## 남긴 것

`@capacitor/push-notifications` 의존성과 `capacitor.config.ts` 의 플러그인 설정은 **남겼습니다** — 백엔드 엔드포인트가 생기면 붙일 자리이고, 지웠다 다시 넣으면 네이티브 프로젝트가 흔들립니다.

## 후속 (이 PR 범위 밖)

- **BE**: 디바이스 토큰 등록 엔드포인트(FCM/APNs) — 이게 있어야 네이티브 푸시가 성립합니다
- **계정**: Play Console $25 (Android 우선, BE #138)

🤖 Generated with [Claude Code](https://claude.com/claude-code)