### PR TITLE
fix(intake): 원터치 대답을 '담기' 로 — 즉시 전송 대신 입력창에 쌓는다

### DIFF
--- a/src/screens/GoalIntakeScreen.tsx
+++ b/src/screens/GoalIntakeScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { Sparkle, ArrowUp, ArrowRight } from '@phosphor-icons/react';
+import { Sparkle, ArrowUp, ArrowRight, X } from '@phosphor-icons/react';
 import { ApiError, friendlyError, interviewApi } from '../lib/api';
 import type { InterviewOutcome, InterviewQuestion, InterviewSession, SlotCatalogEntry } from '../types/api';
 import { SetupProgress } from '../components/SetupProgress';
@@ -271,6 +271,17 @@ export function GoalIntakeScreen({ onDone, onOutcome }: GoalIntakeScreenProps) {
     }
   };
 
+  // 입력창을 "쉼표로 구분된 답 목록" 으로 본다. 선택지를 누르면 전송하지 않고 여기에
+  // 담기만 한다 — 인터뷰 답 하나가 계획 전체를 가르는데 오탭을 되돌릴 방법이 없었다.
+  // 같은 걸 다시 누르면 빠진다(토글). 직접 친 글도 그냥 항목 하나로 취급한다.
+  const parts = inputText.split(',').map((t) => t.trim()).filter(Boolean);
+  const isPicked = (v: string) => parts.includes(v.trim());
+  const togglePart = (v: string) => {
+    const t = v.trim();
+    const next = parts.includes(t) ? parts.filter((x) => x !== t) : [...parts, t];
+    setInputText(next.join(', '));
+  };
+
   // chip/select 는 옵션 버튼, 그 외(text/date/time)는 자유 입력.
   const showQuickReplies =
     currentQuestion &&
@@ -377,18 +388,27 @@ export function GoalIntakeScreen({ onDone, onOutcome }: GoalIntakeScreenProps) {
               </div>
             )}
             {showQuickReplies && (
-              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }}>
-                {currentQuestion.options.map((reply, i) => (
+              <>
+              <span style={{ fontSize: 9, color: 'var(--text-3)', fontFamily: 'var(--font-mono)', letterSpacing: '0.06em' }}>
+                탭해서 담기 · 여러 개 골라도 돼요
+              </span>
+              {/* 선택지가 많은 질문에서 이 목록이 화면을 통째로 먹던 문제 — 대화가 위로
+                  밀려 무슨 질문이었는지 안 보였다. 상한을 두고 안에서만 스크롤한다. */}
+              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8, maxHeight: 168, overflowY: 'auto' }}>
+                {currentQuestion.options.map((reply, i) => {
+                  const picked = isPicked(reply);
+                  return (
                   <button
                     key={i}
-                    onClick={() => submit(reply)}
+                    onClick={() => togglePart(reply)}
                     disabled={isTyping}
                     style={{
                       padding: '11px 12px',
                       borderRadius: 12,
-                      border: '1.5px solid var(--sand-200)',
-                      background: 'var(--surface-raised)',
-                      color: 'var(--text-1)',
+                      border: `1.5px solid ${picked ? 'var(--coral-200)' : 'var(--sand-200)'}`,
+                      background: picked ? 'var(--brand-soft)' : 'var(--surface-raised)',
+                      color: picked ? 'var(--coral-700)' : 'var(--text-1)',
+                      fontWeight: picked ? 700 : 400,
                       fontSize: 12,
                       textAlign: 'left',
                       cursor: isTyping ? 'wait' : 'pointer',
@@ -400,16 +420,18 @@ export function GoalIntakeScreen({ onDone, onOutcome }: GoalIntakeScreenProps) {
                   >
                     {reply}
                   </button>
-                ))}
+                  );
+                })}
               </div>
+              </>
             )}
             {!showQuickReplies && currentQuestion.suggestedAnswers && currentQuestion.suggestedAnswers.length > 0 && (
               <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
-                <span style={{ width: '100%', fontSize: 9, color: 'var(--text-3)', fontFamily: 'var(--font-mono)', letterSpacing: '0.06em' }}>추천 답변 · 탭해서 채우기</span>
+                <span style={{ width: '100%', fontSize: 9, color: 'var(--text-3)', fontFamily: 'var(--font-mono)', letterSpacing: '0.06em' }}>추천 답변 · 탭해서 담기</span>
                 {currentQuestion.suggestedAnswers.map((s, i) => (
                   <button
                     key={i}
-                    onClick={() => setInputText(s)}
+                    onClick={() => togglePart(s)}
                     disabled={isTyping}
                     style={{ padding: '8px 12px', borderRadius: 9999, border: '1px solid var(--coral-200)', background: 'var(--brand-soft)', color: 'var(--coral-700)', fontSize: 12, textAlign: 'left', cursor: isTyping ? 'wait' : 'pointer', fontFamily: 'inherit', wordBreak: 'keep-all', opacity: isTyping ? 0.6 : 1 }}
                   >
@@ -463,6 +485,18 @@ export function GoalIntakeScreen({ onDone, onOutcome }: GoalIntakeScreenProps) {
                     outline: 'none',
                   }}
                 />
+              )}
+              {/* 담은 걸 한 번에 비우기 — 여러 개 골라 담다 보면 지우려고 백스페이스를
+                  길게 누르고 있어야 했다. 비어 있으면 자리를 만들지 않는다. */}
+              {inputText.trim() !== '' && (
+                <button
+                  onClick={() => setInputText('')}
+                  disabled={isTyping}
+                  aria-label="입력 지우기"
+                  style={{ width: 44, height: 44, borderRadius: 9999, border: '1px solid var(--sand-200)', background: 'var(--surface-raised)', color: 'var(--text-2)', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: isTyping ? 'wait' : 'pointer', flexShrink: 0, opacity: isTyping ? 0.5 : 1 }}
+                >
+                  <X size={13} weight="bold" />
+                </button>
               )}
               <button
                 onClick={() => submit(inputText)}

--- a/src/screens/WeeklyPlanGenerationScreen.tsx
+++ b/src/screens/WeeklyPlanGenerationScreen.tsx
@@ -487,16 +487,19 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
             })}
           </div>
         </div>
