### PR TITLE
fix(setup): 저장 안 된 걸 저장했다고 말하던 것을 없앤다 + 초기 번들 22% 감축

### DIFF
--- a/src/lib/native.ts
+++ b/src/lib/native.ts
@@ -1,10 +1,5 @@
 import { Capacitor } from '@capacitor/core';
 
-/** 네이티브 셸(iOS/Android WebView) 안에서 돌고 있는가. 웹 브라우저면 false. */
-export function isNativeApp(): boolean {
-  return Capacitor.isNativePlatform();
-}
-
 // 네이티브(iOS/Android) 셸 초기화. 웹에선 no-op(main.tsx 가 웹에선 호출하지 않음).
 // 플러그인은 동적 import 로 불러 웹 초기 번들에 네이티브 전용 코드가 안 실리게 한다.
 export async function initNative(): Promise<void> {
@@ -55,6 +50,4 @@ export async function initNative(): Promise<void> {
 //
 // 백엔드에 디바이스 토큰 엔드포인트가 생기면(#157) 그때 설정 화면의 토글 —
 // 사용자가 알림을 원한다고 말한 순간 — 에서 요청한다.
-export function nativePushReady(): boolean {
-  return false;
-}
+// (판별 함수는 lib/platform.ts 로 옮겼다 — 이 파일을 정적 import 하면 동적 청크가 깨진다.)

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -1,0 +1,26 @@
+import { Capacitor } from '@capacitor/core';
+
+// 플랫폼 판별만 하는 최소 모듈.
+//
+// 이걸 lib/native.ts 에 두면 안 된다 — main.tsx 는 native.ts 를 **동적으로** import 해
+// 네이티브 전용 코드(스플래시·상태바·앱 라이프사이클 플러그인)를 웹 초기 번들에서
+// 떼어내는데, 화면 하나가 그 파일에서 뭔가를 정적 import 하는 순간 그 분리가 통째로
+// 무너진다(rollup: "dynamic import will not move module into another chunk").
+//
+// 그래서 "지금 네이티브인가?" 처럼 화면이 동기적으로 알아야 하는 것만 여기 둔다.
+
+/** 네이티브 셸(iOS/Android WebView) 안에서 돌고 있는가. 웹 브라우저면 false. */
+export function isNativeApp(): boolean {
+  return Capacitor.isNativePlatform();
+}
+
+/**
+ * 네이티브 푸시를 실제로 켤 수 있는가.
+ *
+ * 지금은 항상 false 다 — 백엔드 POST /notifications/subscribe 가 웹푸시 모양
+ * ({endpoint, keys})만 받아서 FCM/APNs 디바이스 토큰을 등록할 곳이 없다(#157).
+ * 토큰 엔드포인트가 생기면 여기만 바꾸면 설정 화면 토글이 열린다.
+ */
+export function nativePushReady(): boolean {
+  return false;
+}

--- a/src/screens/InboxScreen.tsx
+++ b/src/screens/InboxScreen.tsx
@@ -1,8 +1,12 @@
-import { useEffect, useRef, useState } from 'react';
+import { Suspense, lazy, useEffect, useRef, useState } from 'react';
 import { Sparkle, ArrowUp, Archive, TreeStructure, ListChecks, ArrowCounterClockwise, ArrowRight, BookOpen } from '@phosphor-icons/react';
 import { ApiError, friendlyError, inboxApi } from '../lib/api';
 import { Segmented } from '../components/Segmented';
-import { ResourceViewerSheet } from '../components/ResourceViewerSheet';
+// 자료 뷰어는 열 때만 받아온다. 마크다운 파서(react-markdown + remark-gfm + micromark
+// 체인)가 초기 번들에서 가장 무거운 축인데, 정작 쓰는 화면은 이 시트 하나뿐이다.
+const ResourceViewerSheet = lazy(() =>
+  import('../components/ResourceViewerSheet').then((m) => ({ default: m.ResourceViewerSheet })),
+);
 import { InboxItemCard, InboxAction } from '../components/InboxItemCard';
 import { SkeletonBlock } from '../components/SkeletonBlock';
 import { ErrorBanner } from '../components/ErrorBanner';
@@ -372,6 +376,9 @@ export function InboxScreen() {
 
       {/* 추천 자료 뷰어(#163) — 마크다운 본문. 시트가 화면을 덮으므로 최상단에 렌더. */}
       {resource && (
+        // 파서를 받아오는 동안은 아무것도 안 그린다 — 시트는 이미 로딩 스켈레톤을
+        // 가지고 있고, 그 위에 또 다른 로딩을 겹치면 깜빡임만 늘어난다.
+        <Suspense fallback={null}>
         <ResourceViewerSheet
           title={resource.title}
           markdown={resource.markdown}
@@ -383,6 +390,7 @@ export function InboxScreen() {
           error={resource.error}
           onClose={() => setResource(null)}
         />
+        </Suspense>
       )}
 
       {/* 걸음 채택 결과 — 시트가 열린 채로도 보이도록 시트보다 위에 둔다(zIndex 80 > 60).

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { CaretLeft, CaretRight, Sparkle, BellRinging, BellSlash, Shield, Warning, Check, ArrowClockwise, IdentificationCard } from '@phosphor-icons/react';
 import { ApiError, notificationsApi, privacyApi, settingsApi } from '../lib/api';
-import { isNativeApp, nativePushReady } from '../lib/native';
+import { isNativeApp, nativePushReady } from '../lib/platform';
 import { subscribePush, unsubscribePush, getPushPermission } from '../lib/push';
 import { useNavigation } from '../contexts/NavigationContext';
 import type { ConsentRecord, ConsentType, ToneMode, UserSettings } from '../types/api';

--- a/src/screens/SetupScreen.tsx
+++ b/src/screens/SetupScreen.tsx
@@ -120,16 +120,12 @@ export function SetupScreen({ onDone }: SetupScreenProps) {
       setShowForm(false);
       setDraftTitle('');
       setDraftDays(new Set());
-    } catch {
-      // 백엔드 미동작 — 더미라도 추가하되, 임시 저장임을 사용자에게 알린다.
-      setSchedules((s) => [
-        ...s,
-        { scheduleId: `local-${Date.now()}`, title: draftTitle.trim(), daysOfWeek: Array.from(draftDays), startTime: draftStart, endTime: draftEnd },
-      ]);
-      toast.info('임시로 저장했어요 (서버 연결 후 동기화)');
-      setShowForm(false);
-      setDraftTitle('');
-      setDraftDays(new Set());
+    } catch (err: unknown) {
+      // 실패하면 목록에 넣지 않는다. 예전엔 `local-<시각>` id 로 가짜 행을 만들고
+      // "서버 연결 후 동기화" 라고 알렸는데, **동기화하는 코드가 어디에도 없었다** —
+      // 새로고침하면 사라지는 걸 저장됐다고 말한 셈이다. 게다가 폼까지 비워서
+      // 사용자가 다시 입력해야 했다. 폼은 그대로 두고 다시 시도할 수 있게 한다.
+      toast.error(friendlyError(err, '일정을 저장하지 못했어요. 잠시 후 다시 시도해 주세요.'));
     }
   };
 
@@ -171,8 +167,9 @@ export function SetupScreen({ onDone }: SetupScreenProps) {
         });
       }
     } catch {
-      // 백엔드 미동작 — 온보딩 흐름은 끊지 않되 알림 저장은 다음에 동기화됨을 알린다.
-      toast.info('알림 설정은 서버 연결 후 반영돼요');
+      // 온보딩 흐름은 끊지 않되, 저장되지 않았다는 사실을 그대로 말한다.
+      // "서버 연결 후 반영돼요" 는 거짓이었다 — 나중에 반영하는 코드가 없다.
+      toast.error('알림 시간은 저장되지 않았어요. 설정에서 다시 정할 수 있어요.');
     }
     markOnboardingDone();
     onDone();


### PR DESCRIPTION
"더 개선할 게 있나" 를 받고 훑다 나온 3건입니다.

## 1. 거짓 약속 2건 — 가장 심각

고정 일정 추가가 실패하면 이렇게 했습니다.

```ts
setSchedules((s) => [...s, { scheduleId: `local-${Date.now()}`, ... }]);
toast.info('임시로 저장했어요 (서버 연결 후 동기화)');
```

**동기화하는 코드가 어디에도 없습니다.** 그 id 는 그 한 줄에서만 쓰이고 React state 에만 삽니다 — 새로고침하면 사라집니다. 게다가 폼까지 비워서 사용자는 처음부터 다시 입력해야 했습니다.

이제 목록에 넣지 않고, 저장 실패를 그대로 말하고, **폼은 남겨** 다시 시도하게 합니다.

알림 설정도 같았습니다 — `'알림 설정은 서버 연결 후 반영돼요'` 역시 나중에 반영하는 코드가 없습니다. 저장되지 않았다고 말합니다.

## 2. 제가 만든 회귀 — 동적 청크가 깨져 있었습니다

#199 에서 `SettingsScreen` 이 `lib/native.ts` 를 **정적** import 하게 만들었습니다. `main.tsx` 가 그 파일을 **동적으로** 불러 네이티브 전용 코드를 웹 초기 번들에서 떼어내는 구조인데, 화면 하나가 정적으로 끌어오는 순간 분리가 무너집니다.

```
(!) src/lib/native.ts is dynamically imported by src/main.tsx but also
    statically imported by src/screens/SettingsScreen.tsx,
    dynamic import will not move module into another chunk.
```

판별 함수만 `lib/platform.ts` 로 분리했습니다. `native.ts` 는 다시 동적 전용입니다.

## 3. 마크다운 파서를 전 화면이 지고 있었습니다

`react-markdown` + `remark-gfm` + micromark 체인을 쓰는 곳은 **자료 뷰어 시트 하나뿐**인데 초기 번들에 통째로 실려 있었습니다. 열 때 받아오게 바꿨습니다.

| | 전 | 후 |
|---|---|---|
| `index` | 732 KB | **572 KB** (−160 KB, −22%) |
| `ResourceViewerSheet` | — | 159 KB (자료를 열 때만) |
| `native` | (합쳐짐) | 1 KB (다시 분리) |

Suspense fallback 은 `null` 입니다 — 시트가 이미 로딩 스켈레톤을 갖고 있어 그 위에 로딩을 겹치면 깜빡임만 늡니다.

## 검증

- 자료 시트 지연 로딩 후에도 동작 동일 — 담기 1회 / 재탭 차단 / 재오픈 유지 / 다른 걸음 정상
- 404·422 처리 유지(원시 코드 노출 없음, 시트 유지)
- 13개 화면 회귀 에러 0 · `tsc` 0 errors · `check:api` PASS · `check:fields` PASS(strict)

🤖 Generated with [Claude Code](https://claude.com/claude-code)