### PR TITLE
fix: 실패해도 되돌리지 않던 낙관적 갱신 3곳 — 안 된 걸 됐다고 보여줬다

### DIFF
--- a/src/screens/SetupScreen.tsx
+++ b/src/screens/SetupScreen.tsx
@@ -130,8 +130,14 @@ export function SetupScreen({ onDone }: SetupScreenProps) {
   };
 
   const removeSchedule = async (id: string) => {
-    try { await fixedSchedulesApi.remove(id); } catch { /* ok */ }
-    setSchedules((s) => s.filter((x) => x.scheduleId !== id));
+    // 성공했을 때만 목록에서 뺀다. 예전엔 실패해도 지웠는데, 서버엔 남아 있으니
+    // 새로고침하면 되살아났다 — 지워졌다고 믿은 일정이 계획에 계속 반영된다.
+    try {
+      await fixedSchedulesApi.remove(id);
+      setSchedules((s) => s.filter((x) => x.scheduleId !== id));
+    } catch (err: unknown) {
+      toast.error(friendlyError(err, '일정을 삭제하지 못했어요. 잠시 후 다시 시도해 주세요.'));
+    }
   };
 
   // 정책 on/off — optimistic 후 PATCH /time-policies/{id}. 실패 시 롤백.

--- a/src/screens/TodayScreen.tsx
+++ b/src/screens/TodayScreen.tsx
@@ -346,18 +346,30 @@ export function MergedTodayScreen({ tasks: allTasks, onOpen, onMarkDone, onParti
     return () => { cancelled = true; };
   }, []);
 
-  // optimistic update + 백엔드 호출. 실패는 조용히 (mock-and-replace).
+  // 먼저 화면을 바꾸고 서버에 보낸다. 실패하면 **되돌린다** — 예전엔 조용히 삼켰다.
+  // 백엔드 미구현 시절의 습관인데 /habit-instances/{id}/check, DELETE /habits/{id} 는
+  // 이미 다 있다. 실패를 삼키면 사용자는 체크되지 않은 걸 체크됐다고 믿고,
+  // 그 숫자가 주간 지표의 근거라 신뢰가 통째로 깨진다.
   const checkHabit = (id: string) => {
     const target = habits.find((h) => h.id === id);
     if (!target || target.doneDays >= target.targetDays) return;
     setHabits((hs) => hs.map((h) => (h.id === id ? { ...h, doneDays: h.doneDays + 1 } : h)));
-    if (target.instanceId) {
-      habitsApi.check(target.instanceId).catch(() => { /* 401/501 ok */ });
-    }
+    if (!target.instanceId) return;
+    habitsApi.check(target.instanceId).catch((err: unknown) => {
+      setHabits((hs) => hs.map((h) => (h.id === id ? { ...h, doneDays: Math.max(0, h.doneDays - 1) } : h)));
+      showToast(friendlyError(err, '기록하지 못했어요. 다시 눌러 주세요.'), 'error');
+    });
   };
   const removeHabit = (id: string) => {
+    const removed = habits.find((h) => h.id === id);
+    const at = habits.findIndex((h) => h.id === id);
+    if (!removed) return;
     setHabits((hs) => hs.filter((h) => h.id !== id));
-    habitsApi.remove(id).catch(() => { /* ok */ });
+    habitsApi.remove(id).catch((err: unknown) => {
+      // 서버에 남아 있으므로 화면에도 원래 자리로 되돌린다.
+      setHabits((hs) => { const n = [...hs]; n.splice(Math.min(at, n.length), 0, removed); return n; });
+      showToast(friendlyError(err, '삭제하지 못했어요. 잠시 후 다시 시도해 주세요.'), 'error');
+    });
   };
   const addHabit = () => {
     const title = newHabitName.trim();
@@ -692,7 +704,7 @@ export function MergedTodayScreen({ tasks: allTasks, onOpen, onMarkDone, onParti
 
       {/* Toast */}
       {toast && (
-        <div style={{ position: 'absolute', left: 0, right: 0, bottom: 20, display: 'flex', justifyContent: 'center', zIndex: 80, pointerEvents: 'none' }}>
+        <div role="status" aria-live="polite" style={{ position: 'absolute', left: 0, right: 0, bottom: 20, display: 'flex', justifyContent: 'center', zIndex: 80, pointerEvents: 'none' }}>
           <div style={{ background: 'var(--text-1)', color: '#FAF6EE', borderRadius: 9999, padding: '10px 18px', fontSize: 13, fontWeight: 500, display: 'flex', alignItems: 'center', gap: 8, boxShadow: 'var(--shadow-lg)' }}>
             <span style={{ width: 6, height: 6, background: toast.tone === 'error' ? 'var(--danger)' : 'var(--success)', borderRadius: 9999 }} />{toast.msg}
           </div>


### PR DESCRIPTION
#209 에 이어 같은 계열을 더 찾았습니다. 화면을 먼저 바꾸고 서버에 보내는데, **실패해도 되돌리지 않고 조용히 삼켰습니다.**

| 위치 | 증상 |
|---|---|
| `TodayScreen.checkHabit` | 체크 실패해도 **카운트가 올라간 채로** 남음 |
| `TodayScreen.removeHabit` | 삭제 실패해도 **목록에서 사라진 채로** 남음 |
| `SetupScreen.removeSchedule` | 삭제 실패해도 사라짐 — **서버엔 남아 있음** |

습관 체크가 특히 나쁩니다. **그 숫자가 주간 지표의 근거**라, 안 된 체크를 됐다고 보여주면 이후 통계가 통째로 어긋납니다. 고정 일정은 새로고침하면 되살아나서, **지웠다고 믿은 일정이 계획에 계속 반영**됩니다.

## '미구현이라 무시' 전제는 끝났습니다

주석이 `/* 401/501 ok */`, `mock-and-replace` 라고 적혀 있었는데 지금은 스펙에 전부 있습니다.

```
POST   /habit-instances/{instance_id}/check
DELETE /habits/{habit_id}
DELETE /fixed-schedules/{schedule_id}
```

## 고침

셋 다 실패 시 원래 상태로 되돌리고 사유를 알립니다.

- `removeHabit` 은 **원래 자리(index)로** 되돌립니다 — 맨 끝에 붙이면 목록이 뒤섞인 것처럼 보입니다.
- `removeSchedule` 은 **성공했을 때만** 목록에서 뺍니다.

## 곁들여 — 오늘 화면 토스트에 role 이 없었습니다

에러 문구가 떠도 스크린리더가 못 읽었습니다. `role="status"` + `aria-live="polite"` 추가.

## 실측 — 체크 API 를 500 으로 강제

```
성공 : 1 → 2
실패 : 1 → (2) → 1 로 복귀 · "기록하지 못했어요. 다시 눌러 주세요."
role=status 노출 O · pageErrors 0
```

- 13개 화면 회귀 에러 0 · `tsc` 0 errors · `check:api` PASS · `check:fields` PASS(strict) · `build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)