-        {/* 다중 주 계획 주 단위 이동(#119) — 계획이 여러 주에 걸치면 이전/다음 주로 넘겨 본다. */}
+        {/* 다중 주 계획 주 단위 이동(#119) — 계획이 여러 주에 걸치면 이전/다음 주로 넘겨 본다.
+            화살표를 양끝으로 밀지 않고 날짜와 한 덩어리로 가운데 묶는다. 이 화면은 셸이
+            그리는 뒤로가기('‹')가 왼쪽 위에 있어서, 왼쪽 끝에 같은 모양의 '‹' 를 또 두면
+            뒤로가기가 두 개 겹쳐 보인다. */}
         {(maxWeek > minWeek) && (
-          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8, marginBottom: 8 }}>
             <button
               onClick={() => setGenWeekOffset((o) => Math.max(minWeek, o - 1))}
               disabled={genWeekOffset <= minWeek}
               style={{ width: 28, height: 28, borderRadius: 8, border: '1px solid var(--sand-200)', background: 'var(--surface-raised)', color: genWeekOffset <= minWeek ? 'var(--text-3)' : 'var(--text-1)', cursor: genWeekOffset <= minWeek ? 'default' : 'pointer', opacity: genWeekOffset <= minWeek ? 0.4 : 1, fontFamily: 'inherit', fontSize: 14 }}
               aria-label="이전 주"
             >‹</button>
-            <div style={{ flex: 1, textAlign: 'center', fontSize: 12, fontWeight: 700, color: 'var(--text-1)' }}>
+            <div style={{ textAlign: 'center', fontSize: 12, fontWeight: 700, color: 'var(--text-1)' }}>
               <span className="tnum">{weekDates[0].getMonth() + 1}/{weekDates[0].getDate()}–{weekDates[6].getMonth() + 1}/{weekDates[6].getDate()}</span>
               <span style={{ color: 'var(--text-3)', fontWeight: 600, marginLeft: 6 }}>
                 {genWeekOffset === 0 ? '이번 주' : genWeekOffset === 1 ? '다음 주' : genWeekOffset === -1 ? '지난 주' : `${genWeekOffset > 0 ? '+' : ''}${genWeekOffset}주`}


### PR DESCRIPTION
원터치 대답 관련 3건 + 계획 생성 화면의 겹친 뒤로가기를 함께 고칩니다.

## 1. 누르면 전송이 아니라 담깁니다

이전엔 `onClick={() => submit(reply)}` — **오탭 하나가 그대로 확정**됐고 되돌릴 방법이 없었습니다. 인터뷰 답 하나가 계획 전체를 가르는데도요.

입력창을 **"쉼표로 구분된 답 목록"** 으로 보고, 선택지를 누르면 거기에 담습니다.

- 같은 걸 다시 누르면 **빠집니다**(토글)
- **여러 개**를 고를 수 있습니다 — "시간이 부족했어요, 의욕이 안 났어요"
- 담은 뒤 **직접 덧붙일** 수 있습니다 — "주 3회, 근데 시험기간엔 못해요"

탭이 한 번 늘어나는 건 사실입니다. 그래도 이 화면에선 **속도보다 정확도가 비쌉니다** — 잘못 받은 답이 만든 문제가 이미 여러 건 있었습니다(BE #79 무한 재질문, BE #187 목표 소실).

## 2. 추천 답변 칩도 덮어쓰기 → 담기

`setInputText(s)` 라서 두 개 누르면 앞엣것이 사라졌습니다. **"탭해서 채우기"라고 써놓고 두 번째 탭이 첫 번째를 지우는 건 그냥 버그**입니다.

## 3. 화면을 통째로 먹던 문제

선택지가 많은 질문에서 목록이 세로로 계속 늘어나 **대화가 위로 밀려 무슨 질문이었는지 안 보이는** 상태가 됐습니다. 상한 168px + 안에서만 스크롤.

> 실측: 선택지 8개에서 뷰포트의 **54% → 20%**

## 4. 한 번에 지우기

여러 개 담다 보면 지우려고 백스페이스를 길게 눌러야 했습니다. 입력창 옆에 지우기 버튼을 두되 **비어 있으면 자리를 만들지 않습니다.**

## 5. 계획 생성 화면 — 뒤로가기가 두 개로 보이던 것

`weekly-plan` 은 셸이 왼쪽 위에 뒤로가기 `‹` 를 그립니다. 그 **바로 아래** 주 이동 `‹` 가 같은 왼쪽 끝에 있어 똑같은 화살표가 세로로 겹쳐 보였습니다.

화살표를 양끝으로 밀지 않고 **날짜와 한 덩어리로 가운데** 묶었습니다 — 이제 `‹ 3/2–3/8 이번 주 ›` 가 하나의 컨트롤로 읽힙니다.

## 실측

```
1개 담기       "시간이 부족했어요"                     · 전송 발생 안 함
2개 담기       "시간이 부족했어요, 의욕이 안 났어요"
같은 것 재탭   "의욕이 안 났어요"                      · 빠짐
선택지 8개     높이 168px (뷰포트 20%)
지우기         노출 O → 누르면 "" → 버튼 사라짐
```

- pageErrors 0 · 13개 화면 회귀 에러 0
- `tsc` 0 errors · `check:api` PASS · `check:fields` PASS(strict) · `build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)