### PR TITLE
feat(today): 잘못 담은 카드를 취소한다 — 5초 되돌리기 (BE #214/#218)

### DIFF
--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -10,6 +10,11 @@ export interface ToastProps {
   bottom?: number;
   /** 문구 앞 아이콘. */
   icon?: React.ReactNode;
+  /**
+   * 되돌리기처럼 토스트 안에서 바로 누를 수 있는 행동. 있으면 토스트가
+   * 클릭을 받는다(기본은 pointerEvents: none 이라 아래 화면을 막지 않는다).
+   */
+  action?: { label: string; onClick: () => void };
 }
 
 /**
@@ -20,7 +25,7 @@ export interface ToastProps {
  * 화면 상태를 원래대로 돌렸다는 사실 통지. 사용자가 반드시 읽어야 하는
  * 에러라면 토스트가 아니라 ErrorBanner 를 쓴다 — 토스트는 사라지기 때문.
  */
-export function Toast({ children, tone = 'neutral', bottom, icon }: ToastProps) {
+export function Toast({ children, tone = 'neutral', bottom, icon, action }: ToastProps) {
   return (
     <div
       role="status"
@@ -32,7 +37,7 @@ export function Toast({ children, tone = 'neutral', bottom, icon }: ToastProps) 
         display: 'flex',
         justifyContent: 'center',
         zIndex: 80,
-        pointerEvents: 'none',
+        pointerEvents: action ? 'auto' : 'none',
         padding: '0 16px',
       }}
     >
@@ -53,6 +58,14 @@ export function Toast({ children, tone = 'neutral', bottom, icon }: ToastProps) 
       >
         {icon}
         {children}
+        {action && (
+          <button
+            onClick={action.onClick}
+            style={{ marginLeft: 4, padding: '4px 8px', borderRadius: 8, border: 'none', background: 'rgba(250,246,238,.16)', color: '#FAF6EE', fontSize: 12, fontWeight: 700, fontFamily: 'inherit', cursor: 'pointer', flexShrink: 0 }}
+          >
+            {action.label}
+          </button>
+        )}
       </div>
     </div>
   );

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -547,6 +547,12 @@ export const todayApi = {
   getAction: (actionItemId: string) =>
     request<ActionItem>(`/today/actions/${actionItemId}`),
 
+  // 카드 취소 = soft delete (BE #214). 204, 그리고 이미 보관된 카드를 다시 취소해도 204 다
+  // — FE 가 5초 스낵바 뒤에 호출하므로 재시도가 실패로 보이면 안 된다.
+  // 되돌리기 엔드포인트는 없다. 5초 안에는 요청 자체를 안 보내는 방식으로 덮는다.
+  cancel: (actionItemId: string) =>
+    request<void>(`/today/actions/${actionItemId}/cancel`, { method: 'POST', body: {} }),
+
   start: (actionItemId: string) =>
     request<ExecutionStartResponse>(`/today/actions/${actionItemId}/start`, {
       method: 'POST',

--- a/src/screens/TodayScreen.tsx
+++ b/src/screens/TodayScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import {
   ArrowsClockwise,
   CaretRight,
@@ -10,7 +10,7 @@ import type { Task, TaskStatus } from '../types';
 import type { AgendaCard, AgendaFixedSchedule, ApiGoal, WeeklyPlanResponse } from '../types/api';
 import { FAIL_REASONS, GOAL_CATEGORY_OPTIONS } from '../data';
 import { useNavigation } from '../contexts/NavigationContext';
-import { goalsApi, habitsApi, plansApi, reflectionApi, todayApi } from '../lib/api';
+import { friendlyError, goalsApi, habitsApi, plansApi, reflectionApi, todayApi } from '../lib/api';
 import { localDateStr } from '../lib/dates';
 import { categoryLabel, goalColor } from '../data';
 import { DemoNotice } from '../components/DemoNotice';
@@ -19,6 +19,7 @@ import { TaskRow } from '../components/TaskRow';
 import { ProgressSheet } from '../components/ProgressSheet';
 import { EmptyState } from '../components/EmptyState';
 import { SkeletonBlock } from '../components/SkeletonBlock';
+import { Toast } from '../components/Toast';
 import { FixedScheduleStrip } from '../components/FixedScheduleStrip';
 import { Gear, Target, DotsThreeVertical } from '@phosphor-icons/react';
 
@@ -127,6 +128,7 @@ function actionToTask(a: AgendaCard): Task {
     whyNow: a.whyNow ?? undefined,
     firstStep: a.firstStep ?? undefined,
     priority: a.priority,
+    cancellable: a.cancellable,
   };
 }
 
@@ -162,9 +164,13 @@ function todayShortKo(): string {
   return `${d.getMonth() + 1}월 ${d.getDate()}일 · ${days[d.getDay()]}요일`;
 }
 
-export function MergedTodayScreen({ tasks, onOpen, onMarkDone, onPartial, onFail, onOpenRecovery, onEvening, onAgendaLoaded }: MergedTodayScreenProps) {
+export function MergedTodayScreen({ tasks: allTasks, onOpen, onMarkDone, onPartial, onFail, onOpenRecovery, onEvening, onAgendaLoaded }: MergedTodayScreenProps) {
   const { user } = useNavigation();
   const userName = user?.name ?? '친구';
+
+  // 취소를 누른 카드는 서버 응답을 기다리지 않고 즉시 목록에서 뺀다. 되돌리면 돌아온다.
+  const [hiddenIds, setHiddenIds] = useState<Set<string>>(new Set());
+  const tasks = allTasks.filter((t) => !hiddenIds.has(t.id));
 
   // agenda fetch 성공 = 백엔드 연결됨. 빈 응답이어도 true (연결 ≠ 데이터 존재).
   const [usingRealAgenda, setUsingRealAgenda] = useState(false);
@@ -225,6 +231,58 @@ export function MergedTodayScreen({ tasks, onOpen, onMarkDone, onPartial, onFail
     };
   };
 
+  // 취소 대기 — 5초 안에 '되돌리기' 를 누르면 요청 자체를 보내지 않는다.
+  // BE 에 restore 가 없으므로(#214) 되돌릴 유일한 방법은 "아직 안 보내는 것" 이다.
+  // 5초 안에 앱이 닫히면 요청이 안 나가 카드가 남는다 — 잃는 쪽이 아니라 남는 쪽으로 실패한다.
+  const [pendingCancel, setPendingCancel] = useState<{ id: string; title: string } | null>(null);
+  const cancelTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // 대기 중인 취소를 지금 확정한다(다른 카드를 취소하거나 화면을 떠날 때).
+  const commitCancel = (id: string) => {
+    todayApi.cancel(id).catch((err: unknown) => {
+      // 못 지웠으면 목록에 되돌린다 — 사라진 척하면 사용자는 지워진 줄 안다.
+      setHiddenIds((s) => { const n = new Set(s); n.delete(id); return n; });
+      showToast(friendlyError(err, '취소하지 못했어요. 카드를 되돌렸어요.'), 'error');
+    });
+  };
+
+  const requestCancel = (t: Task) => {
+    // 앞서 대기 중이던 취소가 있으면 먼저 확정한다 — 되돌릴 기회는 하나씩만 준다.
+    if (cancelTimer.current) clearTimeout(cancelTimer.current);
+    if (pendingCancel) commitCancel(pendingCancel.id);
+
+    setHiddenIds((s) => new Set(s).add(t.id));
+    setPendingCancel({ id: t.id, title: t.title });
+    cancelTimer.current = setTimeout(() => {
+      cancelTimer.current = null;
+      commitCancel(t.id);
+      setPendingCancel(null);
+    }, 5000);
+  };
+
+  const undoCancel = () => {
+    if (cancelTimer.current) clearTimeout(cancelTimer.current);
+    cancelTimer.current = null;
+    if (pendingCancel) setHiddenIds((s) => { const n = new Set(s); n.delete(pendingCancel.id); return n; });
+    setPendingCancel(null);
+  };
+
+  // 화면을 떠나면 대기 중인 취소를 확정한다. 타이머만 죽이면 카드는 숨은 채
+  // 서버엔 남아, 다음 진입 때 되살아나 사용자가 취소가 안 먹었다고 느낀다.
+  //
+  // deps 를 [pendingCancel] 로 두면 안 된다 — 취소를 거는 순간 이전 effect 의 정리가
+  // 돌면서 방금 건 타이머를 지운다(그래서 5초가 지나도 아무것도 안 나갔다).
+  // 언마운트에서만 돌도록 빈 deps 로 두고, 최신 값은 ref 로 읽는다.
+  const pendingRef = useRef<{ id: string; title: string } | null>(null);
+  pendingRef.current = pendingCancel;
+  useEffect(() => () => {
+    if (cancelTimer.current) {
+      clearTimeout(cancelTimer.current);
+      const p = pendingRef.current;
+      if (p) commitCancel(p.id);
+    }
+  }, []);
+
   const [detailTask, setDetailTask] = useState<Task | null>(null); // 액션 상세 시트(S11)
   const [failSheet, setFailSheet] = useState<string | null>(null);
   const [partialSheet, setPartialSheet] = useState<string | null>(null);
@@ -237,7 +295,7 @@ export function MergedTodayScreen({ tasks, onOpen, onMarkDone, onPartial, onFail
   // 실패 사유 태그 — 최대 2개 선택(S18). memo 는 선택 자유 텍스트.
   const [failTags, setFailTags] = useState<{ code: string; labelKo: string }[]>([]);
   const [failMemo, setFailMemo] = useState('');
-  const [toast, setToast] = useState<string | null>(null);
+  const [toast, setToast] = useState<{ msg: string; tone: 'ok' | 'error' } | null>(null);
   // 실패 사유 목록 — 백엔드 실패 태그 카탈로그(#17)가 오면 그 tagCode/labelKo 로, 없으면 더미.
   // tagCode 를 같이 들고 있어야 reflectionApi.tagExecution 저장 호출에 실 코드를 실어보낸다(#80).
   const [failReasons, setFailReasons] = useState<{ code: string; labelKo: string }[]>(
@@ -329,7 +387,7 @@ export function MergedTodayScreen({ tasks, onOpen, onMarkDone, onPartial, onFail
       .catch(() => { /* 더미만 보존 */ });
   };
 
-  const showToast = (msg: string) => { setToast(msg); setTimeout(() => setToast(null), 2200); };
+  const showToast = (msg: string, tone: 'ok' | 'error' = 'ok') => { setToast({ msg, tone }); setTimeout(() => setToast(null), 2200); };
   const partialTasks = tasks.filter((t) => t.status === 'partial_done' || t.status === 'recovery_pending');
   const doneTasks = tasks.filter((t) => t.status === 'done');
   // 일정이 0개면 "모두 완료"가 아니다(0===0 이라도) — 없는 걸 다 했다고 하지 않는다.
@@ -578,6 +636,16 @@ export function MergedTodayScreen({ tasks, onOpen, onMarkDone, onPartial, onFail
               </div>
             )}
             <button onClick={() => { const id = detailTask.id; setDetailTask(null); onOpen(id); }} style={{ width: '100%', height: 48, borderRadius: 12, border: 'none', background: 'var(--text-1)', color: '#FAF6EE', fontWeight: 700, fontSize: 15, fontFamily: 'inherit', cursor: 'pointer' }}>시작하기</button>
+            {/* 취소는 BE 가 가능하다고 한 카드에만 보여준다(cancellable). 이미 시작했거나
+                회복·목표에서 파생된 카드는 취소 대상이 아니라 버튼 자체를 만들지 않는다. */}
+            {detailTask.cancellable && (
+              <button
+                onClick={() => { const t = detailTask; setDetailTask(null); requestCancel(t); }}
+                style={{ width: '100%', height: 44, marginTop: 8, borderRadius: 12, border: '1px solid var(--sand-200)', background: 'var(--surface-raised)', color: 'var(--text-2)', fontWeight: 600, fontSize: 13, fontFamily: 'inherit', cursor: 'pointer' }}
+              >
+                이 할 일 취소하기
+              </button>
+            )}
           </div>
         </div>
       )}
@@ -614,11 +682,19 @@ export function MergedTodayScreen({ tasks, onOpen, onMarkDone, onPartial, onFail
         />
       )}
 
+      {/* 취소 되돌리기 — 5초 창. 이게 떠 있는 동안은 서버에 아무것도 보내지 않았다.
+          탭바(하단)를 가리지 않게 위로 띄운다. */}
+      {pendingCancel && (
+        <Toast bottom={96} action={{ label: '되돌리기', onClick: undoCancel }}>
+          취소했어요 — {pendingCancel.title}
+        </Toast>
+      )}
+
       {/* Toast */}
       {toast && (
         <div style={{ position: 'absolute', left: 0, right: 0, bottom: 20, display: 'flex', justifyContent: 'center', zIndex: 80, pointerEvents: 'none' }}>
           <div style={{ background: 'var(--text-1)', color: '#FAF6EE', borderRadius: 9999, padding: '10px 18px', fontSize: 13, fontWeight: 500, display: 'flex', alignItems: 'center', gap: 8, boxShadow: 'var(--shadow-lg)' }}>
-            <span style={{ width: 6, height: 6, background: 'var(--success)', borderRadius: 9999 }} />{toast}
+            <span style={{ width: 6, height: 6, background: toast.tone === 'error' ? 'var(--danger)' : 'var(--success)', borderRadius: 9999 }} />{toast.msg}
           </div>
         </div>
       )}

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -411,6 +411,9 @@ export interface AgendaCard {
   source: string;
   whyNow: string | null;
   firstStep: string | null;
+  // 이 카드를 취소할 수 있는가(BE 파생 필드). 판정 규칙(실행 이력·source·status)은
+  // BE 안에만 두고 FE 는 이 값만 본다 — 규칙을 복제하면 조용히 어긋난다.
+  cancellable: boolean;
 }
 
 // /today/agenda 안의 고정 일정 행. 관리 화면의 FixedSchedule 과 다른 스키마다 —

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -53,6 +53,8 @@ export interface Task {
   firstStep?: string;
   // 백엔드 AgendaCard.priority — 작을수록 중요(1이 최우선). 히어로 카드 선정 기준.
   priority?: number;
+  // 취소 가능 여부(백엔드 판정). 취소 UI 노출에만 쓴다.
+  cancellable?: boolean;
 }
 
 export interface Goal {


### PR DESCRIPTION
BE 가 `POST /today/actions/{id}/cancel` 을 배포했습니다([#218](https://github.com/hanium-reaction/reaction-backend/pull/218)). [#214 에서 우리가 답한 설계](https://github.com/hanium-reaction/reaction-backend/issues/214#issuecomment-5237936947) 그대로 붙입니다.

## 되돌리기를 '아직 안 보내는 것' 으로 구현합니다

BE 에 `restore` 는 **없습니다**(우리가 필요 없다고 답했고, BE 도 안 만들었습니다). 대신:

1. 취소를 누르면 **즉시 카드를 숨기고** 스낵바를 띄웁니다
2. **5초가 지나서야** 서버에 보냅니다
3. 그 안에 '되돌리기' 를 누르면 **요청 자체가 나가지 않습니다**

5초 안에 앱이 닫히면 요청이 안 나가 **카드가 남습니다** — 잃는 쪽이 아니라 남는 쪽으로 실패합니다. 반대(먼저 지우고 나중에 복구)였다면 앱이 죽는 순간 복구 불가입니다.

화면을 떠날 땐 대기 중인 취소를 **확정**합니다. 타이머만 죽이면 카드는 숨은 채 서버엔 남아, 다음 진입 때 되살아납니다.

## 취소 가능 여부는 BE 판정을 그대로 씁니다

`AgendaCard.cancellable`(BE 파생 필드, 우리가 #214 에서 요청한 것)만 보고 버튼을 그립니다. **실행 이력 유무는 FE 가 알 수 없고**, 규칙을 복제하면 조용히 어긋납니다.

## 잡은 버그 — 제가 만든 것

정리 함수의 deps 를 `[pendingCancel]` 로 뒀더니, **취소를 거는 순간 이전 effect 의 정리가 돌면서 방금 건 타이머를 지웠습니다.** 5초가 지나도 아무것도 안 나갔습니다.

언마운트에서만 돌게 빈 deps + ref 로 최신 값을 읽습니다. `tsc` 도 `build` 도 통과하는 종류라 **실측에서만 잡혔습니다.**

## 실측

| 항목 | 결과 |
|---|---|
| 취소 버튼 | `cancellable=true` 만 노출 (false 면 아예 없음) |
| 누른 직후 | 목록에서 사라짐 · 스낵바 `취소했어요 — {제목}` |
| 5초 전 서버 호출 | **0건** |
| 되돌리기 | 카드 복귀 · 이후 끝까지 **0건** |
| 안 되돌리면 | 5초 뒤 **정확히 1건** (`a1`) · 스낵바 사라짐 |
| 실패 시 | 카드를 되돌리고 에러 토스트 |

- pageErrors 0 · 13개 화면 회귀 에러 0
- `tsc` 0 errors · `check:api` PASS · `check:fields` PASS(strict) · `build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)