### PR TITLE
fix(weekly): 3일 뷰에서 3일씩 넘긴다 — 이번 주 목~일이 도달 불가였다

### DIFF
--- a/src/screens/WeeklyCalendarScreen.tsx
+++ b/src/screens/WeeklyCalendarScreen.tsx
@@ -174,12 +174,48 @@ export function WeeklyCalendarScreenV2() {
     return () => ro.disconnect();
   }, []);
 
-  // 3일 뷰에서 보여줄 칸 — 오늘(이번 주가 아니면 월요일)부터 3일.
-  // 주 끝에 걸치면 뒤로 당겨 항상 3칸이 차게 한다.
+  // 3일 뷰의 창 시작 요일. 이 셋으로 7일을 모두 덮는다 — 월화수 / 목금토 / 금토일.
+  // 마지막 창이 금토와 겹치는 건 일요일(6)을 보여주면서 항상 3칸을 채우기 위해서다.
+  //
+  // 예전엔 창이 '오늘부터 3일' 로 고정이고 다음 버튼이 곧장 다음 주로 넘어갔다.
+  // 그래서 오늘이 월요일이면 이번 주 목·금·토·일을 볼 방법이 아예 없었다
+  // (가로 스크롤도 없고 드래그도 보이는 칸 안으로 제한된다).
+  const WINDOWS = [0, 3, 4];
+  const windowIndexFor = (day: number) => (day >= 6 ? 2 : day >= 3 ? 1 : 0);
+  const [winIdx, setWinIdx] = useState(() => (weekOffset === 0 ? windowIndexFor(TODAY) : 0));
+
   const visibleCols = (() => {
     if (dayView === 7) return [0, 1, 2, 3, 4, 5, 6];
-    const anchor = Math.min(isThisWeek ? TODAY : 0, 4);
-    return [anchor, anchor + 1, anchor + 2];
+    const start = WINDOWS[Math.min(winIdx, WINDOWS.length - 1)];
+    return [start, start + 1, start + 2];
+  })();
+
+  // 3일 뷰에서는 3일씩, 7일 뷰에서는 한 주씩 움직인다. 3일 뷰인데 한 주씩 건너뛰면
+  // 중간 요일이 통째로 건너뛰어진다 — 그게 위에 적은 버그였다.
+  const goPrev = () => {
+    if (dayView === 7) return setWeekOffset(weekOffset - 1);
+    if (winIdx > 0) return setWinIdx(winIdx - 1);
+    setWeekOffset(weekOffset - 1);
+    setWinIdx(WINDOWS.length - 1); // 지난 주의 마지막 창(금토일)으로 이어진다
+  };
+  const goNext = () => {
+    if (dayView === 7) return setWeekOffset(weekOffset + 1);
+    if (winIdx < WINDOWS.length - 1) return setWinIdx(winIdx + 1);
+    setWeekOffset(weekOffset + 1);
+    setWinIdx(0); // 다음 주의 첫 창(월화수)으로 이어진다
+  };
+  const goToday = () => {
+    setWeekOffset(0);
+    setWinIdx(windowIndexFor(TODAY));
+  };
+
+  // 헤더는 '실제로 보이는 범위' 를 말해야 한다. 3일만 보이는데 주 전체를 적으면
+  // 라벨이 화면과 다른 말을 하게 된다.
+  const visibleLabel = (() => {
+    if (dayView === 7) return weekLabel;
+    const d0 = new Date(_monday); d0.setDate(d0.getDate() + visibleCols[0]);
+    const d2 = new Date(_monday); d2.setDate(d2.getDate() + visibleCols[2]);
+    return `${d0.getMonth() + 1}/${d0.getDate()}–${d2.getMonth() + 1}/${d2.getDate()}`;
   })();
 
   // 남는 폭을 열이 나눠 갖는다. 너무 좁아지지 않게 하한을 둬서, 폭이 부족하면
@@ -492,26 +528,28 @@ export function WeeklyCalendarScreenV2() {
             주간 리뷰의 "다음 주 계획 확인" 은 weekOffset=1 로 진입한다. */}
         <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
           <button
-            onClick={() => setWeekOffset(weekOffset - 1)}
+            onClick={goPrev}
             style={{ width: 28, height: 28, borderRadius: 8, border: '1px solid var(--sand-200)', background: 'var(--surface-raised)', color: 'var(--text-1)', cursor: 'pointer', fontFamily: 'inherit', fontSize: 14 }}
-            aria-label="이전 주"
+            aria-label={dayView === 3 ? '이전 3일' : '이전 주'}
           >‹</button>
           <div style={{ flex: 1, textAlign: 'center' }}>
-            <span className="tnum" style={{ fontSize: 13, fontWeight: 700, color: 'var(--text-1)' }}>{weekLabel}</span>
+            <span className="tnum" style={{ fontSize: 13, fontWeight: 700, color: 'var(--text-1)' }}>{visibleLabel}</span>
             <span style={{ marginLeft: 6, fontSize: 11, color: 'var(--text-3)', fontWeight: 600 }}>
               {weekOffset === 0 ? '이번 주' : weekOffset === 1 ? '다음 주' : weekOffset === -1 ? '지난 주' : `${weekOffset > 0 ? '+' : ''}${weekOffset}주`}
             </span>
           </div>
           <button
