### PR TITLE
feat(milestone): 큰 그림 카드를 꾹 눌러 끌면 순서가 바뀐다 — ▲/▼ 를 걷어낸다

### DIFF
--- a/src/screens/MilestoneConfirmScreen.tsx
+++ b/src/screens/MilestoneConfirmScreen.tsx
@@ -1,16 +1,30 @@
-import { useEffect, useState } from 'react';
-import { CaretLeft, CaretUp, CaretDown, Plus, X, Sparkle, ArrowRight, Path } from '@phosphor-icons/react';
+import { useEffect, useRef, useState } from 'react';
+import { CaretLeft, Plus, X, Sparkle, ArrowRight, Path } from '@phosphor-icons/react';
 import { ApiError, plansApi } from '../lib/api';
 import { useNavigation } from '../contexts/NavigationContext';
 import type { MilestoneDraft } from '../types/api';
+
+// 카드마다 안정된 신원 — 순서가 바뀌어도 입력 포커스와 커서가 따라가야 해서 index 를 key 로 쓸 수 없다.
+type Row = MilestoneDraft & { uid: number };
+
+const LONG_PRESS_MS = 250; // 이만큼 누르고 있으면 드래그로 전환.
+const CANCEL_SLOP = 8;     // 전환 전에 이만큼 움직였으면 = 목록 스크롤. 드래그 후보에서 내린다.
+const CARD_GAP = 10;       // 카드 사이 간격(아래 목록 컨테이너의 gap 과 같아야 한다).
+
+// 드래그 중인 카드의 현재 상태. from→to 는 '놓으면 갈 자리'.
+type Drag = { from: number; to: number; dy: number; rowH: number };
 
 // 인터뷰 후, 계획을 세우기 전에 '중간 목표(마일스톤)' 뼈대를 사용자가 확인·편집하는 화면(Phase 2).
 // 확정하면 그 구조대로 계획이 생성되고, 건너뛰면 마일스톤 없이 자동 분해된다.
 export function MilestoneConfirmScreen() {
   const { interviewSessionId, setScreen, setPlannedMilestones } = useNavigation();
-  const [milestones, setMilestones] = useState<MilestoneDraft[]>([]);
+  const [milestones, setMilestones] = useState<Row[]>([]);
   const [loading, setLoading] = useState(true);
   const [failed, setFailed] = useState(false);
+  const [drag, setDrag] = useState<Drag | null>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const uidRef = useRef(0);
+  const withUid = (m: MilestoneDraft): Row => ({ ...m, uid: uidRef.current++ });
 
   useEffect(() => {
     let cancelled = false;
@@ -21,7 +35,7 @@ export function MilestoneConfirmScreen() {
       .then(
         (res) => {
           if (!cancelled) {
-            setMilestones(res.milestones ?? []);
+            setMilestones((res.milestones ?? []).map(withUid));
             setLoading(false);
           }
         },
@@ -46,7 +60,120 @@ export function MilestoneConfirmScreen() {
       [next[i], next[j]] = [next[j], next[i]];
       return next;
     });
-  const add = () => setMilestones((ms) => [...ms, { title: '', summary: '' }]);
+  const reorder = (from: number, to: number) =>
+    setMilestones((ms) => {
+      if (from === to || from < 0 || to < 0 || from >= ms.length || to >= ms.length) return ms;
+      const next = [...ms];
+      const [row] = next.splice(from, 1);
+      next.splice(to, 0, row);
+      return next;
+    });
+  const add = () => setMilestones((ms) => [...ms, withUid({ title: '', summary: '' })]);
+
+  // ── 길게 눌러 끌어 순서 바꾸기 ──────────────────────────────────────────
+  // 카드 안이 거의 전부 입력창이라 별도 핸들을 두지 않았다. 짧은 탭은 입력,
+  // 250ms 이상 누르면 드래그. 그 전에 손가락이 움직이면 평범한 스크롤로 넘긴다.
+  const pressRef = useRef<{
+    from: number; to: number; startX: number; startY: number; rowH: number; count: number;
+    active: boolean; timer: number | null; cleanup: () => void;
+  } | null>(null);
+  // 드래그로 끝난 제스처 뒤엔 click 이 한 번 따라와 입력창을 다시 포커스한다(= 키보드가 뜬다). 그 한 번만 삼킨다.
+  const swallowClickRef = useRef(false);
+
+  useEffect(() => () => pressRef.current?.cleanup(), []);
+
+  const startPress = (e: React.PointerEvent, from: number) => {
+    if (e.pointerType === 'mouse' && e.button !== 0) return;
+    if (pressRef.current) return;
+    swallowClickRef.current = false;
+
+    const cards = Array.from(listRef.current?.querySelectorAll('[data-ms-card]') ?? []) as HTMLElement[];
+    if (cards.length < 2) return; // 한 장뿐이면 바꿀 순서가 없다.
+    const rowH = cards[1].getBoundingClientRect().top - cards[0].getBoundingClientRect().top;
+
+    // 터치 스크롤은 compositor 가 가져가면 나중엔 못 막는다. 눌리는 순간 non-passive 로 걸어두고,
+    // 드래그로 전환된 뒤에만 preventDefault 한다 — 그래야 전환 전 스크롤은 그대로 살아 있다.
+    const blockIfDragging = (ev: Event) => { if (pressRef.current?.active) ev.preventDefault(); };
+
+    const cleanup = () => {
+      const st = pressRef.current;
+      if (st?.timer != null) window.clearTimeout(st.timer);
+      window.removeEventListener('touchmove', blockIfDragging);
+      window.removeEventListener('contextmenu', blockIfDragging);
+      window.removeEventListener('selectstart', blockIfDragging);
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+      window.removeEventListener('pointercancel', onUp);
+      pressRef.current = null;
+    };
+
+    const onMove = (ev: PointerEvent) => {
+      const st = pressRef.current;
+      if (!st) return;
+      const dy = ev.clientY - st.startY;
+      if (!st.active) {
+        if (Math.hypot(ev.clientX - st.startX, dy) > CANCEL_SLOP) cleanup();
+        return;
+      }
+      const to = Math.max(0, Math.min(st.count - 1, st.from + Math.round(dy / st.rowH)));
+      st.to = to;
+      setDrag({ from: st.from, to, dy, rowH: st.rowH });
+    };
+
+    const onUp = () => {
+      const st = pressRef.current;
+      const active = !!st?.active;
+      const from = st?.from ?? 0;
+      const to = st?.to ?? 0;
+      cleanup();
+      setDrag(null);
+      if (!active) return;
+      swallowClickRef.current = true;
+      if (from !== to) reorder(from, to);
+    };
+
+    const timer = window.setTimeout(() => {
+      const st = pressRef.current;
+      if (!st) return;
+      st.active = true;
+      st.timer = null;
+      // 포커스와 선택을 걷어내야 iOS 에서 길게 누를 때 돋보기·선택 핸들이 끼어들지 않는다.
+      (document.activeElement as HTMLElement | null)?.blur?.();
+      window.getSelection()?.removeAllRanges();
+      setDrag({ from: st.from, to: st.from, dy: 0, rowH: st.rowH });
+    }, LONG_PRESS_MS);
+
+    pressRef.current = {
+      from, to: from, startX: e.clientX, startY: e.clientY,
+      rowH, count: cards.length, active: false, timer, cleanup,
+    };
+
+    window.addEventListener('touchmove', blockIfDragging, { passive: false });
+    window.addEventListener('contextmenu', blockIfDragging);
+    window.addEventListener('selectstart', blockIfDragging);
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onUp);
+    window.addEventListener('pointercancel', onUp);
+  };
+
+  // 끄는 동안 나머지 카드는 빈자리를 만들어주려 한 칸씩 밀린다.
+  const shiftOf = (i: number): number => {
+    if (!drag) return 0;
+    const { from, to, dy, rowH } = drag;
+    if (i === from) return dy;
+    if (from < to && i > from && i <= to) return -rowH;
+    if (to < from && i >= to && i < from) return rowH;
+    return 0;
+  };
+  // 뱃지 번호는 '지금 놓으면 될 자리'를 보여준다 — 안 그러면 카드는 3번 자리인데 ② 라고 적혀 있다.
+  const previewIndex = (i: number): number => {
+    if (!drag) return i;
+    const { from, to } = drag;
+    if (i === from) return to;
+    if (from < to && i > from && i <= to) return i - 1;
+    if (to < from && i >= to && i < from) return i + 1;
+    return i;
+  };
 
   const confirmAndPlan = () => {
     // 스펙상 summary 는 optional — 없으면 빈 문자열로 보정한다(백엔드가 null 도 받는다).
@@ -82,7 +209,8 @@ export function MilestoneConfirmScreen() {
 
         <p style={{ fontSize: 13, color: 'var(--text-2)', lineHeight: 1.6, margin: 0 }}>
           목표를 이 <b style={{ color: 'var(--text-1)' }}>중간 단계</b>들로 나눠 계획을 세울게요.
-          순서를 바꾸거나 고치고 더하고 빼도 돼요 — 확정하면 이 구조 그대로 계획이 만들어져요.
+          고치고 더하고 빼도 되고, <b style={{ color: 'var(--text-1)' }}>카드를 꾹 눌러 끌면</b> 순서가 바뀌어요 —
+          확정하면 이 구조 그대로 계획이 만들어져요.
         </p>
 
         {loading ? (
@@ -95,31 +223,78 @@ export function MilestoneConfirmScreen() {
             <button onClick={skip} style={{ alignSelf: 'center', padding: '9px 16px', borderRadius: 10, border: 'none', background: 'var(--brand-surface)', color: '#FFFCF6', fontWeight: 700, fontSize: 13, cursor: 'pointer', fontFamily: 'inherit' }}>바로 계획 세우기</button>
           </div>
         ) : (
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-            {milestones.map((m, i) => (
-              <div key={i} style={{ background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', borderRadius: 14, padding: 12, display: 'flex', gap: 10 }}>
-                <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 2, paddingTop: 2 }}>
-                  <div style={{ width: 22, height: 22, borderRadius: 7, background: 'var(--brand-soft)', color: 'var(--brand-ink)', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 12, fontWeight: 700 }}>{i + 1}</div>
-                  <button onClick={() => move(i, -1)} disabled={i === 0} style={iconBtn(i === 0)} aria-label="위로"><CaretUp size={13} /></button>
-                  <button onClick={() => move(i, 1)} disabled={i === milestones.length - 1} style={iconBtn(i === milestones.length - 1)} aria-label="아래로"><CaretDown size={13} /></button>
+          <div ref={listRef} style={{ display: 'flex', flexDirection: 'column', gap: CARD_GAP }}>
+            {milestones.map((m, i) => {
+              const lifted = drag?.from === i;
+              return (
+                <div
+                  key={m.uid}
+                  data-ms-card
+                  onPointerDown={(e) => startPress(e, i)}
+                  onClickCapture={(e) => {
+                    if (!swallowClickRef.current) return;
+                    swallowClickRef.current = false;
+                    e.preventDefault();
+                    e.stopPropagation();
+                  }}
+                  style={{
+                    background: 'var(--surface-raised)',
+                    border: '1px solid var(--sand-200)',
+                    borderRadius: 14,
+                    padding: 12,
+                    display: 'flex',
+                    gap: 10,
+                    position: 'relative',
+                    zIndex: lifted ? 2 : 1,
+                    transform: `translateY(${shiftOf(i)}px)${lifted ? ' scale(1.02)' : ''}`,
+                    transition: drag && !lifted ? 'transform 160ms cubic-bezier(.2,.8,.2,1)' : 'none',
+                    boxShadow: lifted ? 'var(--shadow-lg, 0 10px 24px rgba(0,0,0,.14))' : 'none',
+                    cursor: lifted ? 'grabbing' : undefined,
+                    touchAction: 'manipulation',
+                    WebkitTouchCallout: 'none',
+                    ...(drag ? { userSelect: 'none' as const, WebkitUserSelect: 'none' as const } : {}),
+                  }}
+                >
+                  <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 2, paddingTop: 2 }}>
+                    {/* 뱃지가 곧 순서 컨트롤 — 드래그는 포인터가 없으면 못 쓰므로 키보드 경로를 여기 남긴다. */}
+                    <button
+                      onKeyDown={(e) => {
+                        if (e.key !== 'ArrowUp' && e.key !== 'ArrowDown') return;
+                        e.preventDefault();
+                        move(i, e.key === 'ArrowUp' ? -1 : 1);
+                      }}
+                      aria-label={`${i + 1}번째 중간 목표. 위·아래 화살표 키로 순서를 옮길 수 있어요`}
+                      className="tnum"
+                      style={{ width: 22, height: 22, borderRadius: 7, border: 'none', padding: 0, background: 'var(--brand-soft)', color: 'var(--brand-ink)', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 12, fontWeight: 700, fontFamily: 'inherit', cursor: 'grab' }}
+                    >
+                      {previewIndex(i) + 1}
+                    </button>
+                  </div>
+                  <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 6, minWidth: 0 }}>
+                    <input
+                      value={m.title}
+                      onChange={(e) => update(i, { title: e.target.value })}
+                      placeholder="중간 목표 (예: 기초 문법 익히기)"
+                      style={{ border: 'none', background: 'transparent', color: 'var(--text-1)', fontSize: 14, fontWeight: 700, fontFamily: 'inherit', outline: 'none', padding: 0 }}
+                    />
+                    <input
+                      value={m.summary ?? ''}
+                      onChange={(e) => update(i, { summary: e.target.value })}
+                      placeholder="한 줄 설명 (선택)"
+                      style={{ border: 'none', background: 'transparent', color: 'var(--text-3)', fontSize: 12, fontFamily: 'inherit', outline: 'none', padding: 0 }}
+                    />
+                  </div>
+                  <button
+                    onPointerDown={(e) => { e.stopPropagation(); swallowClickRef.current = false; }}
+                    onClick={() => remove(i)}
+                    style={{ ...iconBtn(false), color: 'var(--text-3)' }}
+                    aria-label="삭제"
+                  >
+                    <X size={14} />
+                  </button>
                 </div>
-                <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 6, minWidth: 0 }}>
-                  <input
-                    value={m.title}
-                    onChange={(e) => update(i, { title: e.target.value })}
-                    placeholder="중간 목표 (예: 기초 문법 익히기)"
-                    style={{ border: 'none', background: 'transparent', color: 'var(--text-1)', fontSize: 14, fontWeight: 700, fontFamily: 'inherit', outline: 'none', padding: 0 }}
-                  />
-                  <input
-                    value={m.summary}
-                    onChange={(e) => update(i, { summary: e.target.value })}
-                    placeholder="한 줄 설명 (선택)"
-                    style={{ border: 'none', background: 'transparent', color: 'var(--text-3)', fontSize: 12, fontFamily: 'inherit', outline: 'none', padding: 0 }}
-                  />
-                </div>
-                <button onClick={() => remove(i)} style={{ ...iconBtn(false), color: 'var(--text-3)' }} aria-label="삭제"><X size={14} /></button>
-              </div>
-            ))}
+              );
+            })}
             <button
               onClick={add}
               style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6, padding: '11px 0', borderRadius: 12, border: '1.5px dashed var(--sand-300)', background: 'transparent', color: 'var(--text-2)', fontSize: 13, fontWeight: 600, cursor: 'pointer', fontFamily: 'inherit' }}


