### PR TITLE
design: 타이포 토대 정리 + 탭바 — 'AI 같다' 의 원인부터 걷어낸다

### DIFF
--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -320,9 +320,8 @@ function BootSplash({ label }: { label?: string }) {
     >
       <div
         style={{
-          fontFamily: 'var(--font-mono)',
           fontSize: 11,
-          letterSpacing: '0.12em',
+          letterSpacing: '0',
           color: 'var(--text-3)',
         }}
       >
@@ -364,9 +363,8 @@ function BootFailed({
     >
       <div
         style={{
-          fontFamily: 'var(--font-mono)',
           fontSize: 11,
-          letterSpacing: '0.12em',
+          letterSpacing: '0',
           color: 'var(--text-3)',
         }}
       >

--- a/src/app/DesktopSidebar.tsx
+++ b/src/app/DesktopSidebar.tsx
@@ -72,7 +72,7 @@ export function DesktopSidebar() {
       ) : (
         /* 온보딩 중: 진행 단계 힌트 */
         <div style={{ padding: '8px 12px', fontSize: 12, color: 'var(--text-3)', lineHeight: 1.6 }}>
-          <div style={{ fontWeight: 600, color: 'var(--brand-ink)', marginBottom: 4, fontSize: 11, letterSpacing: '0.08em', textTransform: 'uppercase' }}>
+          <div style={{ fontWeight: 600, color: 'var(--brand-ink)', marginBottom: 4, fontSize: 11, letterSpacing: '0', textTransform: 'uppercase' }}>
             온보딩
           </div>
           목표 파악 → 분류 → 일정 → 계획 → 마무리 확인. 다섯 단계만 지나면 앱을 시작할 수 있어요.

--- a/src/app/ReActionMerged.tsx
+++ b/src/app/ReActionMerged.tsx
@@ -77,8 +77,8 @@ function MergedTopNav({ screen, onBack }: { screen: ScreenId; onBack: () => void
       ) : (
         <div style={{
           display: 'flex', alignItems: 'center', gap: 6,
-          fontSize: 10, fontFamily: 'var(--font-mono)',
-          letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--text-2)',
+          fontSize: 12, fontWeight: 700,
+          letterSpacing: '-0.01em', color: 'var(--text-2)',
         }}>
           <div style={{ width: 5, height: 5, borderRadius: 9999, background: 'var(--brand)' }} />
           {meta.label}

--- a/src/components/AiDraftCard.tsx
+++ b/src/components/AiDraftCard.tsx
@@ -100,8 +100,7 @@ export function AiDraftCard({
           gap: 6,
           fontSize: 11,
           fontWeight: 700,
-          letterSpacing: '0.06em',
-          textTransform: 'uppercase',
+          letterSpacing: '0',
           color: accentColor,
           fontFamily: 'var(--font-mono, monospace)',
         }}

--- a/src/components/BlockEditSheet.tsx
+++ b/src/components/BlockEditSheet.tsx
@@ -49,12 +49,12 @@ export function BlockEditSheet({ block, existingCategories, durations, minuteSte
         </div>
 
         <div style={{ marginBottom: 14 }}>
-          <label style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-3)', letterSpacing: '0.04em', textTransform: 'uppercase', display: 'block', marginBottom: 6 }}>제목</label>
+          <label style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-3)', letterSpacing: '0.04em', display: 'block', marginBottom: 6 }}>제목</label>
           <input value={title} onChange={(e) => setTitle(e.target.value)} style={{ width: '100%', height: 44, borderRadius: 12, border: '1px solid var(--sand-200)', background: 'var(--surface-ground)', padding: '0 14px', fontSize: 14, fontFamily: 'inherit', color: 'var(--text-1)', outline: 'none', boxSizing: 'border-box' }} />
         </div>
 
         <div style={{ marginBottom: 14 }}>
-          <label style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-3)', letterSpacing: '0.04em', textTransform: 'uppercase', display: 'block', marginBottom: 6 }}>요일</label>
+          <label style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-3)', letterSpacing: '0.04em', display: 'block', marginBottom: 6 }}>요일</label>
           <div style={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', gap: 4 }}>
             {DAYS_KO.map((d, i) => (
               <button key={d} onClick={() => setDay(i)} style={{ height: 44, borderRadius: 10, fontFamily: 'inherit', fontSize: 13, fontWeight: 600, background: day === i ? 'var(--text-1)' : 'var(--surface-ground)', color: day === i ? '#FAF6EE' : 'var(--text-2)', border: `1px solid ${day === i ? 'var(--text-1)' : 'var(--sand-200)'}`, cursor: 'pointer', transition: 'all 120ms' }}>{d}</button>
@@ -63,12 +63,12 @@ export function BlockEditSheet({ block, existingCategories, durations, minuteSte
         </div>
 
         <div style={{ marginBottom: 14 }}>
-          <label style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-3)', letterSpacing: '0.04em', textTransform: 'uppercase', display: 'block', marginBottom: 6 }}>시작 시간</label>
+          <label style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-3)', letterSpacing: '0.04em', display: 'block', marginBottom: 6 }}>시작 시간</label>
           <TimeDial value={time} onChange={setTime} minuteStep={minuteStep} />
         </div>
 
         <div style={{ marginBottom: 14 }}>
-          <label style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-3)', letterSpacing: '0.04em', textTransform: 'uppercase', display: 'block', marginBottom: 6 }}>소요 시간</label>
+          <label style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-3)', letterSpacing: '0.04em', display: 'block', marginBottom: 6 }}>소요 시간</label>
           <div style={{ display: 'flex', gap: 5 }}>
             {durations.map((d) => (
               <button key={d} onClick={() => setDur(d)} className="tnum" style={{ flex: 1, height: 44, borderRadius: 12, fontFamily: 'inherit', fontSize: 14, fontWeight: 600, background: dur === d ? 'var(--text-1)' : 'var(--surface-ground)', color: dur === d ? '#FAF6EE' : 'var(--text-2)', border: `1px solid ${dur === d ? 'var(--text-1)' : 'var(--sand-200)'}`, cursor: 'pointer', transition: 'all 120ms' }}>{d}분</button>
@@ -77,7 +77,7 @@ export function BlockEditSheet({ block, existingCategories, durations, minuteSte
         </div>
 
         <div style={{ marginBottom: 18 }}>
-          <label style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-3)', letterSpacing: '0.04em', textTransform: 'uppercase', display: 'block', marginBottom: 6 }}>목표</label>
+          <label style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-3)', letterSpacing: '0.04em', display: 'block', marginBottom: 6 }}>목표</label>
           <div style={{ display: 'flex', gap: 5, flexWrap: 'wrap' }}>
             {categoryValues.map((v) => {
               const c = goalColor(v);

--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -42,7 +42,6 @@ export function EmptyState({ title, children, tone = 'quiet', icon }: EmptyState
         {title && (
           <div
             style={{
-              fontFamily: 'var(--font-display)',
               fontWeight: 700,
               fontSize: 22,
               color: 'var(--text-2)',

--- a/src/components/FixedScheduleStrip.tsx
+++ b/src/components/FixedScheduleStrip.tsx
@@ -50,7 +50,7 @@ export function FixedScheduleStrip({ items }: FixedScheduleStripProps) {
         <div key={s.scheduleId} style={{ display: 'flex', alignItems: 'baseline', gap: 10 }}>
           <span
             className="tnum"
-            style={{ fontSize: 11.5, fontWeight: 700, color: 'var(--text-2)', fontFamily: 'var(--font-mono)', flexShrink: 0 }}
+            style={{ fontSize: 11.5, fontWeight: 700, color: 'var(--text-2)', flexShrink: 0 }}
           >
             {hhmm(s.startTime)}–{hhmm(s.endTime)}
           </span>

--- a/src/components/GoalCard.tsx
+++ b/src/components/GoalCard.tsx
@@ -82,7 +82,6 @@ export function GoalCard({
                 fontSize: 10,
                 fontWeight: 700,
                 color: m.color,
-                fontFamily: 'var(--font-mono)',
                 display: 'inline-flex',
                 alignItems: 'center',
               }}

--- a/src/components/HeroTaskCard.tsx
+++ b/src/components/HeroTaskCard.tsx
@@ -81,11 +81,10 @@ export function HeroTaskCard({
       <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between' }}>
         <span
           style={{
-            fontSize: 10,
+            fontSize: 12,
             fontWeight: 700,
-            letterSpacing: '0.1em',
+            letterSpacing: '-0.01em',
             color: 'var(--brand-ink)',
-            fontFamily: 'var(--font-mono)',
             display: 'flex',
             alignItems: 'center',
             gap: 5,
@@ -100,7 +99,7 @@ export function HeroTaskCard({
             </>
           )}
         </span>
-        <span className="tnum" style={{ fontSize: 11, color: 'var(--text-3)', fontFamily: 'var(--font-mono)' }}>
+        <span className="tnum" style={{ fontSize: 11, color: 'var(--text-3)' }}>
           {done} / {total} · {pct}%
         </span>
       </div>
@@ -108,7 +107,6 @@ export function HeroTaskCard({
       <div>
         <h2
           style={{
-            fontFamily: 'var(--font-display)',
             fontWeight: 800,
             fontSize: 26,
             letterSpacing: '-0.02em',

--- a/src/components/InboxItemCard.tsx
+++ b/src/components/InboxItemCard.tsx
@@ -53,7 +53,6 @@ export function InboxItemCard({ text, badges = [], aiCategory, actions }: InboxI
               fontSize: 10,
               fontWeight: 700,
               color: b.fg,
-              fontFamily: 'var(--font-mono)',
               display: 'inline-flex',
               alignItems: 'center',
               gap: 4,

--- a/src/components/IosInstallCard.tsx
+++ b/src/components/IosInstallCard.tsx
@@ -40,7 +40,7 @@ export function IosInstallCard() {
         </button>
         <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 8 }}>
           <div style={{ width: 5, height: 5, borderRadius: 9999, background: 'var(--brand)' }} />
-          <span style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--brand-ink)', fontFamily: 'var(--font-mono)' }}>홈 화면에 추가</span>
+          <span style={{ fontSize: 12, fontWeight: 700, letterSpacing: '-0.01em', color: 'var(--brand-ink)' }}>홈 화면에 추가</span>
         </div>
         <p style={{ margin: '0 0 10px', fontSize: 13, color: 'var(--text-1)', fontWeight: 600, lineHeight: 1.5, paddingRight: 24 }}>
           홈 화면에 추가하면 앱처럼 열리고 알림도 받을 수 있어요.

--- a/src/components/ProgressSheet.tsx
+++ b/src/components/ProgressSheet.tsx
@@ -65,9 +65,7 @@ export function ProgressSheet({
             style={{
               fontSize: 11,
               color: 'var(--text-3)',
-              letterSpacing: '0.08em',
-              textTransform: 'uppercase',
-              fontFamily: 'var(--font-mono)',
+              letterSpacing: '0',
             }}
           >
             진척

--- a/src/components/RecoveryOptionCard.tsx
+++ b/src/components/RecoveryOptionCard.tsx
@@ -103,7 +103,6 @@ export function RecoveryOptionCard({
                     fontSize: 9,
                     fontWeight: 700,
                     color: 'var(--coral-700)',
-                    fontFamily: 'var(--font-mono)',
                     display: 'inline-flex',
                     alignItems: 'center',
                     letterSpacing: '0.04em',
@@ -116,8 +115,7 @@ export function RecoveryOptionCard({
                 <span
                   className="tnum"
                   style={{
-                    fontSize: 10,
-                    fontFamily: 'var(--font-mono)',
+                    fontSize: 12,
                     fontWeight: 600,
                     color: confidence > 80 ? 'var(--success-ink)' : confidence > 65 ? 'var(--warning-ink)' : 'var(--text-3)',
                   }}

--- a/src/components/ResourceViewerSheet.tsx
+++ b/src/components/ResourceViewerSheet.tsx
@@ -74,7 +74,7 @@ export function ResourceViewerSheet({
       >
         <div style={{ width: 36, height: 4, borderRadius: 9999, background: 'var(--sand-300)', margin: '0 auto 16px' }} />
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12, marginBottom: 16 }}>
-          <h3 style={{ fontSize: 17, fontWeight: 700, margin: 0, letterSpacing: '-0.01em', fontFamily: 'var(--font-display)' }}>{title}</h3>
+          <h3 style={{ fontSize: 17, fontWeight: 700, margin: 0, letterSpacing: '-0.01em' }}>{title}</h3>
           <button
             onClick={onClose}
             aria-label="닫기"
@@ -97,8 +97,8 @@ export function ResourceViewerSheet({
             <ReactMarkdown
               remarkPlugins={[remarkGfm]}
               components={{
-                h1: ({ children }) => <h1 style={{ fontSize: 20, fontWeight: 800, margin: '18px 0 8px', fontFamily: 'var(--font-display)', letterSpacing: '-0.01em' }}>{children}</h1>,
-                h2: ({ children }) => <h2 style={{ fontSize: 17, fontWeight: 700, margin: '18px 0 8px', fontFamily: 'var(--font-display)' }}>{children}</h2>,
+                h1: ({ children }) => <h1 style={{ fontSize: 20, fontWeight: 800, margin: '18px 0 8px', letterSpacing: '-0.01em' }}>{children}</h1>,
+                h2: ({ children }) => <h2 style={{ fontSize: 17, fontWeight: 700, margin: '18px 0 8px' }}>{children}</h2>,
                 h3: ({ children }) => <h3 style={{ fontSize: 15, fontWeight: 700, margin: '14px 0 6px' }}>{children}</h3>,
                 p: ({ children }) => <p style={{ margin: '0 0 12px' }}>{children}</p>,
                 ul: ({ children }) => <ul style={{ margin: '0 0 12px', paddingLeft: 20 }}>{children}</ul>,
@@ -115,8 +115,8 @@ export function ResourceViewerSheet({
                 code: ({ children, className }) => {
                   // 인라인 코드는 pill, 블록 코드는 pre 안에서 스크롤(아래 pre 참고).
                   const isBlock = typeof className === 'string' && className.startsWith('language-');
-                  if (isBlock) return <code style={{ fontFamily: 'var(--font-mono)', fontSize: 12.5 }}>{children}</code>;
-                  return <code style={{ fontFamily: 'var(--font-mono)', fontSize: 12.5, background: 'var(--sand-100)', border: '1px solid var(--sand-200)', borderRadius: 5, padding: '1px 5px' }}>{children}</code>;
+                  if (isBlock) return <code style={{ fontSize: 12.5 }}>{children}</code>;
+                  return <code style={{ fontSize: 12.5, background: 'var(--sand-100)', border: '1px solid var(--sand-200)', borderRadius: 5, padding: '1px 5px' }}>{children}</code>;
                 },
                 pre: ({ children }) => (
                   <pre style={{ ...scrollX, margin: '0 0 12px', padding: '12px 14px', background: 'var(--sand-100)', border: '1px solid var(--sand-200)', borderRadius: 10, lineHeight: 1.6 }}>{children}</pre>
@@ -186,12 +186,11 @@ export function ResourceViewerSheet({
                         marginTop: 1,
                         background: done ? 'var(--brand-surface)' : 'var(--sand-100)',
                         color: done ? '#FFFCF6' : 'var(--text-3)',
-                        fontSize: 10,
+                        fontSize: 12,
                         fontWeight: 700,
                         display: 'inline-flex',
                         alignItems: 'center',
                         justifyContent: 'center',
-                        fontFamily: 'var(--font-mono)',
                       }}
                     >
                       {done ? '✓' : i + 1}

--- a/src/components/SectionHeader.tsx
+++ b/src/components/SectionHeader.tsx
@@ -35,8 +35,7 @@ export function SectionHeader({ children, action, icon, tone = 'default' }: Sect
           gap: 5,
           fontSize: 12,
           fontWeight: 600,
-          letterSpacing: '0.08em',
-          textTransform: 'uppercase',
+          letterSpacing: '0',
           color: tone === 'danger' ? 'var(--danger-ink)' : 'var(--text-3)',
         }}
       >

--- a/src/components/SetupProgress.tsx
+++ b/src/components/SetupProgress.tsx
@@ -2,7 +2,7 @@
 // 모든 단계 (goal-intake, goal-classify, setup, weekly-plan) 에서 같이 사용.
 export function SetupProgress({ current, total, label }: { current: number; total: number; label: string }) {
   return (
-    <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.1em', color: 'var(--text-3)', fontFamily: 'var(--font-mono)', display: 'flex', gap: 8, alignItems: 'center', marginBottom: 14 }}>
+    <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: '-0.01em', color: 'var(--text-3)', display: 'flex', gap: 8, alignItems: 'center', marginBottom: 14 }}>
       <span style={{ color: 'var(--brand-ink)', fontWeight: 700 }}>{current} / {total}</span>
       <div style={{ flex: 1, height: 3, background: 'var(--sand-200)', borderRadius: 9999, position: 'relative' }}>
         <div style={{ position: 'absolute', inset: 0, width: `${(current / total) * 100}%`, background: 'var(--brand)', borderRadius: 9999, transition: 'width 0.4s ease' }} />

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -15,20 +15,32 @@ interface MergedTabBarProps {
 // 하단 탭 4→3 으로 단순화.
 const tabs: { id: TabId; label: string; Icon: React.ElementType }[] = [
   { id: 'today',  label: '오늘 실행', Icon: House },
-  { id: 'weekly', label: '주간',      Icon: CalendarBlank },
+  { id: 'weekly', label: '주간 계획', Icon: CalendarBlank },
   { id: 'inbox',  label: '인박스',    Icon: Tray },
 ];
 
+/**
+ * 하단 탭.
+ *
+ * 활성 표시를 **색과 무게**로 낸다. 예전엔 아이콘 뒤에 검은 라운드 사각형을 깔았는데,
+ * 그 조합(검정 칩 + 9px 대문자 라벨)이 어느 앱에서나 보이는 기성품 느낌의 출처였다.
+ * 국내외 여행 앱(에어비앤비·호퍼·트리플) 모두 칩을 쓰지 않고 틴트 색으로만 구분한다.
+ *
+ * 라벨은 대문자 변환을 하지 않는다 — 한글엔 대소문자가 없어서 영문 라벨에만
+ * 걸리는 장식이었고, 한국 앱의 관용은 "버튼이 무엇을 하는지 말로 적는" 쪽이다.
+ * 그래서 '주간' 도 '주간 계획' 으로 늘렸다.
+ */
 export function MergedTabBar({ active, onChange }: MergedTabBarProps) {
   return (
-    <div
+    <nav
+      aria-label="주요 화면"
       style={{
         flexShrink: 0,
         display: 'flex',
-        padding: '8px 6px 34px',
-        background: 'rgba(250,246,238,.92)',
-        backdropFilter: 'blur(20px)',
-        WebkitBackdropFilter: 'blur(20px)',
+        // 홈 인디케이터 영역은 기기에 맡긴다. 34px 하드코딩은 노치 없는 기기에서 뜬 여백이 된다.
+        padding: '6px 6px calc(8px + env(safe-area-inset-bottom, 26px))',
+        // 불투명. 반투명+블러는 뒤 내용이 비쳐 라벨 대비가 스크롤에 따라 흔들린다.
+        background: 'var(--surface-raised)',
         borderTop: '1px solid var(--sand-200)',
         zIndex: 20,
       }}
@@ -39,44 +51,36 @@ export function MergedTabBar({ active, onChange }: MergedTabBarProps) {
           <button
             key={t.id}
             onClick={() => onChange(t.id)}
+            aria-current={isActive ? 'page' : undefined}
             style={{
               flex: 1,
               display: 'flex',
               flexDirection: 'column',
               alignItems: 'center',
-              gap: 3,
-              padding: '6px 2px',
+              gap: 4,
+              padding: '8px 2px 6px',
               background: 'transparent',
               border: 'none',
               cursor: 'pointer',
-              fontFamily: 'var(--font-mono)',
-              fontSize: 9,
-              letterSpacing: '0.06em',
-              textTransform: 'uppercase',
-              color: isActive ? 'var(--text-1)' : 'var(--text-3)',
+              fontFamily: 'inherit',
+              fontSize: 11,
+              lineHeight: 1.2,
+              fontWeight: isActive ? 700 : 500,
+              letterSpacing: '-0.01em',
+              color: isActive ? 'var(--brand-ink)' : 'var(--text-3)',
+              // 활성/비활성 전환이 튀지 않게. 색만 바뀌므로 이동은 없다.
+              transition: 'color 140ms',
             }}
           >
-            <div
-              style={{
-                width: 28,
-                height: 28,
-                borderRadius: 8,
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                background: isActive ? 'var(--text-1)' : 'transparent',
-              }}
-            >
-              <t.Icon
-                size={16}
-                weight={isActive ? 'fill' : 'regular'}
-                color={isActive ? '#FAF6EE' : 'var(--text-3)'}
-              />
-            </div>
+            <t.Icon
+              size={22}
+              weight={isActive ? 'fill' : 'regular'}
+              color={isActive ? 'var(--brand-ink)' : 'var(--text-3)'}
+            />
             {t.label}
           </button>
         );
       })}
-    </div>
+    </nav>
   );
 }

--- a/src/components/TimeDial.tsx
+++ b/src/components/TimeDial.tsx
@@ -83,7 +83,6 @@ function WheelColumn({
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center',
-              fontFamily: 'var(--font-mono)',
               fontVariantNumeric: 'tabular-nums',
               fontSize: sel ? 19 : 15,
               fontWeight: sel ? 700 : 500,

--- a/src/components/WeekGrid.tsx
+++ b/src/components/WeekGrid.tsx
@@ -141,7 +141,7 @@ export function WeekGrid({
         {(h > 36 || colWidth >= 80) && b.subLabel && (
           <div
             className="tnum"
-            style={{ fontSize: colWidth >= 80 ? 10 : 7, color: c.fg, opacity: 0.7, marginTop: 1, fontFamily: 'var(--font-mono)' }}
+            style={{ fontSize: colWidth >= 80 ? 10 : 7, color: c.fg, opacity: 0.7, marginTop: 1 }}
           >
             {b.subLabel}
           </div>
@@ -203,8 +203,7 @@ export function WeekGrid({
               <div
                 style={{
                   fontSize: colWidth >= 80 ? 10 : 8,
-                  fontFamily: 'var(--font-mono)',
-                  letterSpacing: '0.08em',
+                  letterSpacing: '0',
                   color: isToday ? 'var(--coral-700)' : 'var(--text-3)',
                   marginBottom: 3,
                 }}
@@ -251,7 +250,7 @@ export function WeekGrid({
                   paddingRight: 4,
                 }}
               >
-                <span className="tnum" style={{ fontSize: colWidth >= 80 ? 10 : 8, color: 'var(--text-3)', fontFamily: 'var(--font-mono)' }}>
+                <span className="tnum" style={{ fontSize: colWidth >= 80 ? 10 : 8, color: 'var(--text-3)' }}>
                   {h}
                 </span>
               </div>

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,4 @@
 @import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.css");
-@import url("https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;1,6..72,400;1,6..72,500;1,6..72,600&display=swap");
 
 @tailwind base;
 @tailwind components;
@@ -140,11 +139,12 @@
   --space-30: 120px;
 
   /* RADII */
-  --radius-sm:   8px;
-  --radius-md:   12px;
-  --radius-lg:   20px;
-  --radius-xl:   28px;
-  --radius-full: 9999px;
+  /* 값마다 '무엇인가' 를 나타낸다. 전부 12~16 이면 칩·카드·시트가 구분되지 않는다. */
+  --radius-sm:   6px;   /* 배지·인풋처럼 네모에 가까운 것 */
+  --radius-md:   12px;  /* 목록 행·작은 카드 */
+  --radius-lg:   18px;  /* 본문 카드 */
+  --radius-xl:   28px;  /* 바텀시트·전면 패널 */
+  --radius-full: 9999px;/* 알약·원형 */
 
   /* CONTROL HEIGHTS — 컴포넌트 사이즈 일관성 스케일 */
   --ctrl-xs: 20px;  /* 칩·배지 */
@@ -154,6 +154,9 @@
   --ctrl-xl: 52px;  /* 히어로 CTA */
 
   /* ELEVATION */
+  /* 기본은 그림자 없음(테두리로 구분), 떠 있는 것만 --shadow-raise 하나.
+     예전엔 sm/md/lg/xl 4단을 섞어 써서 어느 게 위인지 알 수 없었다. */
+  --shadow-raise: 0 1px 2px rgba(54,40,28,.05), 0 6px 16px -6px rgba(54,40,28,.14);
   --shadow-sm:  0 1px 2px rgba(54, 40, 28, 0.06);
   --shadow-md:  0 4px 12px rgba(54, 40, 28, 0.08), 0 1px 2px rgba(54, 40, 28, 0.04);
   --shadow-lg:  0 12px 32px -8px rgba(54, 40, 28, 0.14), 0 2px 4px rgba(54, 40, 28, 0.04);
@@ -169,8 +172,19 @@
 
   /* TYPOGRAPHY */
   --font-sans:    "Pretendard Variable", Pretendard, -apple-system, BlinkMacSystemFont, system-ui, "Apple SD Gothic Neo", "Malgun Gothic", sans-serif;
-  --font-display: "Pretendard Variable", Pretendard, -apple-system, BlinkMacSystemFont, system-ui, "Apple SD Gothic Neo", "Malgun Gothic", sans-serif;
-  --font-mono:    "Pretendard Variable", Pretendard, ui-monospace, SFMono-Regular, Menlo, monospace;
+  /* display 는 sans 와 같은 서체를 쓰되 **무게와 크기로** 위계를 만든다.
+     한글 본문용 세리프를 따로 싣는 건 용량이 크고(한글 웹폰트), 라틴만 세리프로
+     바꾸면 한 문장 안에서 서체가 섞인다. 한국 앱의 관용은 강한 sans 하나로
+     위계를 세우는 쪽이다. */
+  --font-display: var(--font-sans);
+  /* 숫자 전용. 시각·날짜·카운트처럼 세로로 줄이 맞아야 하는 것에만 쓴다.
+     예전엔 맨 앞이 Pretendard 라 mono 가 절대 적용되지 않았다 — 82곳에서 쓰였지만
+     실제로는 전부 그냥 Pretendard 였다. 한글에는 쓰지 않는다(모노에 한글 자소가 없다). */
+  /* 서체는 Pretendard 하나다. 예전엔 sans/display/mono 세 토큰이 있었는데 셋 다
+     같은 Pretendard 로 해석됐고(mono 는 맨 앞이 Pretendard 라 절대 적용되지 않았다),
+     그 위에 9~10px 대문자 라벨을 얹어 '모노 캡션' 인 척했다. 위계는 서체가 아니라
+     크기·무게로 만든다. 숫자 정렬은 .tnum(tabular-nums)이 맡는다. */
+  --font-mono: var(--font-sans);
 
   --fs-micro:   12px;
   --fs-small:   14px;
@@ -291,6 +305,9 @@ body {
   box-shadow: 0 0 0 1px var(--sand-200);
 }
 
+/* 자릿수 정렬만 한다. 서체는 바꾸지 않는다 — 모노를 걸면 한글이 섞인 라벨
+   ("8월 16일 · 일요일")에서 공백까지 모노 폭이 되어 단어가 벌어진다.
+   Pretendard 의 tabular-nums 로 숫자는 이미 세로로 맞는다. */
 .tnum { font-variant-numeric: tabular-nums; }
 .text-brand { color: var(--brand); }
 

--- a/src/screens/EveningCheckInScreen.tsx
+++ b/src/screens/EveningCheckInScreen.tsx
@@ -127,7 +127,7 @@ export function EveningCheckInScreen({ onDone }: EveningCheckInScreenProps) {
         <div style={{ width: 64, height: 64, borderRadius: 9999, background: '#E5EFE3', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
           <CheckCircle size={32} weight="fill" color="var(--success-ink)" />
         </div>
-        <div style={{ fontFamily: 'var(--font-display)', fontSize: 28, fontWeight: 500, letterSpacing: '-0.01em' }}>저녁 체크인 완료.</div>
+        <div style={{ fontSize: 28, fontWeight: 500, letterSpacing: '-0.01em' }}>저녁 체크인 완료.</div>
         <p style={{ fontSize: 14, color: 'var(--text-2)', lineHeight: 1.6, maxWidth: 260 }}>오늘의 실행 데이터가 저장됐어요. 내일 아침에 맞춤 모닝 브리프가 준비될 거예요.</p>
         {selectedEnergy && (
           <div style={{ padding: '10px 14px', background: 'var(--brand-soft)', borderRadius: 12, border: '1px solid var(--coral-200)', fontSize: 12, color: 'var(--coral-700)', textAlign: 'left', width: '100%' }}>
@@ -155,7 +155,7 @@ export function EveningCheckInScreen({ onDone }: EveningCheckInScreenProps) {
 
   return (
     <div style={{ height: '100%', overflowY: 'auto', padding: '16px 18px 32px', background: 'var(--surface-ground)', display: 'flex', flexDirection: 'column', gap: 14 }}>
-      <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--text-3)', fontFamily: 'var(--font-mono)' }}>저녁 체크인 · 1/2</div>
+      <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: '-0.01em', color: 'var(--text-3)' }}>저녁 체크인 · 1/2</div>
       <h2 style={{ fontSize: 22, fontWeight: 700, letterSpacing: '-0.02em', margin: '0 0 4px' }}>오늘 하루 어땠나요?</h2>
       <p style={{ fontSize: 13, color: 'var(--text-2)' }}>에너지 상태를 기록하면 내일 계획에 반영해요.</p>
 
@@ -166,7 +166,7 @@ export function EveningCheckInScreen({ onDone }: EveningCheckInScreenProps) {
           <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between' }}>
             <div style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-3)' }}>아직 체크인하지 않은 실행</div>
             {!pendingLoading && (
-              <span className="tnum" style={{ fontSize: 11, fontFamily: 'var(--font-mono)', color: 'var(--text-3)' }}>{pending.length}건</span>
+              <span className="tnum" style={{ fontSize: 11, color: 'var(--text-3)' }}>{pending.length}건</span>
             )}
           </div>
           {!pendingLoading && carriedOver > 0 && (
@@ -184,7 +184,7 @@ export function EveningCheckInScreen({ onDone }: EveningCheckInScreenProps) {
                     <span style={{ height: 'var(--ctrl-xs)', minWidth: 34, padding: '0 7px', background: 'var(--sand-100)', border: '1px solid var(--sand-200)', borderRadius: 9999, fontSize: 10, color: 'var(--text-2)', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>{relDayLabel(p.scheduledDate)}</span>
                     <div style={{ flex: 1, fontSize: 13, fontWeight: 500, color: 'var(--text-1)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{p.title}</div>
                     {p.scheduledTime && (
-                      <div className="tnum" style={{ fontSize: 10, fontFamily: 'var(--font-mono)', color: 'var(--text-3)', flexShrink: 0 }}>{p.scheduledTime.slice(0, 5)}</div>
+                      <div className="tnum" style={{ fontSize: 12, fontWeight: 700, color: 'var(--text-3)', flexShrink: 0 }}>{p.scheduledTime.slice(0, 5)}</div>
                     )}
                   </div>
                   <div style={{ display: 'flex', gap: 5 }}>
@@ -275,7 +275,7 @@ function TomorrowPreview({ onBack, onConfirm }: { onBack: () => void; onConfirm:
 
   return (
     <div style={{ height: '100%', overflowY: 'auto', padding: '16px 18px 32px', background: 'var(--surface-ground)', display: 'flex', flexDirection: 'column', gap: 14 }}>
-      <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--text-3)', fontFamily: 'var(--font-mono)' }}>저녁 체크인 · 2/2</div>
+      <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: '-0.01em', color: 'var(--text-3)' }}>저녁 체크인 · 2/2</div>
       <h2 style={{ fontSize: 22, fontWeight: 700, letterSpacing: '-0.02em', margin: '0 0 6px' }}>내일 계획 미리보기</h2>
       <div style={{ background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', borderRadius: 14, padding: 14 }}>
         <div style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-3)', marginBottom: 10 }}>{weekdayLabel}요일 예정 블록 · {tomorrowStr.slice(5)}</div>
@@ -293,7 +293,7 @@ function TomorrowPreview({ onBack, onConfirm }: { onBack: () => void; onConfirm:
               const hhmm = `${String(start.getHours()).padStart(2, '0')}:${String(start.getMinutes()).padStart(2, '0')}`;
               return (
                 <div key={b.blockId} style={{ display: 'flex', gap: 10, alignItems: 'center' }}>
-                  <div className="tnum" style={{ width: 38, fontSize: 10, fontFamily: 'var(--font-mono)', color: 'var(--text-3)', flexShrink: 0 }}>{hhmm}</div>
+                  <div className="tnum" style={{ width: 38, fontSize: 12, fontWeight: 700, color: 'var(--text-3)', flexShrink: 0 }}>{hhmm}</div>
                   <div style={{ flex: 1, fontSize: 13, fontWeight: 500, color: 'var(--text-1)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{b.title}</div>
                   <span style={{ height: 'var(--ctrl-xs)', padding: '0 7px', background: 'var(--sand-100)', border: '1px solid var(--sand-200)', borderRadius: 9999, fontSize: 10, color: 'var(--text-2)', display: 'inline-flex', alignItems: 'center', flexShrink: 0 }}>{mins}분</span>
                 </div>

--- a/src/screens/FocusScreen.tsx
+++ b/src/screens/FocusScreen.tsx
@@ -107,7 +107,7 @@ export function FocusScreen({ task, elapsedMin, totalMin, onComplete, onBack, on
   if (!task) {
     return (
       <div style={{ padding: '60px 24px', background: 'var(--surface-ground)', minHeight: '100%', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 16, textAlign: 'center' }}>
-        <div style={{ fontFamily: 'var(--font-display)', fontWeight: 700, fontSize: 22, color: 'var(--text-1)' }}>시작할 카드가 없어요</div>
+        <div style={{ fontWeight: 700, fontSize: 22, color: 'var(--text-1)' }}>시작할 카드가 없어요</div>
         <p style={{ fontSize: 13, color: 'var(--text-2)', maxWidth: 260, margin: 0, lineHeight: 1.6 }}>오늘 화면에서 카드를 골라 시작해주세요.</p>
         <ReButton variant="primary" size="md" onClick={onBack}>오늘로 돌아가기</ReButton>
       </div>

--- a/src/screens/GoalClassificationScreen.tsx
+++ b/src/screens/GoalClassificationScreen.tsx
@@ -129,8 +129,8 @@ export function GoalClassificationScreen({ onNext, outcome }: GoalClassification
       <div style={{ flex: 1, overflowY: 'auto', padding: '14px 18px 0', display: 'flex', flexDirection: 'column', gap: 12 }}>
         <SetupProgress current={2} total={4} label="분류" />
         <div>
-          <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--brand-ink)', fontFamily: 'var(--font-mono)', marginBottom: 4 }}>목표 분류</div>
-          <div style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 24, letterSpacing: '-0.02em', lineHeight: 1.15, marginBottom: 4 }}>무엇에 집중할까요?</div>
+          <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: '-0.01em', color: 'var(--brand-ink)', marginBottom: 4 }}>목표 분류</div>
+          <div style={{ fontWeight: 800, fontSize: 24, letterSpacing: '-0.02em', lineHeight: 1.15, marginBottom: 4 }}>무엇에 집중할까요?</div>
           <p style={{ fontSize: 12, color: 'var(--text-2)', margin: 0 }}>
             {isLoading ? '대화에서 파악한 목표를 불러오는 중…' : '대화에서 파악한 목표들이에요. 분류를 조정할 수 있어요.'}
           </p>
@@ -169,9 +169,9 @@ export function GoalClassificationScreen({ onNext, outcome }: GoalClassification
                 <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10 }}>
                   <div style={{ flex: 1 }}>
                     <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 6, flexWrap: 'wrap' }}>
-                      <div style={{ height: 'var(--ctrl-xs)', padding: '0 8px', borderRadius: 9999, background: m.bg, border: `1px solid ${m.border}`, fontSize: 10, fontWeight: 700, color: m.color, letterSpacing: '0.04em', fontFamily: 'var(--font-mono)', display: 'inline-flex', alignItems: 'center' }}>{m.label}</div>
+                      <div style={{ height: 'var(--ctrl-xs)', padding: '0 8px', borderRadius: 9999, background: m.bg, border: `1px solid ${m.border}`, fontSize: 10, fontWeight: 700, color: m.color, letterSpacing: '0.04em', display: 'inline-flex', alignItems: 'center' }}>{m.label}</div>
                       {g.status === 'focus' && (
-                        <div style={{ height: 'var(--ctrl-xs)', padding: '0 7px', borderRadius: 9999, background: 'var(--brand-surface)', color: '#FFFCF6', fontSize: 9, fontWeight: 700, display: 'inline-flex', alignItems: 'center', fontFamily: 'var(--font-mono)' }}>ACTIVE</div>
+                        <div style={{ height: 'var(--ctrl-xs)', padding: '0 7px', borderRadius: 9999, background: 'var(--brand-surface)', color: '#FFFCF6', fontSize: 12, fontWeight: 700, display: 'inline-flex', alignItems: 'center' }}>ACTIVE</div>
                       )}
                     </div>
                     <div style={{ fontWeight: 700, fontSize: 13, color: 'var(--text-1)', marginBottom: 4, letterSpacing: '-0.01em' }}>{g.name}</div>
@@ -205,7 +205,7 @@ export function GoalClassificationScreen({ onNext, outcome }: GoalClassification
                         <button
                           key={s}
                           onClick={() => changeStatus(g.id, s)}
-                          style={{ flex: 1, height: 38, borderRadius: 9999, fontSize: 10, fontWeight: 600, background: g.status === s ? sm.color : 'var(--surface-ground)', color: g.status === s ? '#FFFCF6' : 'var(--text-3)', border: `1px solid ${g.status === s ? sm.color : 'var(--sand-200)'}`, cursor: 'pointer', fontFamily: 'var(--font-mono)', letterSpacing: '0.04em', transition: 'all 160ms' }}
+                          style={{ flex: 1, height: 38, borderRadius: 9999, fontSize: 10, fontWeight: 600, background: g.status === s ? sm.color : 'var(--surface-ground)', color: g.status === s ? '#FFFCF6' : 'var(--text-3)', border: `1px solid ${g.status === s ? sm.color : 'var(--sand-200)'}`, cursor: 'pointer', letterSpacing: '0.04em', transition: 'all 160ms' }}
                         >
                           {sm.label}
                         </button>

--- a/src/screens/GoalIntakeScreen.tsx
+++ b/src/screens/GoalIntakeScreen.tsx
@@ -301,7 +301,7 @@ export function GoalIntakeScreen({ onDone, onOutcome }: GoalIntakeScreenProps) {
             <div style={{ fontWeight: 700, fontSize: 14, color: 'var(--text-1)' }}>목표 파악 AI</div>
             <div style={{ fontSize: 11, color: 'var(--text-3)' }}>질문에 답하면 자동으로 목표를 분류해요</div>
           </div>
-          <div style={{ height: 'var(--ctrl-xs)', padding: '0 8px', background: 'var(--brand-soft)', border: '1px solid var(--coral-200)', borderRadius: 9999, fontSize: 9, fontWeight: 700, color: 'var(--coral-700)', fontFamily: 'var(--font-mono)', display: 'flex', alignItems: 'center' }}>
+          <div style={{ height: 'var(--ctrl-xs)', padding: '0 8px', background: 'var(--brand-soft)', border: '1px solid var(--coral-200)', borderRadius: 9999, fontSize: 12, fontWeight: 700, color: 'var(--coral-700)', display: 'flex', alignItems: 'center' }}>
             {currentCategory ? (CATEGORY_LABEL[currentCategory] ?? '목표 파악') : '목표 파악'}
           </div>
         </div>
@@ -309,7 +309,7 @@ export function GoalIntakeScreen({ onDone, onOutcome }: GoalIntakeScreenProps) {
         <div style={{ background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', borderRadius: 12, padding: '10px 12px', display: 'flex', flexDirection: 'column', gap: 7, marginTop: 4 }}>
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
             <span style={{ fontSize: 11, fontWeight: 700, color: 'var(--text-2)', letterSpacing: '0.01em' }}>명료성 지표</span>
-            <span style={{ fontSize: 11, fontWeight: 800, color: 'var(--brand-ink)', fontFamily: 'var(--font-mono)' }}>{clarity}%&nbsp;명확</span>
+            <span style={{ fontSize: 11, fontWeight: 800, color: 'var(--brand-ink)' }}>{clarity}%&nbsp;명확</span>
           </div>
           <div style={{ height: 5, background: 'var(--sand-200)', borderRadius: 9999, overflow: 'hidden' }}>
             <div style={{ height: '100%', borderRadius: 9999, background: 'var(--brand)', width: `${clarity}%`, transition: 'width 0.6s ease' }} />
@@ -370,11 +370,11 @@ export function GoalIntakeScreen({ onDone, onOutcome }: GoalIntakeScreenProps) {
             <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
               <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
                 <span style={{ fontSize: 13 }}>💡</span>
-                <span style={{ fontSize: 10, color: 'var(--text-3)', fontFamily: 'var(--font-mono)', letterSpacing: '0.06em', fontWeight: 600 }}>원터치 대답하기</span>
+                <span style={{ fontSize: 12, color: 'var(--text-3)', letterSpacing: '-0.01em', fontWeight: 600 }}>원터치 대답하기</span>
               </div>
               <button
                 onClick={finishEarly}
-                style={{ fontSize: 10, color: 'var(--text-3)', background: 'transparent', border: 'none', fontFamily: 'var(--font-mono)', letterSpacing: '0.06em', cursor: 'pointer' }}
+                style={{ fontSize: 12, fontWeight: 700, color: 'var(--text-3)', background: 'transparent', border: 'none', letterSpacing: '-0.01em', cursor: 'pointer' }}
               >
                 충분해요
               </button>
@@ -389,7 +389,7 @@ export function GoalIntakeScreen({ onDone, onOutcome }: GoalIntakeScreenProps) {
             )}
             {showQuickReplies && (
               <>
-              <span style={{ fontSize: 9, color: 'var(--text-3)', fontFamily: 'var(--font-mono)', letterSpacing: '0.06em' }}>
+              <span style={{ fontSize: 12, fontWeight: 700, color: 'var(--text-3)', letterSpacing: '-0.01em' }}>
                 탭해서 담기 · 여러 개 골라도 돼요
               </span>
               {/* 선택지가 많은 질문에서 이 목록이 화면을 통째로 먹던 문제 — 대화가 위로
@@ -427,7 +427,7 @@ export function GoalIntakeScreen({ onDone, onOutcome }: GoalIntakeScreenProps) {
             )}
             {!showQuickReplies && currentQuestion.suggestedAnswers && currentQuestion.suggestedAnswers.length > 0 && (
               <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
-                <span style={{ width: '100%', fontSize: 9, color: 'var(--text-3)', fontFamily: 'var(--font-mono)', letterSpacing: '0.06em' }}>추천 답변 · 탭해서 담기</span>
+                <span style={{ width: '100%', fontSize: 12, fontWeight: 700, color: 'var(--text-3)', letterSpacing: '-0.01em' }}>추천 답변 · 탭해서 담기</span>
                 {currentQuestion.suggestedAnswers.map((s, i) => (
                   <button
                     key={i}

--- a/src/screens/GoalsScreen.tsx
+++ b/src/screens/GoalsScreen.tsx
@@ -204,7 +204,7 @@ export function GoalsScreen() {
         <div>
           <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 4 }}>
             <Target size={18} weight="fill" color="var(--brand)" />
-            <h1 style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 22, letterSpacing: '-0.02em', margin: 0 }}>목표 관리</h1>
+            <h1 style={{ fontWeight: 800, fontSize: 22, letterSpacing: '-0.02em', margin: 0 }}>목표 관리</h1>
           </div>
           <p style={{ fontSize: 12, color: 'var(--text-2)', margin: '0 0 8px' }}>
             {isLoading ? '목표를 불러오는 중…' : '집중·유지·보류로 나눠 관리해요. 집중은 최대 3개, 유지는 5개까지.'}
@@ -245,7 +245,7 @@ export function GoalsScreen() {
           const m = GOAL_STATUS_META[tier];
           return (
             <div key={tier} style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-              <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--text-3)', fontFamily: 'var(--font-mono)' }}>
+              <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: '-0.01em', color: 'var(--text-3)' }}>
                 {m.label} · {items.length}
               </div>
               {items.map((g) => {
@@ -291,7 +291,7 @@ export function GoalsScreen() {
                             const tm = GOAL_STATUS_META[t];
                             const active = g.goalTier === t;
                             return (
-                              <button key={t} onClick={() => changeTier(g, t)} style={{ flex: 1, height: 36, borderRadius: 9999, fontSize: 11, fontWeight: 600, background: active ? tm.color : 'var(--surface-ground)', color: active ? '#FFFCF6' : 'var(--text-3)', border: `1px solid ${active ? tm.color : 'var(--sand-200)'}`, cursor: 'pointer', fontFamily: 'var(--font-mono)' }}>{tm.label}</button>
+                              <button key={t} onClick={() => changeTier(g, t)} style={{ flex: 1, height: 36, borderRadius: 9999, fontSize: 11, fontWeight: 600, background: active ? tm.color : 'var(--surface-ground)', color: active ? '#FFFCF6' : 'var(--text-3)', border: `1px solid ${active ? tm.color : 'var(--sand-200)'}`, cursor: 'pointer' }}>{tm.label}</button>
                             );
                           })}
                         </div>
@@ -352,7 +352,7 @@ export function GoalsScreen() {
                 const tm = GOAL_STATUS_META[t];
                 const active = addTier === t;
                 return (
-                  <button key={t} onClick={() => { setAddTier(t); setAddLimitHit(false); }} style={{ flex: 1, height: 34, borderRadius: 9999, fontSize: 11, fontWeight: 600, background: active ? tm.color : 'var(--surface-raised)', color: active ? '#FFFCF6' : 'var(--text-3)', border: `1px solid ${active ? tm.color : 'var(--sand-200)'}`, cursor: 'pointer', fontFamily: 'var(--font-mono)' }}>{tm.label}</button>
+                  <button key={t} onClick={() => { setAddTier(t); setAddLimitHit(false); }} style={{ flex: 1, height: 34, borderRadius: 9999, fontSize: 11, fontWeight: 600, background: active ? tm.color : 'var(--surface-raised)', color: active ? '#FFFCF6' : 'var(--text-3)', border: `1px solid ${active ? tm.color : 'var(--sand-200)'}`, cursor: 'pointer' }}>{tm.label}</button>
                 );
               })}
             </div>

--- a/src/screens/InboxScreen.tsx
+++ b/src/screens/InboxScreen.tsx
@@ -234,10 +234,10 @@ export function InboxScreen() {
     <div style={{ height: '100%', display: 'flex', flexDirection: 'column', background: 'var(--surface-ground)' }}>
       {/* Header */}
       <div style={{ flexShrink: 0, padding: '14px 18px 10px' }}>
-        <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--brand-ink)', fontFamily: 'var(--font-mono)', marginBottom: 4, display: 'flex', alignItems: 'center', gap: 4 }}>
+        <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: '-0.01em', color: 'var(--brand-ink)', marginBottom: 4, display: 'flex', alignItems: 'center', gap: 4 }}>
           <Sparkle size={11} weight="fill" /> 인박스
         </div>
-        <h2 style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 22, letterSpacing: '-0.02em', margin: '0 0 4px' }}>떠오르면 일단 적어요</h2>
+        <h2 style={{ fontWeight: 800, fontSize: 22, letterSpacing: '-0.02em', margin: '0 0 4px' }}>떠오르면 일단 적어요</h2>
         <p style={{ fontSize: 12, color: 'var(--text-2)', margin: 0 }}>AI 가 카테고리를 추정해두고, 나중에 목표로 올릴 수 있어요.</p>
       </div>
 

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -99,7 +99,7 @@ export function LoginScreen({ onGoogleCredential, onDemoLogin, isBusy, error }: 
         >
           <Sparkle size={26} weight="fill" color="#FAF6EE" />
         </div>
-        <div style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 24, letterSpacing: '-0.02em', color: 'var(--text-1)' }}>
+        <div style={{ fontWeight: 800, fontSize: 24, letterSpacing: '-0.02em', color: 'var(--text-1)' }}>
           Re:Action
         </div>
         <p style={{ fontSize: 13, color: 'var(--text-3)', margin: 0, maxWidth: 260, lineHeight: 1.6 }}>
@@ -112,7 +112,7 @@ export function LoginScreen({ onGoogleCredential, onDemoLogin, isBusy, error }: 
           <>
             <div ref={buttonRef} style={{ minHeight: 44 }} />
             {!buttonReady && (
-              <span style={{ fontSize: 11, color: 'var(--text-3)', fontFamily: 'var(--font-mono)' }}>
+              <span style={{ fontSize: 11, color: 'var(--text-3)' }}>
                 Google 로그인 준비 중…
               </span>
             )}
@@ -145,7 +145,6 @@ export function LoginScreen({ onGoogleCredential, onDemoLogin, isBusy, error }: 
             border: 'none',
             color: 'var(--text-3)',
             fontSize: 12,
-            fontFamily: 'var(--font-mono)',
             letterSpacing: '0.04em',
             textDecoration: 'underline',
             cursor: isBusy ? 'wait' : 'pointer',

--- a/src/screens/MilestoneConfirmScreen.tsx
+++ b/src/screens/MilestoneConfirmScreen.tsx
@@ -76,7 +76,7 @@ export function MilestoneConfirmScreen() {
           </button>
           <div style={{ display: 'flex', alignItems: 'center', gap: 7 }}>
             <Path size={20} weight="fill" color="var(--brand)" />
-            <h1 style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 22, letterSpacing: '-0.02em', margin: 0 }}>계획의 큰 그림</h1>
+            <h1 style={{ fontWeight: 800, fontSize: 22, letterSpacing: '-0.02em', margin: 0 }}>계획의 큰 그림</h1>
           </div>
         </div>
 
@@ -99,7 +99,7 @@ export function MilestoneConfirmScreen() {
             {milestones.map((m, i) => (
               <div key={i} style={{ background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', borderRadius: 14, padding: 12, display: 'flex', gap: 10 }}>
                 <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 2, paddingTop: 2 }}>
-                  <div style={{ width: 22, height: 22, borderRadius: 7, background: 'var(--brand-soft)', color: 'var(--brand-ink)', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 12, fontWeight: 700, fontFamily: 'var(--font-mono)' }}>{i + 1}</div>
+                  <div style={{ width: 22, height: 22, borderRadius: 7, background: 'var(--brand-soft)', color: 'var(--brand-ink)', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 12, fontWeight: 700 }}>{i + 1}</div>
                   <button onClick={() => move(i, -1)} disabled={i === 0} style={iconBtn(i === 0)} aria-label="위로"><CaretUp size={13} /></button>
                   <button onClick={() => move(i, 1)} disabled={i === milestones.length - 1} style={iconBtn(i === milestones.length - 1)} aria-label="아래로"><CaretDown size={13} /></button>
                 </div>

--- a/src/screens/MorningBriefScreen.tsx
+++ b/src/screens/MorningBriefScreen.tsx
@@ -143,19 +143,19 @@ export function MorningBriefScreen({ onStart }: MorningBriefScreenProps) {
         )}
         {/* Hero card — dark */}
         <div style={{ background: 'var(--sand-950)', borderRadius: 20, padding: '20px 18px' }}>
-          <div style={{ fontSize: 9, fontFamily: 'var(--font-mono)', letterSpacing: '0.14em', color: 'rgba(250,246,238,.4)', marginBottom: 6, textTransform: 'uppercase' }}>{date}</div>
-          <div style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 26, letterSpacing: '-0.02em', lineHeight: 1.1, color: '#FAF6EE', marginBottom: 14 }}>{briefGreeting || fallbackGreeting}</div>
+          <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: '-0.01em', color: 'rgba(250,246,238,.4)', marginBottom: 6, textTransform: 'uppercase' }}>{date}</div>
+          <div style={{ fontWeight: 800, fontSize: 26, letterSpacing: '-0.02em', lineHeight: 1.1, color: '#FAF6EE', marginBottom: 14 }}>{briefGreeting || fallbackGreeting}</div>
           <div style={{ display: 'flex', gap: 20 }}>
             <div>
-              <div style={{ fontSize: 9, fontFamily: 'var(--font-mono)', color: 'rgba(250,246,238,.4)', marginBottom: 2 }}>오늘 할 일</div>
-              <div className="tnum" style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 26, color: '#FAF6EE', letterSpacing: '-0.02em' }}>{loading ? '·' : blocks.length}</div>
+              <div style={{ fontSize: 12, fontWeight: 700, color: 'rgba(250,246,238,.4)', marginBottom: 2 }}>오늘 할 일</div>
+              <div className="tnum" style={{ fontWeight: 800, fontSize: 26, color: '#FAF6EE', letterSpacing: '-0.02em' }}>{loading ? '·' : blocks.length}</div>
             </div>
             <div>
-              <div style={{ fontSize: 9, fontFamily: 'var(--font-mono)', color: 'rgba(250,246,238,.4)', marginBottom: 2 }}>주간 달성</div>
-              <div className="tnum" style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 26, color: '#FAF6EE', letterSpacing: '-0.02em' }}>{loading ? '·' : `${weekProgress ?? '—'}%`}</div>
+              <div style={{ fontSize: 12, fontWeight: 700, color: 'rgba(250,246,238,.4)', marginBottom: 2 }}>주간 달성</div>
+              <div className="tnum" style={{ fontWeight: 800, fontSize: 26, color: '#FAF6EE', letterSpacing: '-0.02em' }}>{loading ? '·' : `${weekProgress ?? '—'}%`}</div>
             </div>
             <div>
-              <div style={{ fontSize: 9, fontFamily: 'var(--font-mono)', color: 'rgba(250,246,238,.4)', marginBottom: 2 }}>핵심 목표</div>
+              <div style={{ fontSize: 12, fontWeight: 700, color: 'rgba(250,246,238,.4)', marginBottom: 2 }}>핵심 목표</div>
               <div style={{ fontSize: 11, color: 'rgba(250,246,238,.65)', marginTop: 4, lineHeight: 1.3 }}>{loading ? '불러오는 중…' : (goalName || '—')}</div>
             </div>
           </div>
@@ -187,7 +187,7 @@ export function MorningBriefScreen({ onStart }: MorningBriefScreenProps) {
 
         {/* Today's blocks */}
         <div style={{ paddingBottom: 16 }}>
-          <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--text-3)', fontFamily: 'var(--font-mono)', marginBottom: 10 }}>오늘의 실행 계획</div>
+          <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: '-0.01em', color: 'var(--text-3)', marginBottom: 10 }}>오늘의 실행 계획</div>
           {loading ? (
             <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }} aria-hidden="true">
               <SkeletonBlock count={3} height={64} radius={16} gap={10} />
@@ -206,10 +206,10 @@ export function MorningBriefScreen({ onStart }: MorningBriefScreenProps) {
                     <div style={{ flex: 1 }}>
                       <div style={{ display: 'flex', gap: 6, marginBottom: 5, flexWrap: 'wrap' }}>
                         {isBigRock && (
-                          <span style={{ height: 'var(--ctrl-xs)', padding: '0 8px', background: 'var(--brand-surface)', borderRadius: 9999, fontSize: 9, color: '#FFFCF6', fontWeight: 700, fontFamily: 'var(--font-mono)', display: 'inline-flex', alignItems: 'center' }}>오늘의 큰 돌</span>
+                          <span style={{ height: 'var(--ctrl-xs)', padding: '0 8px', background: 'var(--brand-surface)', borderRadius: 9999, fontSize: 12, color: '#FFFCF6', fontWeight: 700, display: 'inline-flex', alignItems: 'center' }}>오늘의 큰 돌</span>
                         )}
                         {b.carryover && (
-                          <span style={{ height: 'var(--ctrl-xs)', padding: '0 8px', background: '#FBEEDA', border: '1px solid #F2D29A', borderRadius: 9999, fontSize: 9, color: 'var(--warning-ink)', fontWeight: 600, fontFamily: 'var(--font-mono)', display: 'inline-flex', alignItems: 'center' }}>이월</span>
+                          <span style={{ height: 'var(--ctrl-xs)', padding: '0 8px', background: '#FBEEDA', border: '1px solid #F2D29A', borderRadius: 9999, fontSize: 12, color: 'var(--warning-ink)', fontWeight: 600, display: 'inline-flex', alignItems: 'center' }}>이월</span>
                         )}
                         {b.time && (
                           <span className="tnum" style={{ height: 'var(--ctrl-xs)', padding: '0 8px', background: 'var(--sand-100)', border: '1px solid var(--sand-200)', borderRadius: 9999, fontSize: 10, color: 'var(--text-2)', fontWeight: 500, display: 'inline-flex', alignItems: 'center' }}>{b.time}</span>

--- a/src/screens/MyInfoScreen.tsx
+++ b/src/screens/MyInfoScreen.tsx
@@ -74,7 +74,7 @@ export function MyInfoScreen() {
           >
             <CaretLeft size={16} />
           </button>
-          <h1 style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 24, letterSpacing: '-0.02em', margin: 0 }}>내 정보</h1>
+          <h1 style={{ fontWeight: 800, fontSize: 24, letterSpacing: '-0.02em', margin: 0 }}>내 정보</h1>
         </div>
 
         {user && (
@@ -159,7 +159,7 @@ export function MyInfoScreen() {
 
 function SectionLabel({ icon, children }: { icon?: React.ReactNode; children: React.ReactNode }) {
   return (
-    <div style={{ display: 'flex', alignItems: 'center', gap: 5, fontSize: 10, fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--text-3)', fontFamily: 'var(--font-mono)', marginBottom: 8 }}>
+    <div style={{ display: 'flex', alignItems: 'center', gap: 5, fontSize: 12, fontWeight: 700, letterSpacing: '-0.01em', color: 'var(--text-3)', marginBottom: 8 }}>
       {icon}
       {children}
     </div>

--- a/src/screens/RecoveredScreen.tsx
+++ b/src/screens/RecoveredScreen.tsx
@@ -84,7 +84,7 @@ export function RecoveredScreen({ recoveryCount, applied, onDone, executionId }:
       <div style={{ width: 72, height: 72, borderRadius: 9999, background: 'var(--coral-50)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
         <ArrowsClockwise size={32} weight="fill" color="var(--brand)" />
       </div>
-      <div style={{ fontFamily: 'var(--font-display)', fontSize: 28, fontWeight: 500, letterSpacing: '-0.01em' }}>복구 계획이 준비됐어요</div>
+      <div style={{ fontSize: 28, fontWeight: 500, letterSpacing: '-0.01em' }}>복구 계획이 준비됐어요</div>
 
       {/* Before → After — 무엇이 어떻게 바뀌었는지 한눈에. */}
       {view ? (
@@ -93,7 +93,7 @@ export function RecoveredScreen({ recoveryCount, applied, onDone, executionId }:
           <div style={{ background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', borderRadius: 14, padding: '12px 14px', textAlign: 'left', display: 'flex', alignItems: 'flex-start', gap: 10 }}>
             <XCircle size={18} color="var(--danger-ink)" style={{ flexShrink: 0, marginTop: 1 }} />
             <div style={{ flex: 1, minWidth: 0 }}>
-              <div style={{ fontSize: 9, fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--text-3)', fontFamily: 'var(--font-mono)', marginBottom: 3 }}>이전</div>
+              <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: '-0.01em', color: 'var(--text-3)', marginBottom: 3 }}>이전</div>
               <div style={{ fontSize: 14, fontWeight: 700, color: 'var(--text-2)', textDecoration: 'line-through', textDecorationColor: 'var(--sand-300)' }}>{view.taskTitle}</div>
               {view.failReason && <div style={{ fontSize: 11, color: 'var(--text-3)', marginTop: 2 }}>막힌 이유: {view.failReason}</div>}
             </div>
@@ -105,7 +105,7 @@ export function RecoveredScreen({ recoveryCount, applied, onDone, executionId }:
           <div style={{ background: 'var(--brand-soft)', border: '1.5px solid var(--coral-200)', borderRadius: 14, padding: '12px 14px', textAlign: 'left', display: 'flex', alignItems: 'flex-start', gap: 10 }}>
             <CheckCircle size={18} weight="fill" color="var(--brand)" style={{ flexShrink: 0, marginTop: 1 }} />
             <div style={{ flex: 1, minWidth: 0 }}>
-              <div style={{ fontSize: 9, fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--coral-600)', fontFamily: 'var(--font-mono)', marginBottom: 3 }}>이렇게 다시</div>
+              <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: '-0.01em', color: 'var(--coral-600)', marginBottom: 3 }}>이렇게 다시</div>
               <div style={{ fontSize: 14, fontWeight: 700, color: 'var(--text-1)' }}>{view.proposalTitle}</div>
               {view.proposalDesc && <div style={{ fontSize: 12, color: 'var(--coral-700)', marginTop: 2, lineHeight: 1.5 }}>{view.proposalDesc}</div>}
               {view.proposalTime && view.proposalTime !== '—' && (
@@ -118,7 +118,7 @@ export function RecoveredScreen({ recoveryCount, applied, onDone, executionId }:
 
           {/* 백엔드 diff 가 응답하면 실제 일정 반영 확정, 아니면 미리보기임을 정직하게 알림. */}
           {usingRealDiff ? (
-            <div style={{ display: 'inline-flex', alignItems: 'center', gap: 5, alignSelf: 'flex-start', marginTop: 2, fontSize: 10, fontWeight: 700, color: 'var(--success-ink)', fontFamily: 'var(--font-mono)' }}>
+            <div style={{ display: 'inline-flex', alignItems: 'center', gap: 5, alignSelf: 'flex-start', marginTop: 2, fontSize: 12, fontWeight: 700, color: 'var(--success-ink)' }}>
               <CheckCircle size={12} weight="fill" /> 실제 일정에 반영됐어요
             </div>
           ) : (
@@ -135,7 +135,7 @@ export function RecoveredScreen({ recoveryCount, applied, onDone, executionId }:
 
       {/* 이번 세션 회복 카드 (백엔드 누적 집계 엔드포인트가 없어 세션 카운트로 정직하게) */}
       <div style={{ background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', borderRadius: 18, padding: 18, width: '100%', maxWidth: 320, textAlign: 'left', flexShrink: 0 }}>
-        <div style={{ fontSize: 10, fontWeight: 600, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--text-3)', fontFamily: 'var(--font-mono)', marginBottom: 8 }}>이번 세션 회복</div>
+        <div style={{ fontSize: 12, fontWeight: 600, letterSpacing: '-0.01em', color: 'var(--text-3)', marginBottom: 8 }}>이번 세션 회복</div>
         <div style={{ display: 'flex', alignItems: 'baseline', gap: 6 }}>
           <span className="tnum" style={{ fontSize: 44, fontWeight: 800, color: 'var(--brand-ink)', letterSpacing: '-0.03em' }}>{recoveryCount}</span>
           <span style={{ fontSize: 16, color: 'var(--text-2)' }}>회</span>

--- a/src/screens/RecoveryScreen.tsx
+++ b/src/screens/RecoveryScreen.tsx
@@ -144,7 +144,7 @@ export function MergedRecoveryScreen({ task, failReason, onAccept, onDismiss, ex
   if (alreadyDecided) {
     return (
       <div style={{ position: 'absolute', inset: 0, zIndex: 50, background: 'var(--surface-ground)', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '40px 24px', gap: 14 }}>
-        <div style={{ fontFamily: 'var(--font-display)', fontWeight: 700, fontSize: 22 }}>이미 회복 계획을 골랐어요</div>
+        <div style={{ fontWeight: 700, fontSize: 22 }}>이미 회복 계획을 골랐어요</div>
         <p style={{ fontSize: 13, color: 'var(--text-2)', maxWidth: 260, margin: 0, lineHeight: 1.6 }}>이 카드는 회복 방법이 정해져 있어요. 주간 계획에서 새로 잡힌 시간을 확인할 수 있어요.</p>
         <button onClick={onDismiss} style={{ height: 44, padding: '0 20px', borderRadius: 12, border: 'none', background: 'var(--text-1)', color: '#FAF6EE', fontWeight: 700, fontSize: 14, fontFamily: 'inherit', cursor: 'pointer' }}>오늘로 돌아가기</button>
       </div>
@@ -155,7 +155,7 @@ export function MergedRecoveryScreen({ task, failReason, onAccept, onDismiss, ex
   if (!task) {
     return (
       <div style={{ position: 'absolute', inset: 0, zIndex: 50, background: 'var(--surface-ground)', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '40px 24px', gap: 14 }}>
-        <div style={{ fontFamily: 'var(--font-display)', fontWeight: 700, fontSize: 22 }}>회복할 카드를 먼저 골라주세요</div>
+        <div style={{ fontWeight: 700, fontSize: 22 }}>회복할 카드를 먼저 골라주세요</div>
         <p style={{ fontSize: 13, color: 'var(--text-2)', maxWidth: 260, margin: 0, lineHeight: 1.6 }}>오늘 화면에서 ‘일부만’ 또는 ‘잘 안됨’ 으로 표시한 카드가 있으면 여기서 회복 제안을 받을 수 있어요.</p>
         <button onClick={onDismiss} style={{ height: 44, padding: '0 20px', borderRadius: 12, border: 'none', background: 'var(--text-1)', color: '#FAF6EE', fontWeight: 700, fontSize: 14, fontFamily: 'inherit', cursor: 'pointer' }}>오늘로 돌아가기</button>
       </div>
@@ -209,7 +209,7 @@ export function MergedRecoveryScreen({ task, failReason, onAccept, onDismiss, ex
         <div style={{ width: 72, height: 72, borderRadius: 9999, background: 'var(--coral-50)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
           <ArrowsClockwise size={32} weight="fill" color="var(--brand)" />
         </div>
-        <div style={{ fontFamily: 'var(--font-display)', fontSize: 30, fontWeight: 500, letterSpacing: '-0.01em' }}>좋아요.</div>
+        <div style={{ fontSize: 30, fontWeight: 500, letterSpacing: '-0.01em' }}>좋아요.</div>
         <p style={{ fontSize: 14, color: 'var(--text-2)', lineHeight: 1.6, maxWidth: 260 }}>{p?.title} — 복구안을 적용하고 있어요…</p>
       </div>
     );
@@ -229,18 +229,18 @@ export function MergedRecoveryScreen({ task, failReason, onAccept, onDismiss, ex
             <div style={{ display: 'flex', gap: 10, alignItems: 'center', marginBottom: 14, padding: '9px 11px', background: 'var(--sand-100)', border: '1px solid var(--sand-200)', borderRadius: 10 }}>
               <Flag size={14} color="var(--text-3)" weight="fill" style={{ flexShrink: 0 }} />
               <div style={{ flex: 1, minWidth: 0 }}>
-                <div style={{ fontSize: 9, fontWeight: 700, letterSpacing: '0.08em', color: 'var(--text-3)', fontFamily: 'var(--font-mono)', marginBottom: 1 }}>여기서 멈췄어요</div>
+                <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: '-0.01em', color: 'var(--text-3)', marginBottom: 1 }}>여기서 멈췄어요</div>
                 <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--text-1)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{task.title}</div>
                 {failReason && <div style={{ fontSize: 10, color: 'var(--text-3)', marginTop: 1 }}>{failReason} · 실행 기록에 남겼어요</div>}
               </div>
             </div>
           )}
 
-          <div style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 10, fontWeight: 700, letterSpacing: '0.08em', color: 'var(--coral-600)', marginBottom: 10, fontFamily: 'var(--font-mono)' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12, fontWeight: 700, letterSpacing: '-0.01em', color: 'var(--coral-600)', marginBottom: 10 }}>
             <Sparkle size={12} weight="fill" /> AI 추천 · 회복 제안
           </div>
 
-          <div style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 26, letterSpacing: '-0.01em', lineHeight: 1.2, marginBottom: 6 }}>오늘은 절반쯤 왔어요.</div>
+          <div style={{ fontWeight: 800, fontSize: 26, letterSpacing: '-0.01em', lineHeight: 1.2, marginBottom: 6 }}>오늘은 절반쯤 왔어요.</div>
           <p style={{ fontSize: 13, color: 'var(--text-2)', marginBottom: 12, lineHeight: 1.55 }}>끝까지 가지 못해도 괜찮아요. 다시 시작할 방법이 있어요.</p>
 
           {!usingRealProposals && (

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -136,7 +136,7 @@ export function SettingsScreen() {
           >
             <CaretLeft size={16} />
           </button>
-          <h1 style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 24, letterSpacing: '-0.02em', margin: 0 }}>설정</h1>
+          <h1 style={{ fontWeight: 800, fontSize: 24, letterSpacing: '-0.02em', margin: 0 }}>설정</h1>
         </div>
 
         {user && (

--- a/src/screens/SetupScreen.tsx
+++ b/src/screens/SetupScreen.tsx
@@ -188,7 +188,7 @@ export function SetupScreen({ onDone }: SetupScreenProps) {
     <div style={{ height: '100%', display: 'flex', flexDirection: 'column', background: 'var(--surface-ground)' }}>
       <div style={{ flex: 1, overflowY: 'auto', padding: '16px 20px 0' }}>
         <SetupProgress current={3} total={4} label="마무리" />
-        <h1 style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 26, lineHeight: 1.2, letterSpacing: '-0.02em', marginBottom: 6 }}>
+        <h1 style={{ fontWeight: 800, fontSize: 26, lineHeight: 1.2, letterSpacing: '-0.02em', marginBottom: 6 }}>
           마지막 확인이에요
         </h1>
         <p style={{ color: 'var(--text-2)', fontSize: 13, marginBottom: 16 }}>
@@ -222,7 +222,7 @@ export function SetupScreen({ onDone }: SetupScreenProps) {
           <div style={{ flex: 1 }}>
             <div style={{ fontWeight: 600, fontSize: 12, color: 'var(--text-2)', display: 'flex', alignItems: 'center', gap: 5 }}>
               Google 캘린더 자동 가져오기
-              <span style={{ height: 'var(--ctrl-xs)', padding: '0 5px', borderRadius: 9999, background: 'var(--sand-200)', fontSize: 8, fontWeight: 700, color: 'var(--text-3)', fontFamily: 'var(--font-mono)', display: 'inline-flex', alignItems: 'center' }}>준비 중</span>
+              <span style={{ height: 'var(--ctrl-xs)', padding: '0 5px', borderRadius: 9999, background: 'var(--sand-200)', fontSize: 12, fontWeight: 700, color: 'var(--text-3)', display: 'inline-flex', alignItems: 'center' }}>준비 중</span>
             </div>
             <div style={{ fontSize: 10, color: 'var(--text-3)', marginTop: 1 }}>지금은 아래에서 직접 추가해 주세요</div>
           </div>
@@ -332,7 +332,7 @@ export function SetupScreen({ onDone }: SetupScreenProps) {
 
 function SectionTitle({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ fontSize: 9, fontWeight: 700, letterSpacing: '0.12em', textTransform: 'uppercase', color: 'var(--text-3)', fontFamily: 'var(--font-mono)', marginBottom: 8 }}>{children}</div>
+    <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: '-0.01em', color: 'var(--text-3)', marginBottom: 8 }}>{children}</div>
   );
 }
 
@@ -355,7 +355,7 @@ function TimeChips({ icon, title, options, value, onChange }: {
         {options.map((opt) => {
           const active = opt === value;
           return (
-            <button key={opt} onClick={() => onChange(opt)} className="tnum" style={{ height: 26, padding: '0 9px', borderRadius: 9999, border: `1px solid ${active ? 'var(--brand)' : 'var(--sand-200)'}`, background: active ? 'var(--brand-surface)' : 'var(--surface-ground)', color: active ? '#FFFCF6' : 'var(--text-2)', fontWeight: 600, fontSize: 10, cursor: 'pointer', fontFamily: 'var(--font-mono)' }}>{opt}</button>
+            <button key={opt} onClick={() => onChange(opt)} className="tnum" style={{ height: 26, padding: '0 9px', borderRadius: 9999, border: `1px solid ${active ? 'var(--brand)' : 'var(--sand-200)'}`, background: active ? 'var(--brand-surface)' : 'var(--surface-ground)', color: active ? '#FFFCF6' : 'var(--text-2)', fontWeight: 600, fontSize: 10, cursor: 'pointer' }}>{opt}</button>
           );
         })}
       </div>

--- a/src/screens/SystemIntroScreen.tsx
+++ b/src/screens/SystemIntroScreen.tsx
@@ -49,9 +49,9 @@ function TeaserVisual() {
         </div>
         <div style={{ flex: 1, minWidth: 0 }}>
           <div style={{ fontSize: 13, fontWeight: 700, color: 'var(--text-1)', marginBottom: 2 }}>자기소개서 도입부 작성</div>
-          <div style={{ fontSize: 11, color: 'var(--danger-ink)', fontFamily: 'var(--font-mono)' }}>실패 — 막막해서 시작 못 함</div>
+          <div style={{ fontSize: 11, color: 'var(--danger-ink)' }}>실패 — 막막해서 시작 못 함</div>
         </div>
-        <span style={{ fontSize: 10, color: 'var(--text-4)', fontFamily: 'var(--font-mono)', flexShrink: 0 }}>오후 9:00</span>
+        <span style={{ fontSize: 12, fontWeight: 700, color: 'var(--text-4)', flexShrink: 0 }}>오후 9:00</span>
       </div>
 
       {/* 연결 화살표 + AI 뱃지 */}
@@ -63,8 +63,8 @@ function TeaserVisual() {
           display: 'inline-flex', alignItems: 'center', gap: 5,
           height: 20, padding: '0 10px',
           background: 'var(--sand-950)', borderRadius: 9999,
-          fontSize: 9, fontWeight: 700, color: '#FAF6EE',
-          fontFamily: 'var(--font-mono)', letterSpacing: '0.08em',
+          fontSize: 12, fontWeight: 700, color: '#FAF6EE',
+          letterSpacing: '-0.01em',
         }}>
           <Sparkle size={10} weight="fill" color="var(--brand)" />
           RE:ACTION 분석
@@ -82,14 +82,14 @@ function TeaserVisual() {
         </div>
         <div style={{ flex: 1, minWidth: 0 }}>
           <div style={{ fontSize: 13, fontWeight: 700, color: 'var(--text-1)', marginBottom: 2 }}>딱 3문장만 써보기</div>
-          <div style={{ fontSize: 11, color: 'var(--success-ink)', fontFamily: 'var(--font-mono)' }}>작게 시작 · 성공률 88%</div>
+          <div style={{ fontSize: 11, color: 'var(--success-ink)' }}>작게 시작 · 성공률 88%</div>
         </div>
         <div style={{
           height: 20, padding: '0 8px',
           background: 'var(--success)', borderRadius: 9999,
-          fontSize: 9, fontWeight: 700, color: '#fff',
+          fontSize: 12, fontWeight: 700, color: '#fff',
           display: 'inline-flex', alignItems: 'center',
-          fontFamily: 'var(--font-mono)', flexShrink: 0,
+          flexShrink: 0,
         }}>완료</div>
       </div>
     </div>
@@ -116,7 +116,7 @@ function MemoryDiagram() {
             : <XCircle size={14} weight="fill" color="var(--danger-ink)" style={{ flexShrink: 0 }} />
           }
           <div style={{ flex: 1, fontSize: 12, fontWeight: 600, color: 'var(--text-1)' }}>{r.t}</div>
-          <span style={{ fontSize: 9, fontWeight: 600, color: r.ok ? 'var(--success-ink)' : 'var(--danger-ink)', fontFamily: 'var(--font-mono)' }}>{r.st}</span>
+          <span style={{ fontSize: 12, fontWeight: 600, color: r.ok ? 'var(--success-ink)' : 'var(--danger-ink)' }}>{r.st}</span>
         </div>
       ))}
       <div style={{ padding: '8px 10px', background: 'var(--brand-soft)', border: '1px solid var(--coral-200)', borderRadius: 10, fontSize: 11, color: 'var(--coral-700)', display: 'flex', alignItems: 'center', gap: 7 }}>
@@ -137,7 +137,7 @@ function RecoveryDiagram() {
     <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
       {items.map((r, i) => (
         <div key={i} style={{ background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', borderRadius: 10, padding: '9px 12px' }}>
-          <div style={{ display: 'inline-flex', alignItems: 'center', height: 'var(--ctrl-xs)', padding: '0 7px', background: r.bg, border: `1px solid ${r.bc}`, borderRadius: 9999, fontSize: 9, fontWeight: 700, color: r.tc, letterSpacing: '0.06em', marginBottom: 4, fontFamily: 'var(--font-mono)' }}>{r.type}</div>
+          <div style={{ display: 'inline-flex', alignItems: 'center', height: 'var(--ctrl-xs)', padding: '0 7px', background: r.bg, border: `1px solid ${r.bc}`, borderRadius: 9999, fontSize: 9, fontWeight: 700, color: r.tc, letterSpacing: '0', marginBottom: 4 }}>{r.type}</div>
           <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--text-1)', marginBottom: 1 }}>{r.t}</div>
           <div style={{ fontSize: 10, color: 'var(--text-3)' }}>{r.w}</div>
         </div>
@@ -160,13 +160,13 @@ export function SystemIntroScreen({ onDone }: SystemIntroScreenProps) {
               display: 'inline-flex', alignItems: 'center',
               height: 22, padding: '0 10px',
               background: 'var(--brand-surface)', color: '#FFFCF6',
-              borderRadius: 9999, fontSize: 9, fontWeight: 700,
-              letterSpacing: '0.1em', fontFamily: 'var(--font-mono)',
+              borderRadius: 9999, fontSize: 12, fontWeight: 700,
+              letterSpacing: '-0.01em',
               marginBottom: 16,
             }}>{s.tag}</div>
 
             <div style={{
-              fontFamily: 'var(--font-display)', fontWeight: 800,
+              fontWeight: 800,
               fontSize: 36, lineHeight: 1.1, letterSpacing: '-0.03em',
               marginBottom: 14, whiteSpace: 'pre-line', color: 'var(--text-1)',
             }}>{s.title}</div>

--- a/src/screens/TodayScreen.tsx
+++ b/src/screens/TodayScreen.tsx
@@ -450,7 +450,7 @@ export function MergedTodayScreen({ tasks: allTasks, onOpen, onMarkDone, onParti
         {/* Header — 한 줄로 압축. 열품타식 미니멀. */}
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
           <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, minWidth: 0 }}>
-            <span style={{ fontFamily: 'var(--font-display)', fontSize: 18, fontWeight: 700, letterSpacing: '-0.01em', color: 'var(--text-1)' }}>{userName}</span>
+            <span style={{ fontSize: 18, fontWeight: 700, letterSpacing: '-0.01em', color: 'var(--text-1)' }}>{userName}</span>
             <span className="tnum" style={{ fontSize: 11, color: 'var(--text-3)' }}>{todayShortKo()}</span>
           </div>
           <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
@@ -587,7 +587,7 @@ export function MergedTodayScreen({ tasks: allTasks, onOpen, onMarkDone, onParti
                   style={{ width: '100%', height: 40, borderRadius: 10, border: '1px solid var(--sand-200)', background: 'var(--surface-ground)', padding: '0 12px', boxSizing: 'border-box', outline: 'none', fontSize: 14, fontFamily: 'inherit', color: 'var(--text-1)' }}
                 />
                 <div>
-                  <div style={{ fontSize: 10, fontWeight: 600, color: 'var(--text-3)', letterSpacing: '0.04em', textTransform: 'uppercase', marginBottom: 6 }}>주 몇 회</div>
+                  <div style={{ fontSize: 10, fontWeight: 600, color: 'var(--text-3)', letterSpacing: '0.04em', marginBottom: 6 }}>주 몇 회</div>
                   <div style={{ display: 'flex', gap: 4 }}>
                     {[1, 2, 3, 4, 5, 6, 7].map((n) => {
                       const sel = newHabitFreq === n;
@@ -598,7 +598,7 @@ export function MergedTodayScreen({ tasks: allTasks, onOpen, onMarkDone, onParti
                   </div>
                 </div>
                 <div>
-                  <div style={{ fontSize: 10, fontWeight: 600, color: 'var(--text-3)', letterSpacing: '0.04em', textTransform: 'uppercase', marginBottom: 6 }}>카테고리</div>
+                  <div style={{ fontSize: 10, fontWeight: 600, color: 'var(--text-3)', letterSpacing: '0.04em', marginBottom: 6 }}>카테고리</div>
                   <select value={newHabitCategory} onChange={(e) => setNewHabitCategory(e.target.value)} style={{ width: '100%', height: 38, borderRadius: 10, border: '1px solid var(--sand-200)', background: 'var(--surface-ground)', padding: '0 10px', fontSize: 13, fontFamily: 'inherit', color: 'var(--text-1)', outline: 'none' }}>
                     {GOAL_CATEGORY_OPTIONS.map((c) => <option key={c.value} value={c.value}>{c.label}</option>)}
                   </select>
@@ -637,13 +637,13 @@ export function MergedTodayScreen({ tasks: allTasks, onOpen, onMarkDone, onParti
             <div style={{ fontSize: 19, fontWeight: 800, color: 'var(--text-1)', letterSpacing: '-0.01em', marginBottom: 14 }}>{detailTask.title}</div>
             {detailTask.whyNow && (
               <div style={{ marginBottom: 12 }}>
-                <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.06em', textTransform: 'uppercase', color: 'var(--brand-ink)', fontFamily: 'var(--font-mono)', marginBottom: 4 }}>왜 지금</div>
+                <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: '-0.01em', color: 'var(--brand-ink)', marginBottom: 4 }}>왜 지금</div>
                 <p style={{ margin: 0, fontSize: 13, color: 'var(--text-2)', lineHeight: 1.55 }}>{detailTask.whyNow}</p>
               </div>
             )}
             {detailTask.firstStep && (
               <div style={{ marginBottom: 16, padding: '10px 12px', background: 'var(--brand-soft)', border: '1px solid var(--coral-200)', borderRadius: 12 }}>
-                <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.06em', textTransform: 'uppercase', color: 'var(--coral-700)', fontFamily: 'var(--font-mono)', marginBottom: 4 }}>첫 걸음</div>
+                <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: '-0.01em', color: 'var(--coral-700)', marginBottom: 4 }}>첫 걸음</div>
                 <p style={{ margin: 0, fontSize: 13, color: 'var(--coral-700)', lineHeight: 1.55 }}>{detailTask.firstStep}</p>
               </div>
             )}

--- a/src/screens/WeeklyCalendarScreen.tsx
+++ b/src/screens/WeeklyCalendarScreen.tsx
@@ -580,7 +580,7 @@ export function WeeklyCalendarScreenV2() {
             { label: '완료', n: blocks.filter((b) => b.status === 'done').length, bg: '#E5EFE3', bd: '#b4dfc8', fg: 'var(--success-ink)' },
             { label: '대기', n: blocks.filter((b) => b.status === 'pending').length, bg: 'var(--sand-100)', bd: 'var(--sand-200)', fg: 'var(--text-2)' },
           ].map((c, i) => (
-            <span key={i} className="tnum" style={{ height: 'var(--ctrl-xs)', padding: '0 9px', background: c.bg, border: `1px solid ${c.bd}`, borderRadius: 9999, fontSize: 10, color: c.fg, fontWeight: 600, display: 'inline-flex', alignItems: 'center', fontFamily: 'var(--font-mono)' }}>{c.label} {c.n}</span>
+            <span key={i} className="tnum" style={{ height: 'var(--ctrl-xs)', padding: '0 9px', background: c.bg, border: `1px solid ${c.bd}`, borderRadius: 9999, fontSize: 10, color: c.fg, fontWeight: 600, display: 'inline-flex', alignItems: 'center' }}>{c.label} {c.n}</span>
           ))}
 
           <div style={{ flex: 1 }} />
@@ -588,13 +588,13 @@ export function WeeklyCalendarScreenV2() {
           {hiddenHours > 0 && !showAllHours && (
             <button
               onClick={() => setShowAllHours(true)}
-              style={{ height: 'var(--ctrl-xs)', padding: '0 9px', borderRadius: 9999, border: '1px dashed var(--sand-300)', background: 'transparent', color: 'var(--text-3)', fontSize: 10, fontWeight: 600, cursor: 'pointer', fontFamily: 'var(--font-mono)' }}
+              style={{ height: 'var(--ctrl-xs)', padding: '0 9px', borderRadius: 9999, border: '1px dashed var(--sand-300)', background: 'transparent', color: 'var(--text-3)', fontSize: 12, fontWeight: 600, cursor: 'pointer' }}
             >빈 {hiddenHours}시간 접힘</button>
           )}
           {showAllHours && (
             <button
               onClick={() => setShowAllHours(false)}
-              style={{ height: 'var(--ctrl-xs)', padding: '0 9px', borderRadius: 9999, border: '1px solid var(--sand-200)', background: 'var(--surface-raised)', color: 'var(--text-3)', fontSize: 10, fontWeight: 600, cursor: 'pointer', fontFamily: 'var(--font-mono)' }}
+              style={{ height: 'var(--ctrl-xs)', padding: '0 9px', borderRadius: 9999, border: '1px solid var(--sand-200)', background: 'var(--surface-raised)', color: 'var(--text-3)', fontSize: 12, fontWeight: 600, cursor: 'pointer' }}
             >24시간</button>
           )}
 
@@ -606,7 +606,7 @@ export function WeeklyCalendarScreenV2() {
                   key={n}
                   onClick={() => setDayView(n)}
                   className="tnum"
-                  style={{ height: 22, padding: '0 10px', borderRadius: 9999, border: 'none', background: on ? 'var(--surface-raised)' : 'transparent', color: on ? 'var(--text-1)' : 'var(--text-3)', fontSize: 10, fontWeight: 700, cursor: 'pointer', fontFamily: 'var(--font-mono)', boxShadow: on ? 'var(--shadow-sm, 0 1px 2px rgba(0,0,0,.06))' : 'none' }}
+                  style={{ height: 22, padding: '0 10px', borderRadius: 9999, border: 'none', background: on ? 'var(--surface-raised)' : 'transparent', color: on ? 'var(--text-1)' : 'var(--text-3)', fontSize: 12, fontWeight: 700, cursor: 'pointer', boxShadow: on ? 'var(--shadow-sm, 0 1px 2px rgba(0,0,0,.06))' : 'none' }}
                 >{n}일</button>
               );
             })}

--- a/src/screens/WeeklyPlanGenerationScreen.tsx
+++ b/src/screens/WeeklyPlanGenerationScreen.tsx
@@ -91,11 +91,11 @@ function PlanGeneratingView() {
       <div style={{ width: 64, height: 64, borderRadius: 9999, background: 'var(--coral-50)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
         <div style={{ width: 28, height: 28, border: '3px solid var(--coral-200)', borderTopColor: 'var(--brand)', borderRadius: 9999, animation: 'spin 1s linear infinite' }} />
       </div>
-      <div style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 22, letterSpacing: '-0.02em' }}>주간 계획 생성 중…</div>
+      <div style={{ fontWeight: 800, fontSize: 22, letterSpacing: '-0.02em' }}>주간 계획 생성 중…</div>
 
       {/* 현재 단계 (N/총) — 실제 파이프라인 순서에 맞춘 문구 */}
       <div aria-live="polite" style={{ minHeight: 20, display: 'flex', alignItems: 'center', gap: 7 }}>
-        <span className="tnum" style={{ fontSize: 10, fontFamily: 'var(--font-mono)', color: 'var(--text-3)', letterSpacing: '0.06em' }}>{stage + 1}/{GEN_STAGES.length}</span>
+        <span className="tnum" style={{ fontSize: 12, fontWeight: 700, color: 'var(--text-3)', letterSpacing: '-0.01em' }}>{stage + 1}/{GEN_STAGES.length}</span>
         <span key={stage} style={{ fontSize: 13, color: 'var(--text-2)', animation: 'toastIn 350ms ease-out' }}>{GEN_STAGES[stage]}</span>
       </div>
 
@@ -110,7 +110,7 @@ function PlanGeneratingView() {
           <Lightbulb size={14} weight="fill" color="var(--brand)" />
         </div>
         <div style={{ flex: 1, minWidth: 0 }}>
-          <div style={{ fontSize: 9, fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--text-3)', fontFamily: 'var(--font-mono)', marginBottom: 3 }}>알아두면 좋아요</div>
+          <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: '-0.01em', color: 'var(--text-3)', marginBottom: 3 }}>알아두면 좋아요</div>
           <p key={tip} style={{ margin: 0, fontSize: 12, color: 'var(--text-2)', lineHeight: 1.5, animation: 'toastIn 400ms ease-out' }}>{GEN_TIPS[tip]}</p>
         </div>
       </div>
@@ -465,11 +465,11 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
         <SetupProgress current={4} total={4} label="계획" />
         {/* 헤더 'AI 생성 완료' 뱃지는 AiDraftCard 가 푸터에서 동일 정보 (LLM 아이콘 + 점선 +
             '수락/수정/재생성' 라벨) 를 표시하므로 중복 제거. §1.4 잠금 결정의 시각 통일. */}
-        <h2 style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 22, letterSpacing: '-0.02em', margin: '0 0 6px' }}>계획이 만들어졌어요</h2>
+        <h2 style={{ fontWeight: 800, fontSize: 22, letterSpacing: '-0.02em', margin: '0 0 6px' }}>계획이 만들어졌어요</h2>
         <p style={{ fontSize: 12, color: 'var(--text-2)', margin: '0 0 8px' }}>블록을 탭하면 수정, 끌면 15분 단위로 옮길 수 있어요.</p>
         {/* 3일 뷰에선 일부 요일이 가려지므로, 승인 판단에 필요한 '이번 주 몇 개'를 함께 둔다. */}
         <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 8 }}>
-          <span className="tnum" style={{ height: 'var(--ctrl-xs)', padding: '0 9px', background: 'var(--brand-soft)', border: '1px solid var(--coral-200)', borderRadius: 9999, fontSize: 10, fontWeight: 700, color: 'var(--brand-ink)', display: 'inline-flex', alignItems: 'center', fontFamily: 'var(--font-mono)' }}>
+          <span className="tnum" style={{ height: 'var(--ctrl-xs)', padding: '0 9px', background: 'var(--brand-soft)', border: '1px solid var(--coral-200)', borderRadius: 9999, fontSize: 12, fontWeight: 700, color: 'var(--brand-ink)', display: 'inline-flex', alignItems: 'center' }}>
             이번 주 {weekBlocks.length}개
           </span>
           <div style={{ flex: 1 }} />
@@ -481,7 +481,7 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
                   key={n}
                   onClick={() => setDayView(n)}
                   className="tnum"
-                  style={{ height: 22, padding: '0 10px', borderRadius: 9999, border: 'none', background: on ? 'var(--surface-raised)' : 'transparent', color: on ? 'var(--text-1)' : 'var(--text-3)', fontSize: 10, fontWeight: 700, cursor: 'pointer', fontFamily: 'var(--font-mono)' }}
+                  style={{ height: 22, padding: '0 10px', borderRadius: 9999, border: 'none', background: on ? 'var(--surface-raised)' : 'transparent', color: on ? 'var(--text-1)' : 'var(--text-3)', fontSize: 12, fontWeight: 700, cursor: 'pointer' }}
                 >{n}일</button>
               );
             })}

--- a/src/screens/WeeklyReviewScreen.tsx
+++ b/src/screens/WeeklyReviewScreen.tsx
@@ -148,8 +148,8 @@ export function WeeklyReviewScreenV2() {
 
         {/* Header */}
         <div>
-          <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--text-3)', fontFamily: 'var(--font-mono)', marginBottom: 3 }}>{weekLabel}</div>
-          <h1 style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 24, letterSpacing: '-0.02em', margin: '0 0 10px' }}>{headline}</h1>
+          <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: '-0.01em', color: 'var(--text-3)', marginBottom: 3 }}>{weekLabel}</div>
+          <h1 style={{ fontWeight: 800, fontSize: 24, letterSpacing: '-0.02em', margin: '0 0 10px' }}>{headline}</h1>
           {reviewLoading ? null : !usingReal ? (
             <DemoNotice storageKey="weekly-review">
               주간 리뷰를 서버에서 불러오지 못했어요. 잠시 후 다시 시도해 주세요.
@@ -166,7 +166,7 @@ export function WeeklyReviewScreenV2() {
           <div key={c.habitId} style={{ background: 'var(--surface-raised)', border: '1px solid var(--coral-200)', borderRadius: 16, padding: '14px 16px', display: 'flex', flexDirection: 'column', gap: 10 }}>
             <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
               <Sparkle size={13} color="var(--brand)" weight="fill" />
-              <span style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--coral-600)', fontFamily: 'var(--font-mono)' }}>습관 조정 제안</span>
+              <span style={{ fontSize: 12, fontWeight: 700, letterSpacing: '-0.01em', color: 'var(--coral-600)' }}>습관 조정 제안</span>
             </div>
             <div style={{ fontSize: 14, fontWeight: 700, color: 'var(--text-1)' }}>{c.title}</div>
             <p style={{ margin: 0, fontSize: 12, color: 'var(--text-2)', lineHeight: 1.55 }}>
@@ -199,9 +199,9 @@ export function WeeklyReviewScreenV2() {
         <div style={{ background: 'linear-gradient(135deg, var(--coral-50) 0%, var(--surface-raised) 100%)', border: '1px solid var(--coral-200)', borderRadius: 18, padding: '14px 16px', display: 'flex', alignItems: 'center', gap: 14, minWidth: 0 }}>
           <ScoreDonut score={score} />
           <div style={{ flex: 1, minWidth: 0 }}>
-            <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--coral-600)', fontFamily: 'var(--font-mono)', marginBottom: 3 }}>주간 점수</div>
+            <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: '-0.01em', color: 'var(--coral-600)', marginBottom: 3 }}>주간 점수</div>
             {real?.oneLiner && (
-              <div style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 15, letterSpacing: '-0.01em', color: 'var(--text-1)', lineHeight: 1.3, marginBottom: 5 }}>
+              <div style={{ fontWeight: 800, fontSize: 15, letterSpacing: '-0.01em', color: 'var(--text-1)', lineHeight: 1.3, marginBottom: 5 }}>
                 {real.oneLiner}
               </div>
             )}
@@ -244,8 +244,8 @@ export function WeeklyReviewScreenV2() {
                   </div>
                 </div>
                 <div>
-                  <div style={{ fontSize: 9, fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--text-3)', fontFamily: 'var(--font-mono)' }}>{k.label}</div>
-                  <div className="tnum" style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 22, letterSpacing: '-0.03em', color: 'var(--text-1)' }}>
+                  <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: '-0.01em', color: 'var(--text-3)' }}>{k.label}</div>
+                  <div className="tnum" style={{ fontWeight: 800, fontSize: 22, letterSpacing: '-0.03em', color: 'var(--text-1)' }}>
                     {k.val}<span style={{ fontSize: 13, color: 'var(--text-3)' }}>{k.unit}</span>
                   </div>
                 </div>


### PR DESCRIPTION
전면 개편 **1단계**. 한국 여행/커머스 앱 관용을 기준으로 잡았습니다.

## 원인은 취향이 아니라 배선이었습니다

폰트 토큰 3개가 **전부 같은 서체**로 해석되고 있었습니다.

```
--font-sans     Pretendard
--font-display  Pretendard            ← sans 와 완전 동일
--font-mono     Pretendard, ui-mono…  ← 맨 앞이 Pretendard 라 mono 가 절대 적용 안 됨
```

`var(--font-mono)` 를 **82곳**, 대문자 라벨을 **33곳**에서 썼는데 실제로는 전부 그냥 Pretendard 대문자였습니다. '모노 캡션' 느낌은 **존재한 적이 없습니다.**

거기에 **Newsreader(세리프)를 CDN 에서 받아오면서 어디서도 쓰지 않았습니다** — 초기 로딩에 폰트 값만 치르고 화면엔 한 글자도 안 나왔습니다.

즉 한 서체·한 목소리에 9~10px 대문자 마이크로 라벨을 얹은 상태였고, 그게 기성품 대시보드처럼 읽히는 이유였습니다.

## 조사에서 방향을 바꿨습니다

한국 앱 관용은 서양 미니멀과 **반대**입니다 — "여백보다 밀도", "아이콘이 아니라 텍스트, 버튼은 완전한 문장". 지금 화면은 여백 많고 아이콘 위주에 마이크로 라벨이라 정확히 **서양 템플릿** 쪽이었습니다. 에어비앤비를 그대로 베끼면 더 나빠집니다.

## 한 것

- **Newsreader 임포트 제거** — 안 쓰는데 받고 있었습니다
- 폰트 토큰을 **Pretendard 하나로**. 위계는 크기·무게로. 인라인 `fontFamily` 전부 제거(23개 파일)
- `.tnum` 은 **자릿수 정렬만**. 모노 서체를 걸면 한글 섞인 라벨(`8월 16일 · 일요일`)에서 공백까지 모노 폭이 되어 단어가 벌어집니다
- **대문자 변환 30곳 제거** — 한글엔 대소문자가 없어 영문에만 걸리는 장식이었습니다
- 넓은 자간(0.06~0.14em) 정리
- **9~10px 마이크로 라벨 → 12px/700** 읽히는 섹션 라벨
- 라운드 스케일에 역할 부여 — 6 배지 / 12 행 / 18 카드 / 28 시트
- 그림자 4단(`sm/md/lg/xl`) → 기본 없음 + `--shadow-raise` 하나

## 탭바

- 아이콘 뒤 **검은 라운드 사각형 제거**. 활성은 색과 무게로만 — 에어비앤비·호퍼·트리플 모두 칩을 쓰지 않습니다
- 아이콘 16 → 22px, 라벨 9px 대문자 → **11px 한글**
- `주간` → `주간 계획` (한국 앱 관용: 버튼이 무엇을 하는지 말로 적습니다)
- 반투명+블러 → **불투명** (스크롤에 따라 라벨 대비가 흔들렸습니다)
- 하단 여백 `34px` 하드코딩 → `env(safe-area-inset-bottom)`

## 검증

- 13개 화면 회귀 에러 0 · 자료 시트 동작 유지 · `tsc` 0 errors
- `check:api` PASS · `check:fields` PASS(strict) · `build` 성공

## 다음 단계

오늘 화면을 **여정(itinerary) 레일**로 재구성합니다. 지금은 하단 **35%가 비어 있고**, 고정 일정 띠·히어로 카드·행이 서로 다른 **세 가지 시각 언어**입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)