-            onClick={() => setWeekOffset(weekOffset + 1)}
+            onClick={goNext}
             style={{ width: 28, height: 28, borderRadius: 8, border: '1px solid var(--sand-200)', background: 'var(--surface-raised)', color: 'var(--text-1)', cursor: 'pointer', fontFamily: 'inherit', fontSize: 14 }}
-            aria-label="다음 주"
+            aria-label={dayView === 3 ? '다음 3일' : '다음 주'}
           >›</button>
-          {weekOffset !== 0 && (
+          {/* 오늘이 안 보이면 돌아갈 길을 준다. 주만 보고 판단하면, 이번 주인데
+              금토일 창을 보는 상태에서 버튼이 사라져 오늘로 못 돌아간다. */}
+          {(weekOffset !== 0 || (dayView === 3 && !visibleCols.includes(TODAY))) && (
             <button
-              onClick={() => setWeekOffset(0)}
+              onClick={goToday}
               style={{ height: 28, padding: '0 10px', borderRadius: 8, border: '1px solid var(--sand-200)', background: 'var(--surface-raised)', color: 'var(--text-2)', cursor: 'pointer', fontFamily: 'inherit', fontSize: 11, fontWeight: 600 }}
-            >이번 주</button>
+            >오늘</button>
           )}
         </div>
         {/* 조작 안내는 상시 UI 로 두지 않는다 — 헤더가 화면의 35% 를 먹던 원인 중 하나.


### PR DESCRIPTION
## 지적하신 대로였고, 단순한 불편이 아니었습니다

3일 뷰인데 다음/이전 버튼이 **한 주씩** 움직였습니다. 보이는 칸은 `[anchor, anchor+1, anchor+2]` 로 고정(`anchor = min(오늘, 4)`)이라 —

> 오늘이 월요일이면 **월화수만** 보이고, 다음을 누르면 **다음 주 월화수**로 갑니다.

즉 **이번 주 목·금·토·일을 볼 방법이 아예 없었습니다.** 가로 스크롤도 없고(열 폭이 컨테이너에 맞춰 계산됩니다), 드래그도 보이는 칸 안으로 제한됩니다. 화면에서 데이터가 사라지는 문제였습니다.

## 창 3개로 7일을 덮습니다

```
WINDOWS = [0, 3, 4]  →  월화수 / 목금토 / 금토일
```

마지막 창이 금토와 겹치는 건 **일요일(6)을 보여주면서 항상 3칸을 채우기 위해서**입니다. 창 끝에서 다음을 누르면 다음 주 첫 창으로, 첫 창에서 이전을 누르면 지난 주 마지막 창으로 이어집니다.

## 주를 걸치는 창은 만들지 않았습니다

구글 캘린더처럼 연속 슬라이드(`일월화`)를 하려면 두 주의 블록을 합쳐야 합니다. 그런데 이 화면은 **주 단위로 페치하고**(`plansApi.weekly`) **드래그가 요일 인덱스로 서버에 되씁니다**(`plansApi.updateBlock`). 데이터 레이어와 드래그 저장 경로를 같이 갈아야 해서 **위험 대비 이득이 작다**고 판단했습니다. 도달 불가라는 실제 문제는 이 변경으로 해소됩니다.

원하시면 다음 단계로 연속 슬라이드까지 갈 수 있습니다 — 그땐 드래그 저장을 날짜 기준으로 바꾸는 게 선행입니다.

## 헤더가 화면과 다른 말을 하던 것

3일만 보이는데 라벨은 주 전체(`W33 · 8/10–8/16`)를 적고 있었습니다. **보이는 범위**(`8/10–8/12`)로 바꿨습니다. 7일 뷰에선 기존 주 라벨 그대로입니다.

## '오늘' 로 돌아갈 길

기존 '이번 주' 버튼은 `weekOffset` 만 봐서, **이번 주인데 금토일 창을 보는 상태에선 사라졌습니다** — 오늘로 돌아갈 수단이 없었습니다. 오늘이 보이는 칸에 없으면 뜨게 하고 이름도 '오늘' 로 바꿨습니다.

## 실측 (오늘 = 8/10 월)

| 조작 | 결과 |
|---|---|
| 초기 | `8/10–8/12` 월화수 |
| 다음 ×1 | `8/13–8/15` 목금토 |
| 다음 ×2 | `8/14–8/16` 금토일 ← **일요일 도달** |
| 다음 ×3 | `8/17–8/19` 다음 주 월화수 |
| 이전 ×2 | `8/14–8/16` 이번 주로 되돌아옴 |
| 7일 토글 | `W33 · 8/10–8/16`, 버튼 라벨 `다음 주` |
| '오늘' | 보이면 숨김 / 안 보이면 노출 → 누르면 `8/10–8/12` |

- pageErrors 0 · 13개 화면 회귀 에러 0
- `tsc` 0 errors · `check:api` PASS · `check:fields` PASS(strict) · `build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)