### PR DESCRIPTION
## 무엇을

`계획의 큰 그림`(milestone-confirm) 화면에서 마일스톤 카드를 **꾹 눌러 끌어 순서를 바꾼다**. 한 칸씩만 움직이던 ▲/▼ 버튼은 걷어냈다.

- 카드를 **250ms 이상** 누르면 드래그로 전환. 그 전에 손가락이 움직이면 평범한 목록 스크롤이다.
- **짧은 탭은 지금처럼 입력.** 드래그로 끝난 제스처 뒤에 따라오는 click 한 번만 삼켜서, 끌고 놓자마자 키보드가 튀어나오지 않게 했다.
- 끄는 동안 나머지 카드는 한 칸씩 밀려 빈자리를 만들고, **뱃지 번호는 '놓으면 될 자리'** 를 보여준다.

## 왜 이렇게

- **라이브러리를 넣지 않았다.** `WeeklyCalendarScreen` 에 이미 같은 모양의 Pointer Events 드래그(임계값 → 상태 → 커밋)가 있어 그 방식에 맞췄다. Capacitor 셸에서 HTML5 `draggable` 은 애초에 동작하지 않아 선택지가 아니었다.
- **핸들을 두지 않았다.** 카드 안이 거의 전부 입력창이라 좁은 좌측 열에 컨트롤을 더 얹는 것보다 카드 전체를 잡는 편이 낫다고 봤다.
- **터치 스크롤은 compositor 가 가져가면 나중엔 못 막는다.** 눌리는 순간 non-passive `touchmove` 를 걸어두고, 드래그로 전환된 뒤에만 `preventDefault` 한다. 전환 전 스크롤은 그대로 살아 있다.
- **key 를 index → uid 로 바꿨다.** 순서가 바뀌어도 입력 포커스와 커서가 카드를 따라가야 한다.
- **접근성**: 드래그는 포인터가 없으면 못 쓴다. 번호 뱃지를 버튼으로 만들어 포커스 후 `↑`/`↓` 로 옮기는 경로를 남겼다 (모양은 그대로).

## 확인한 것

`npm run build` (tsc + vite) 통과. 임시 하니스 페이지를 띄워 실제 브라우저에서 확인했고, 하니스는 커밋에 포함하지 않았다.

| 케이스 | 결과 |
|---|---|
| 1번 카드를 꾹 눌러 두 칸 아래로 | `기초/작은/알고리즘/포트폴리오` → `작은/알고리즘/기초/포트폴리오` |
| 끄는 중 화면 | 끌린 카드만 떠오르고(scale 1.02 + 그림자), 사이 카드 2장이 `-81px` 밀림, 뱃지 1·2·3·4 |
| 250ms 전에 움직임 | 순서 변화 없음, 카드도 안 떠오름 (= 스크롤) |
| 짧은 탭 후 타이핑 | 입력창 포커스·입력 정상 |
| 뱃지 포커스 + `↓` | 순서 바뀌고 포커스가 카드를 따라감 (`2번째 중간 목표…`) |
| 드래그 직후 ✕ 탭 | 첫 탭에 바로 삭제 (4장 → 3장) |

콘솔 에러·React 경고 없음.

## 남긴 것

목록 끝까지 끌었을 때 따라 스크롤되는 auto-scroll 은 넣지 않았다. 마일스톤이 보통 3~5개라 한 화면에 들어온다 — 개수가 늘면 그때 붙이는 게 맞다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)