### PR TITLE
주간 시간표: 3일 뷰 제거 + 한 주를 넓게, AI 초안 카드 축소

### DIFF
--- a/src/components/AiDraftCard.tsx
+++ b/src/components/AiDraftCard.tsx
@@ -8,6 +8,11 @@ export interface AiDraftCardProps {
   aiSource: AiSource;
   llmRunId?: string | null;
   children: React.ReactNode;
+  /**
+   * 헤더 오른쪽 끝에 붙는 보조 액션(보통 '⋯' 더보기). 자주 안 쓰는 선택지를
+   * 카드 밑에 버튼으로 계속 늘어놓는 대신 여기로 접어 넣는다.
+   */
+  headerAction?: React.ReactNode;
   onAccept: () => void;
   onEdit: () => void;
   onReject: () => void;
@@ -52,6 +57,7 @@ export function AiDraftCard({
   aiSource,
   llmRunId,
   children,
+  headerAction,
   onAccept,
   onEdit,
   onReject,
@@ -93,7 +99,8 @@ export function AiDraftCard({
     >
       <div
         style={{
-          padding: '8px 12px',
+          padding: '4px 6px 4px 11px',
+          minHeight: 30,
           background: headerBg,
           display: 'flex',
           alignItems: 'center',
@@ -107,17 +114,16 @@ export function AiDraftCard({
       >
         {isLlm ? <Sparkle size={11} weight="fill" /> : <Robot size={11} weight="fill" />}
         <span>{isLlm ? 'AI 초안' : '오프라인 모드 · 룰 기반'}</span>
+        <span style={{ flex: 1 }} />
         {import.meta.env.DEV && llmRunId && (
-          <span
-            style={{ marginLeft: 'auto', opacity: 0.6, fontSize: 9 }}
-            title={`llmRunId: ${llmRunId}`}
-          >
+          <span style={{ opacity: 0.6, fontSize: 9 }} title={`llmRunId: ${llmRunId}`}>
             #{llmRunId.slice(0, 6)}
           </span>
         )}
+        {headerAction}
       </div>
 
-      <div style={{ padding: '12px 14px' }}>
+      <div style={{ padding: '9px 11px' }}>
         {children}
         {!isLlm && (
           <div
@@ -141,7 +147,7 @@ export function AiDraftCard({
         style={{
           display: 'flex',
           gap: 6,
-          padding: '8px 10px 10px',
+          padding: '7px 9px 9px',
           borderTop: '1px solid var(--sand-200, #E4D4BC)',
         }}
       >
@@ -150,7 +156,7 @@ export function AiDraftCard({
           type="button"
           style={{
             flex: 1,
-            height: 40,
+            height: 38,
             borderRadius: 10,
             border: '1px solid var(--sand-300, #D8C5A8)',
             background: 'transparent',
@@ -172,7 +178,7 @@ export function AiDraftCard({
           type="button"
           style={{
             flex: 1,
-            height: 40,
+            height: 38,
             borderRadius: 10,
             border: '1px solid var(--sand-300, #D8C5A8)',
             background: 'var(--surface-ground, #FAF6EE)',
@@ -195,7 +201,7 @@ export function AiDraftCard({
           disabled={acceptDisabled}
           style={{
             flex: 1.4,
-            height: 40,
+            height: 38,
             borderRadius: 10,
             border: 'none',
             background: 'var(--brand, #E26D4E)',

--- a/src/components/PlanOptionsSheet.tsx
+++ b/src/components/PlanOptionsSheet.tsx
@@ -1,0 +1,159 @@
+import { X, ArrowsClockwise, ChatCircleDots } from '@phosphor-icons/react';
+import type { PlanDensity } from '../types/api';
+
+// 주간 계획 초안 화면의 '가끔 쓰는' 선택지 모음. 예전엔 계획 분량 세그먼트와
+// "다시 인터뷰하기" 버튼이 초안 카드 위아래에 그대로 붙어 있었다. 둘 다 대부분의
+// 사용자가 한 번도 안 누르는데 세로를 80px 넘게 먹어서, 정작 봐야 할 시간표가
+// 눌려 있었다. 자주 쓰는 것(재생성·블록 추가·이대로 시작)만 카드에 남기고
+// 나머지는 헤더의 '⋯' 뒤로 접는다.
+const DENSITIES: [PlanDensity, string, string][] = [
+  ['light', '가볍게', '여유 있게, 적은 블록'],
+  ['standard', '표준', '무리 없는 기본 분량'],
+  ['intense', '촘촘히', '빈 시간을 꽉 채워서'],
+];
+
+interface PlanOptionsSheetProps {
+  density: PlanDensity;
+  onDensityChange: (d: PlanDensity) => void;
+  /** 지금 고른 분량으로 다시 만든다. 시트는 호출한 쪽에서 닫는다. */
+  onRegenerate: () => void;
+  /** 이 초안을 버리고 인터뷰부터 다시. */
+  onRestartInterview: () => void;
+  /** 초안 폐기 요청이 나가는 중 */
+  restarting?: boolean;
+  /** 승인/생성이 진행 중이라 아무것도 건드리면 안 되는 상태 */
+  busy?: boolean;
+  onClose: () => void;
+}
+
+export function PlanOptionsSheet({
+  density,
+  onDensityChange,
+  onRegenerate,
+  onRestartInterview,
+  restarting = false,
+  busy = false,
+  onClose,
+}: PlanOptionsSheetProps) {
+  const locked = busy || restarting;
+
+  return (
+    <div
+      onClick={onClose}
+      style={{ position: 'absolute', inset: 0, background: 'rgba(26,23,20,.45)', zIndex: 60, display: 'flex', alignItems: 'flex-end' }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-label="계획 옵션"
+        style={{ background: 'var(--surface-raised)', width: '100%', borderRadius: '24px 24px 0 0', padding: '12px 20px 32px', boxShadow: 'var(--shadow-xl)', maxHeight: '82%', overflowY: 'auto' }}
+      >
+        <div style={{ width: 36, height: 4, borderRadius: 9999, background: 'var(--sand-300)', margin: '0 auto 16px' }} />
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
+          <h3 style={{ fontSize: 17, fontWeight: 700, margin: 0, letterSpacing: '-0.01em' }}>계획 옵션</h3>
+          <button
+            onClick={onClose}
+            aria-label="닫기"
+            style={{ width: 44, height: 44, borderRadius: 9999, border: 'none', background: 'var(--sand-100)', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer' }}
+          >
+            <X size={12} color="var(--text-2)" />
+          </button>
+        </div>
+
+        {/* 계획 분량 — 고르기만 해선 아무 일도 안 일어난다. 아래 '다시 만들기' 로 반영. */}
+        <label style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-3)', letterSpacing: '0.04em', display: 'block', marginBottom: 8 }}>
+          계획 분량
+        </label>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 6, marginBottom: 12 }}>
+          {DENSITIES.map(([val, label, desc]) => {
+            const active = density === val;
+            return (
+              <button
+                key={val}
+                onClick={() => onDensityChange(val)}
+                disabled={locked}
+                aria-pressed={active}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 10,
+                  width: '100%',
+                  minHeight: 48,
+                  padding: '8px 14px',
+                  borderRadius: 12,
+                  border: `1px solid ${active ? 'var(--text-1)' : 'var(--sand-200)'}`,
+                  background: active ? 'var(--text-1)' : 'var(--surface-ground)',
+                  color: active ? '#FAF6EE' : 'var(--text-2)',
+                  fontFamily: 'inherit',
+                  textAlign: 'left',
+                  cursor: locked ? 'default' : 'pointer',
+                  opacity: locked ? 0.5 : 1,
+                  transition: 'background 120ms, color 120ms, border-color 120ms',
+                }}
+              >
+                <span style={{ fontSize: 14, fontWeight: 700, flexShrink: 0 }}>{label}</span>
+                <span style={{ fontSize: 11.5, opacity: active ? 0.75 : 1, color: active ? '#FAF6EE' : 'var(--text-3)' }}>{desc}</span>
+              </button>
+            );
+          })}
+        </div>
+        <button
+          onClick={onRegenerate}
+          disabled={locked}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 6,
+            width: '100%',
+            height: 48,
+            borderRadius: 12,
+            border: '1px solid var(--sand-300)',
+            background: 'var(--surface-ground)',
+            color: 'var(--text-1)',
+            fontSize: 13.5,
+            fontWeight: 700,
+            fontFamily: 'inherit',
+            cursor: locked ? 'default' : 'pointer',
+            opacity: locked ? 0.5 : 1,
+          }}
+        >
+          <ArrowsClockwise size={15} /> 이 분량으로 다시 만들기
+        </button>
+
+        <div style={{ height: 1, background: 'var(--sand-200)', margin: '20px 0 16px' }} />
+
+        {/* 재생성은 '같은 답으로 다시', 재인터뷰는 '답 자체를 바꿈'. 되돌릴 수 없는
+            쪽이라 설명을 붙이고 강조하지 않은 버튼으로 둔다. */}
+        <div style={{ fontSize: 13, fontWeight: 700, color: 'var(--text-1)', marginBottom: 4 }}>답을 바꾸고 싶어요</div>
+        <p style={{ margin: '0 0 10px', fontSize: 11.5, color: 'var(--text-3)', lineHeight: 1.5 }}>
+          지금 초안은 버려지고, 인터뷰를 처음부터 다시 진행해요. 다시 만들기로는 답 내용이
+          바뀌지 않아요.
+        </p>
+        <button
+          onClick={onRestartInterview}
+          disabled={locked}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 6,
+            width: '100%',
+            height: 48,
+            borderRadius: 12,
+            border: '1px solid var(--sand-200)',
+            background: 'transparent',
+            color: 'var(--text-2)',
+            fontSize: 13.5,
+            fontWeight: 600,
+            fontFamily: 'inherit',
+            cursor: locked ? 'default' : 'pointer',
+            opacity: locked ? 0.5 : 1,
+          }}
+        >
+          <ChatCircleDots size={15} /> {restarting ? '정리하는 중…' : '다시 인터뷰하기'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/WeekGrid.tsx
+++ b/src/components/WeekGrid.tsx
@@ -46,10 +46,9 @@ export interface WeekGridProps {
   /** 블록을 누르거나 끌기 시작할 때. 드래그/탭 분기는 호출한 쪽에서 판단한다. */
   onBlockPointerDown?: (e: React.PointerEvent, block: WeekGridBlock) => void;
   /**
-   * 보여줄 요일 칸(0=월 … 6=일). 없으면 7일 전부.
-   * 3일 뷰는 [2,3,4] 처럼 넘긴다 — 같은 폭에 칸이 셋뿐이라 colWidth 를 두 배로 줄 수 있고,
-   * 그래야 "캡스톤 발표 / 자료" 처럼 제목이 깨지지 않는다.
-   * 여기 없는 칸의 블록은 렌더하지 않는다.
+   * 보여줄 요일 칸(0=월 … 6=일). 없으면 7일 전부. 여기 없는 칸의 블록은 렌더하지 않는다.
+   * 지금 두 화면 모두 7일 전부를 넘긴다 — 좁아서 제목이 깨지던 문제는 칸 수를 줄이는
+   * 대신 colWidth 를 키우고 가로로 스크롤해 푼다.
    */
   visibleCols?: number[];
   /** 스크롤 위치를 밖에서 제어할 때(첫 블록으로 스크롤 등). */
@@ -69,6 +68,26 @@ const LOADING_SLOTS = [
 const NEUTRAL = { bg: 'var(--sand-100)', bd: 'var(--sand-300)', fg: 'var(--text-3)' };
 
 /**
+ * 한 주 7칸이 폰 폭에 다 안 들어가므로, 봐야 할 요일(오늘·첫 블록)을 가로 가운데로
+ * 보내준다. 이게 없으면 일요일이 오늘일 때 화면엔 월~목만 보이고, 사용자는 자기
+ * 오늘이 어디 있는지 모른 채 옆으로 밀어봐야 한다.
+ *
+ * timeWidth 를 빼는 건 왼쪽 시간 눈금이 sticky 라 격자를 그만큼 가리기 때문이다.
+ */
+export function scrollColIntoView(
+  el: HTMLElement | null,
+  col: number,
+  colWidth: number,
+  timeWidth: number,
+) {
+  if (!el || col < 0) return;
+  const viewport = el.clientWidth - timeWidth;
+  if (viewport <= 0) return;
+  const target = col * colWidth + colWidth / 2 - viewport / 2;
+  el.scrollLeft = Math.max(0, Math.min(target, el.scrollWidth - el.clientWidth));
+}
+
+/**
  * 주간 시간표. 온보딩의 계획 확인 화면과 메인 주간 캘린더가 이걸 공유한다.
  *
  * 이 앱에서 시간표는 장식이 아니라 "계획이 실제 시간에 놓였다"는 증거다.
@@ -77,6 +96,12 @@ const NEUTRAL = { bg: 'var(--sand-100)', bd: 'var(--sand-300)', fg: 'var(--text-
  *
  * 배치는 전부 절대좌표다. 세로 = 시각(hourPx/60 × 분), 가로 = 요일(colWidth × col).
  * 좁다고 느끼면 colWidth 만 올리면 되고, 그러면 가로 스크롤이 생긴다.
+ *
+ * 스크롤은 가로·세로를 **한 컨테이너**가 함께 맡는다. 예전엔 요일 헤더가 스크롤
+ * 바깥의 형제였는데, 그 구조에선 열을 넓혀 가로 스크롤이 생기는 순간 헤더(요일·날짜)만
+ * 제자리에 남아 본문 격자와 하루씩 어긋났다. 그래서 열을 못 넓히고 7일 뷰가 51px 로
+ * 찌그러져 있었다. 이제 헤더는 sticky top, 시간 눈금은 sticky left 로 붙어서
+ * 가로로 밀어도 요일이 따라오고 세로로 내려도 시각이 왼쪽에 남는다.
  */
 export function WeekGrid({
   blocks,
@@ -180,64 +205,68 @@ export function WeekGrid({
   };
 
   return (
-    <>
-      {/* 요일 헤더 */}
-      <div style={{ flexShrink: 0, display: 'flex', borderBottom: '1px solid var(--sand-200)' }}>
-        <div style={{ width: timeWidth, flexShrink: 0 }} />
-        {cols.map((i) => {
-          const d = DAYS_KO[i];
-          const isToday = todayCol === i;
-          return (
-            <div
-              key={d}
-              style={{
-                width: colWidth,
-                flexShrink: 0,
-                display: 'flex',
-                flexDirection: 'column',
-                alignItems: 'center',
-                padding: '6px 0',
-                background: isToday ? 'rgba(226,109,78,0.04)' : 'transparent',
-              }}
-            >
+    <div ref={scrollRef} style={{ flex: 1, minHeight: 0, overflow: 'auto' }}>
+      {/* 가로 스크롤 폭의 기준. 헤더와 본문이 이 한 상자를 공유해야 어긋나지 않는다. */}
+      <div style={{ minWidth: timeWidth + bodyWidth }}>
+        {/* 요일 헤더 — 세로로 내려도 위에 붙고, 가로로 밀면 본문과 함께 움직인다 */}
+        <div style={{ position: 'sticky', top: 0, zIndex: 30, display: 'flex', background: 'var(--surface-ground)', borderBottom: '1px solid var(--sand-200)' }}>
+          {/* 좌상단 모서리 — 위(부모 sticky)로도 왼쪽으로도 고정돼 눈금 열을 덮는다 */}
+          <div style={{ width: timeWidth, flexShrink: 0, position: 'sticky', left: 0, zIndex: 1, background: 'var(--surface-ground)' }} />
+          {cols.map((i) => {
+            const d = DAYS_KO[i];
+            const isToday = todayCol === i;
+            return (
               <div
+                key={d}
                 style={{
-                  fontSize: colWidth >= 80 ? 10 : 8,
-                  letterSpacing: '0',
-                  color: isToday ? 'var(--coral-700)' : 'var(--text-3)',
-                  marginBottom: 3,
+                  width: colWidth,
+                  flexShrink: 0,
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                  padding: '6px 0',
+                  background: isToday ? 'rgba(226,109,78,0.04)' : 'transparent',
                 }}
               >
-                {d}
-              </div>
-              {dayNumbers && (
                 <div
-                  className="tnum"
                   style={{
-                    width: 22,
-                    height: 22,
-                    borderRadius: 9999,
-                    background: isToday ? 'var(--brand-surface)' : 'transparent',
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    fontWeight: 700,
-                    fontSize: 11,
-                    color: isToday ? '#FFFCF6' : 'var(--text-1)',
+                    fontSize: colWidth >= 80 ? 10 : 8,
+                    letterSpacing: '0',
+                    color: isToday ? 'var(--coral-700)' : 'var(--text-3)',
+                    marginBottom: 3,
                   }}
                 >
-                  {dayNumbers[i]}
+                  {d}
                 </div>
-              )}
-            </div>
-          );
-        })}
-      </div>
+                {dayNumbers && (
+                  <div
+                    className="tnum"
+                    style={{
+                      width: 22,
+                      height: 22,
+                      borderRadius: 9999,
+                      background: isToday ? 'var(--brand-surface)' : 'transparent',
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      fontWeight: 700,
+                      fontSize: 11,
+                      color: isToday ? '#FFFCF6' : 'var(--text-1)',
+                    }}
+                  >
+                    {dayNumbers[i]}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
 
-      {/* 격자 본문 */}
-      <div ref={scrollRef} style={{ flex: 1, overflowY: 'auto' }}>
-        <div style={{ display: 'flex', minWidth: timeWidth + bodyWidth }}>
-          <div style={{ width: timeWidth, flexShrink: 0, background: 'var(--surface-ground)' }}>
+        {/* 격자 본문 */}
+        <div style={{ display: 'flex' }}>
+          {/* 시간 눈금 — 가로로 밀어도 왼쪽에 남는다. 안 그러면 오른쪽 요일을 볼 때
+              몇 시인지 알 수 없다. boxShadow 는 자리를 안 먹는 1px 경계선. */}
+          <div style={{ width: timeWidth, flexShrink: 0, position: 'sticky', left: 0, zIndex: 20, background: 'var(--surface-ground)', boxShadow: '1px 0 0 var(--sand-200)' }}>
             {hours.map((h) => (
               <div
                 key={h}
@@ -257,7 +286,9 @@ export function WeekGrid({
             ))}
           </div>
 
-          <div style={{ flex: 1, position: 'relative', minWidth: bodyWidth }}>
+          {/* zIndex:0 으로 스택 컨텍스트를 만들어, 드래그 중인 블록(zIndex 10)이
+              sticky 시간 눈금(zIndex 20) 위로 튀어나오지 않게 가둔다. */}
+          <div style={{ flex: 1, position: 'relative', zIndex: 0, minWidth: bodyWidth }}>
             {hours.map((h, i) => (
               <div
                 key={h}
@@ -340,6 +371,6 @@ export function WeekGrid({
           </div>
         </div>
       </div>
-    </>
+    </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -422,3 +422,13 @@ body {
 .rx-wheel::-webkit-scrollbar {
   display: none;                  /* Chrome/Safari */
 }
+
+/* 칩 한 줄 가로 스크롤 — 스크롤바가 보이면 칩 아래로 회색 막대가 생겨
+   카드가 한 줄 더 커 보인다. 데스크탑에서도 숨긴다. */
+.rx-hscroll {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+.rx-hscroll::-webkit-scrollbar {
+  display: none;
+}

--- a/src/screens/WeeklyCalendarScreen.tsx
+++ b/src/screens/WeeklyCalendarScreen.tsx
@@ -5,7 +5,7 @@ import { ApiError, goalsApi, plansApi } from '../lib/api';
 import { localDateStr } from '../lib/dates';
 import { DemoNotice } from '../components/DemoNotice';
 import { BlockEditSheet } from '../components/BlockEditSheet';
-import { WeekGrid, type WeekGridBlock } from '../components/WeekGrid';
+import { WeekGrid, scrollColIntoView, type WeekGridBlock } from '../components/WeekGrid';
 import { EmptyState } from '../components/EmptyState';
 import { Toast } from '../components/Toast';
 import { useNavigation } from '../contexts/NavigationContext';
@@ -14,6 +14,9 @@ import type { WeeklyPlanResponse, BlockEditRequest, ApiGoal } from '../types/api
 
 // 소요 시간 프리셋(15분 옵션 포함) — 공유 BlockEditSheet 에 넘긴다.
 const DURATIONS = [15, 30, 45, 60, 90, 120];
+
+// 보여줄 요일 칸 — 언제나 한 주 전부(월~일).
+const ALL_COLS = [0, 1, 2, 3, 4, 5, 6];
 
 // 백엔드 WeeklyPlanResponse(days[].blocks[] = WeeklyBlock) → 화면 BlockWithStatus[].
 function weeklyToBlocks(res: WeeklyPlanResponse): (Block & { status: 'pending' | 'done' | 'failed' })[] {
@@ -153,12 +156,13 @@ export function WeeklyCalendarScreenV2() {
   const parseMin = (t: string) => { const [h, m] = t.split(':').map(Number); return h * 60 + m; };
 
   // ── 밀도 ────────────────────────────────────────────────────
-  // 390px 에 7열 × 24시간을 넣으면 열이 50px 이라 "캡스톤 발표 / 자료" 처럼 제목이
-  // 깨지고 글씨가 8px 이 된다. 기본은 3일 뷰로 열을 넓히고, 전체 조망이 필요하면
-  // 7일로 토글한다. 시간표 자체는 그대로 — 드래그·다중 주 로직 전부 재사용.
-  const [dayView, setDayView] = useState<3 | 7>(3);
-  const TIME_W = dayView === 3 ? 34 : 30;
-  const HOUR_PX = dayView === 3 ? 64 : 56;
+  // 390px 에 7열을 넣으면 열이 50px 이라 "캡스톤 발표 / 자료" 처럼 제목이 깨지고
+  // 글씨가 8px 이 된다. 예전엔 3일 뷰로 칸 수를 줄여 폭을 벌었지만, 그러면 한 주가
+  // 절대 한 화면에 안 들어와서 "이번 주 어떤 모양인가" 를 볼 방법이 없었다.
+  // 이제 칸은 7일 그대로 두고, 좁으면 열을 찌그러뜨리는 대신 가로로 민다.
+  const TIME_W = 34;
+  // 세로도 넉넉히 — 60분 블록이 72px 라 제목과 시각 두 줄이 다 들어간다.
+  const HOUR_PX = 72;
 
   // 열 폭은 실제 컨테이너 폭에서 계산한다. 고정값으로 두면 폰(390px)에선 맞아도
   // 태블릿·데스크탑·가로모드에선 격자가 왼쪽에 몰리고 오른쪽이 텅 빈다.
@@ -174,56 +178,19 @@ export function WeeklyCalendarScreenV2() {
     return () => ro.disconnect();
   }, []);
 
-  // 3일 뷰의 창 시작 요일. 이 셋으로 7일을 모두 덮는다 — 월화수 / 목금토 / 금토일.
-  // 마지막 창이 금토와 겹치는 건 일요일(6)을 보여주면서 항상 3칸을 채우기 위해서다.
-  //
-  // 예전엔 창이 '오늘부터 3일' 로 고정이고 다음 버튼이 곧장 다음 주로 넘어갔다.
-  // 그래서 오늘이 월요일이면 이번 주 목·금·토·일을 볼 방법이 아예 없었다
-  // (가로 스크롤도 없고 드래그도 보이는 칸 안으로 제한된다).
-  const WINDOWS = [0, 3, 4];
-  const windowIndexFor = (day: number) => (day >= 6 ? 2 : day >= 3 ? 1 : 0);
-  const [winIdx, setWinIdx] = useState(() => (weekOffset === 0 ? windowIndexFor(TODAY) : 0));
+  // 한 주 전부를 항상 띄운다. 이동은 주 단위 하나뿐이라 "중간 요일이 통째로
+  // 건너뛰어지는" 3일 창 이동 버그의 여지 자체가 없다.
+  const goPrev = () => setWeekOffset(weekOffset - 1);
+  const goNext = () => setWeekOffset(weekOffset + 1);
+  const goToday = () => setWeekOffset(0);
 
-  const visibleCols = (() => {
-    if (dayView === 7) return [0, 1, 2, 3, 4, 5, 6];
-    const start = WINDOWS[Math.min(winIdx, WINDOWS.length - 1)];
-    return [start, start + 1, start + 2];
-  })();
-
-  // 3일 뷰에서는 3일씩, 7일 뷰에서는 한 주씩 움직인다. 3일 뷰인데 한 주씩 건너뛰면
-  // 중간 요일이 통째로 건너뛰어진다 — 그게 위에 적은 버그였다.
-  const goPrev = () => {
-    if (dayView === 7) return setWeekOffset(weekOffset - 1);
-    if (winIdx > 0) return setWinIdx(winIdx - 1);
-    setWeekOffset(weekOffset - 1);
-    setWinIdx(WINDOWS.length - 1); // 지난 주의 마지막 창(금토일)으로 이어진다
-  };
-  const goNext = () => {
-    if (dayView === 7) return setWeekOffset(weekOffset + 1);
-    if (winIdx < WINDOWS.length - 1) return setWinIdx(winIdx + 1);
-    setWeekOffset(weekOffset + 1);
-    setWinIdx(0); // 다음 주의 첫 창(월화수)으로 이어진다
-  };
-  const goToday = () => {
-    setWeekOffset(0);
-    setWinIdx(windowIndexFor(TODAY));
-  };
-
-  // 헤더는 '실제로 보이는 범위' 를 말해야 한다. 3일만 보이는데 주 전체를 적으면
-  // 라벨이 화면과 다른 말을 하게 된다.
-  const visibleLabel = (() => {
-    if (dayView === 7) return weekLabel;
-    const d0 = new Date(_monday); d0.setDate(d0.getDate() + visibleCols[0]);
-    const d2 = new Date(_monday); d2.setDate(d2.getDate() + visibleCols[2]);
-    return `${d0.getMonth() + 1}/${d0.getDate()}–${d2.getMonth() + 1}/${d2.getDate()}`;
-  })();
-
-  // 남는 폭을 열이 나눠 갖는다. 너무 좁아지지 않게 하한을 둬서, 폭이 부족하면
-  // 찌그러지는 대신 가로 스크롤이 생기게 한다.
-  const MIN_COL_W = dayView === 3 ? 96 : 44;
+  // 남는 폭을 열이 나눠 갖되, 하한 아래로는 찌그러뜨리지 않고 가로 스크롤을 준다.
+  // 84 인 이유: WeekGrid 가 80px 부터 제목을 11px·부제를 10px 로 올려 그린다.
+  // 그 아래는 8px 이라 "캡스톤 발표 자료" 가 사실상 안 읽힌다.
+  const MIN_COL_W = 84;
   const COL_W = rootW > 0
-    ? Math.max(MIN_COL_W, Math.floor((rootW - TIME_W) / visibleCols.length))
-    : (dayView === 3 ? 108 : 50);
+    ? Math.max(MIN_COL_W, Math.floor((rootW - TIME_W) / ALL_COLS.length))
+    : MIN_COL_W;
 
   // 블록이 하나도 없는 새벽·심야를 잘라낸다. 주 4블록인데 24시간을 스크롤하는 게
   // 지금 화면의 가장 큰 낭비다. 잘라내도 앞뒤로 1시간 여유는 남겨 드래그로 옮길
@@ -252,7 +219,14 @@ export function WeeklyCalendarScreenV2() {
     if (START_H > 0 || END_H < 24) { el.scrollTop = 0; return; }
     const targetH = isThisWeek ? Math.min(Math.max(_now.getHours(), 6), 20) : 8;
     el.scrollTop = Math.max(0, toY(targetH * 60) - 8);
-  }, [planLoading, isThisWeek, weekStartStr, START_H, END_H, dayView]);
+  }, [planLoading, isThisWeek, weekStartStr, START_H, END_H]);
+
+  // 가로도 맞춰준다. 7칸이 폰 폭에 다 안 들어가므로 이번 주면 오늘 칸을, 다른 주면
+  // 월요일을 가운데로 보낸다. 예전 3일 뷰가 오늘 기준 창을 골라주던 역할을 대신한다.
+  useEffect(() => {
+    if (planLoading) return;
+    scrollColIntoView(gridRef.current, isThisWeek ? TODAY : 0, COL_W, TIME_W);
+  }, [planLoading, isThisWeek, weekStartStr, TODAY, COL_W, TIME_W]);
 
   const blockStyle = (b: BlockWithStatus) => {
     if (b.status === 'done')   return { bg: '#E5EFE3', bd: '#b4dfc8', fg: 'var(--success)' };
@@ -386,14 +360,9 @@ export function WeeklyCalendarScreenV2() {
     }
   };
 
-  // 가로 드래그 거리 → 새 요일. 3일 뷰에선 보이는 칸(visibleCols) 안에서만 움직인다 —
-  // 화면에 없는 요일로 끌어다 놓으면 블록이 사라진 것처럼 보이기 때문.
-  const dayFromDx = (startDay: number, dx: number): number => {
-    const from = visibleCols.indexOf(startDay);
-    if (from < 0) return startDay;
-    const to = Math.max(0, Math.min(visibleCols.length - 1, from + Math.round(dx / COL_W)));
-    return visibleCols[to];
-  };
+  // 가로 드래그 거리 → 새 요일. 한 주가 통째로 열려 있으니 0~6 안에서만 자른다.
+  const dayFromDx = (startDay: number, dx: number): number =>
+    Math.max(0, Math.min(6, startDay + Math.round(dx / COL_W)));
 
   // pointerdown 핸들러 — 블록에 등록.
   const handleBlockPointerDown = (e: React.PointerEvent, block: BlockWithStatus) => {
@@ -530,10 +499,10 @@ export function WeeklyCalendarScreenV2() {
           <button
             onClick={goPrev}
             style={{ width: 28, height: 28, borderRadius: 8, border: '1px solid var(--sand-200)', background: 'var(--surface-raised)', color: 'var(--text-1)', cursor: 'pointer', fontFamily: 'inherit', fontSize: 14 }}
-            aria-label={dayView === 3 ? '이전 3일' : '이전 주'}
+            aria-label="이전 주"
           >‹</button>
           <div style={{ flex: 1, textAlign: 'center' }}>
-            <span className="tnum" style={{ fontSize: 13, fontWeight: 700, color: 'var(--text-1)' }}>{visibleLabel}</span>
+            <span className="tnum" style={{ fontSize: 13, fontWeight: 700, color: 'var(--text-1)' }}>{weekLabel}</span>
             <span style={{ marginLeft: 6, fontSize: 11, color: 'var(--text-3)', fontWeight: 600 }}>
               {weekOffset === 0 ? '이번 주' : weekOffset === 1 ? '다음 주' : weekOffset === -1 ? '지난 주' : `${weekOffset > 0 ? '+' : ''}${weekOffset}주`}
             </span>
@@ -541,15 +510,13 @@ export function WeeklyCalendarScreenV2() {
           <button
             onClick={goNext}
             style={{ width: 28, height: 28, borderRadius: 8, border: '1px solid var(--sand-200)', background: 'var(--surface-raised)', color: 'var(--text-1)', cursor: 'pointer', fontFamily: 'inherit', fontSize: 14 }}
-            aria-label={dayView === 3 ? '다음 3일' : '다음 주'}
+            aria-label="다음 주"
           >›</button>
-          {/* 오늘이 안 보이면 돌아갈 길을 준다. 주만 보고 판단하면, 이번 주인데
-              금토일 창을 보는 상태에서 버튼이 사라져 오늘로 못 돌아간다.
-              자리는 항상 잡아둔다 — 조건부로 넣고 빼면 나타날 때마다 '›' 와 가운데
-              라벨이 같이 밀린다(실측 49px / 24px). 넘길 때마다 화살표가 움직이면
-              같은 자리를 연타할 수 없다. */}
+          {/* 다른 주를 보고 있으면 돌아갈 길을 준다. 자리는 항상 잡아둔다 —
+              조건부로 넣고 빼면 나타날 때마다 '›' 와 가운데 라벨이 같이 밀린다
+              (실측 49px / 24px). 넘길 때마다 화살표가 움직이면 같은 자리를 연타할 수 없다. */}
           <div style={{ width: 41, flexShrink: 0, display: 'flex', justifyContent: 'flex-end' }}>
-            {(weekOffset !== 0 || (dayView === 3 && !visibleCols.includes(TODAY))) && (
+            {weekOffset !== 0 && (
               <button
                 onClick={goToday}
                 style={{ height: 28, padding: '0 10px', borderRadius: 8, border: '1px solid var(--sand-200)', background: 'var(--surface-raised)', color: 'var(--text-2)', cursor: 'pointer', fontFamily: 'inherit', fontSize: 11, fontWeight: 600 }}
@@ -574,7 +541,7 @@ export function WeeklyCalendarScreenV2() {
           </div>
         )}
         {/* 칩은 완료·대기만. 이월은 0 일 때가 대부분이라 자리만 차지했다.
-            같은 줄에 3일/7일 토글과 시간대 접기를 둬서 헤더를 2줄로 유지한다. */}
+            같은 줄에 시간대 접기를 둬서 헤더를 2줄로 유지한다. */}
         <div style={{ display: 'flex', gap: 6, alignItems: 'center', flexWrap: 'wrap' }}>
           {[
             { label: '완료', n: blocks.filter((b) => b.status === 'done').length, bg: '#E5EFE3', bd: '#b4dfc8', fg: 'var(--success-ink)' },
@@ -597,20 +564,6 @@ export function WeeklyCalendarScreenV2() {
               style={{ height: 'var(--ctrl-xs)', padding: '0 9px', borderRadius: 9999, border: '1px solid var(--sand-200)', background: 'var(--surface-raised)', color: 'var(--text-3)', fontSize: 12, fontWeight: 600, cursor: 'pointer' }}
             >24시간</button>
           )}
-
-          <div style={{ display: 'inline-flex', background: 'var(--sand-100)', borderRadius: 9999, padding: 2, gap: 2 }}>
-            {([3, 7] as const).map((n) => {
-              const on = dayView === n;
-              return (
-                <button
-                  key={n}
-                  onClick={() => setDayView(n)}
-                  className="tnum"
-                  style={{ height: 22, padding: '0 10px', borderRadius: 9999, border: 'none', background: on ? 'var(--surface-raised)' : 'transparent', color: on ? 'var(--text-1)' : 'var(--text-3)', fontSize: 12, fontWeight: 700, cursor: 'pointer', boxShadow: on ? 'var(--shadow-sm, 0 1px 2px rgba(0,0,0,.06))' : 'none' }}
-                >{n}일</button>
-              );
-            })}
-          </div>
         </div>
       </div>
 
@@ -626,7 +579,7 @@ export function WeeklyCalendarScreenV2() {
         colWidth={COL_W}
         timeWidth={TIME_W}
         loading={planLoading}
-        visibleCols={visibleCols}
+        visibleCols={ALL_COLS}
         onBlockPointerDown={(e, gb) => {
           const b = blocks.find((x) => x.id === gb.id);
           if (b) handleBlockPointerDown(e, b);

--- a/src/screens/WeeklyPlanGenerationScreen.tsx
+++ b/src/screens/WeeklyPlanGenerationScreen.tsx
@@ -1,11 +1,12 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { Clock, Lightbulb } from '@phosphor-icons/react';
+import { Clock, Lightbulb, DotsThreeOutline } from '@phosphor-icons/react';
 import { DEFAULT_GOAL_CATEGORY, categoryLabel, goalColor } from '../data';
 import { SetupProgress } from '../components/SetupProgress';
 import { AiDraftCard } from '../components/AiDraftCard';
 import { DemoNotice } from '../components/DemoNotice';
 import { BlockEditSheet } from '../components/BlockEditSheet';
-import { WeekGrid, type WeekGridBlock } from '../components/WeekGrid';
+import { PlanOptionsSheet } from '../components/PlanOptionsSheet';
+import { WeekGrid, scrollColIntoView, type WeekGridBlock } from '../components/WeekGrid';
 import { ApiError, plansApi } from '../lib/api';
 import { localDateStr } from '../lib/dates';
 import { useNavigation } from '../contexts/NavigationContext';
@@ -37,6 +38,9 @@ function weeklyToBlocks(res: WeeklyPlanResponse): Block[] {
 
 // 소요 시간 프리셋 — 온보딩(생성)과 메인 캘린더가 공유하는 블록 편집 시트에 넘긴다.
 const DURATIONS = [30, 45, 60, 90, 120];
+
+// 보여줄 요일 칸 — 언제나 한 주 전부(월~일).
+const ALL_COLS = [0, 1, 2, 3, 4, 5, 6];
 
 // 백엔드 ScheduledBlockPreview(start/end KST ISO) → 화면 Block(day/time/dur).
 function previewToBlock(b: ScheduledBlockPreview, i: number): Block {
@@ -260,6 +264,8 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
   // 까지 승인 대기로 남고 인터뷰가 만든 잠정 목표도 그대로 쌓였다. 명시적으로 버리면
   // 초안은 그 자리에서 종착 상태가 되고, 새 인터뷰가 이전 잠정 목표를 대체한다.
   const [discarding, setDiscarding] = useState(false);
+  // '⋯' 시트(계획 분량 · 다시 인터뷰하기) 열림 여부.
+  const [optionsOpen, setOptionsOpen] = useState(false);
   const handleRestartInterview = () => {
     if (discarding || approvingRef.current) return;
     setDiscarding(true);
@@ -277,18 +283,21 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
   const START_H = 0, END_H = 24;
   const SNAP_MIN = 15; // 15분 snap (메인 캘린더와 동일)
 
-  // 메인 캘린더(S14)와 같은 밀도 규칙. 7열을 폰 폭에 넣으면 열이 51px 이라
-  // "캡스톤 발표 / 자료" 처럼 제목이 깨진다. 기본 3일로 열을 넓게 쓰고,
-  // 한 주 전체를 확인해야 할 때(승인 판단) 7일로 토글한다.
-  const [dayView, setDayView] = useState<3 | 7>(3);
-  const TIME_W = dayView === 3 ? 34 : 30;
-  const HOUR_PX = dayView === 3 ? 64 : 56;
+  // 메인 캘린더(S14)와 같은 밀도 규칙. 한 주는 언제나 7열 전부를 보여준다 —
+  // 3일만 띄우고 토글로 넘기던 방식은 "이대로 시작할까" 를 판단할 근거(이번 주 전체)가
+  // 한눈에 안 들어와서 걷어냈다. 좁아지는 건 열을 줄여서가 아니라 가로 스크롤로 푼다.
+  const TIME_W = 34;
+  // 세로도 넉넉히 — 60분 블록이 72px 라 제목과 "14:00·60분" 두 줄이 다 들어간다.
+  const HOUR_PX = 72;
 
   // 열 폭을 고정하면 폰 밖(태블릿·데스크탑·가로모드)에서 격자가 왼쪽에 몰리고
   // 오른쪽이 텅 빈다. 실제 컨테이너 폭에서 계산한다(메인 캘린더와 같은 규칙).
   // 드래그도 이 값으로 픽셀 → 요일을 환산하므로 렌더와 같은 값이어야 한다.
   const rootRef = useRef<HTMLDivElement>(null);
   const [rootW, setRootW] = useState(0);
+  // generating 을 deps 에 넣어야 한다 — 생성 중엔 PlanGeneratingView 로 early return 해서
+  // rootRef 가 아직 null 이다. [] 로 두면 관찰이 영영 안 붙고 rootW 가 0 에 굳어,
+  // 태블릿·데스크탑에서 격자가 남는 폭을 못 쓰고 왼쪽에 몰린 채로 남았다.
   useEffect(() => {
     const el = rootRef.current;
     if (!el) return;
@@ -296,8 +305,8 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
     const ro = new ResizeObserver((entries) => setRootW(entries[0].contentRect.width));
     ro.observe(el);
     return () => ro.disconnect();
-  }, []);
-  // COL_W 는 visibleCols 가 정해진 뒤 계산한다(아래).
+  }, [generating]);
+  // COL_W 는 rootW 가 실측된 뒤 계산한다(아래).
   const parseMin = (t: string) => { const [h, m] = t.split(':').map(Number); return h * 60 + m; };
   const toY = (m: number) => (m - START_H * 60) * HOUR_PX / 60;
 
@@ -337,32 +346,30 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
     );
     return idx >= 0 && idx <= 6 ? idx : -1;
   };
-  // 표시 주에 속하는 블록만 컬럼과 함께. 편집 시트가 요일(day)로 동작하므로 day=col 로 맞춘다.
-  // 3일 뷰에서 보여줄 칸 — 블록이 처음 등장하는 요일부터 3일(없으면 오늘, 그것도 없으면 월요일).
-  // 계획을 열었을 때 빈 칸부터 보이지 않게 한다.
-  const visibleCols = (() => {
-    if (dayView === 7) return [0, 1, 2, 3, 4, 5, 6];
-    const cols = blocks.map(colOf).filter((c) => c >= 0);
-    const first = cols.length ? Math.min(...cols) : (TODAY >= 0 ? TODAY : 0);
-    const anchorCol = Math.min(first, 4);
-    return [anchorCol, anchorCol + 1, anchorCol + 2];
-  })();
-
-  // 남는 폭을 열이 나눠 갖는다. 하한 아래로는 찌그러뜨리지 않고 가로 스크롤을 준다.
+  // 남는 폭을 열이 나눠 갖되, 하한 아래로는 찌그러뜨리지 않고 가로 스크롤을 준다.
+  // 84 인 이유: WeekGrid 가 80px 부터 제목을 11px·부제를 10px 로 올려 그린다.
+  // 그 아래는 8px 이라 "캡스톤 발표 자료" 가 사실상 안 읽힌다.
+  const MIN_COL_W = 84;
   const COL_W = rootW > 0
-    ? Math.max(dayView === 3 ? 96 : 44, Math.floor((rootW - TIME_W) / visibleCols.length))
-    : (dayView === 3 ? 108 : 50);
+    ? Math.max(MIN_COL_W, Math.floor((rootW - TIME_W) / ALL_COLS.length))
+    : MIN_COL_W;
+  // 실제로 가로로 넘치는지 — 넘칠 때만 "옆으로 밀면" 안내를 띄운다.
+  const overflowsX = rootW > 0 && COL_W * ALL_COLS.length + TIME_W > rootW + 1;
 
-  // 가로 드래그 → 새 요일. 보이는 칸 안에서만 움직인다(화면에 없는 요일로 놓으면 사라져 보임).
-  const dayFromDx = (fromCol: number, dx: number): number => {
-    const i = visibleCols.indexOf(fromCol);
-    if (i < 0) return fromCol;
-    const to = Math.max(0, Math.min(visibleCols.length - 1, i + Math.round(dx / COL_W)));
-    return visibleCols[to];
-  };
+  // 가로 드래그 → 새 요일. 한 주가 통째로 열려 있으니 0~6 안에서만 자른다.
+  const dayFromDx = (fromCol: number, dx: number): number =>
+    Math.max(0, Math.min(6, fromCol + Math.round(dx / COL_W)));
 
   const weekBlocks = blocks.map((b) => ({ b, col: colOf(b) })).filter((x) => x.col >= 0);
   const weekExisting = existingBlocks.map((b) => ({ b, col: colOf(b) })).filter((x) => x.col >= 0);
+
+  // 가로도 맞춰준다. 7칸이 폰 폭에 다 안 들어가니, 계획이 처음 시작하는 요일
+  // (없으면 오늘)이 화면 밖에 있으면 "계획이 비었나?" 로 보인다.
+  const firstCol = weekBlocks.length ? Math.min(...weekBlocks.map((x) => x.col)) : TODAY;
+  useEffect(() => {
+    if (generating) return;
+    scrollColIntoView(gridRef.current, firstCol, COL_W, TIME_W);
+  }, [generating, firstCol, COL_W, TIME_W, genWeekOffset]);
 
   // 화면 Block → WeekGrid 가 받는 모양. backdrop(기존 계획)은 muted 로 넘겨 뒤에 흐리게 깔린다.
   const toGridBlock = (b: Block, col: number, muted = false): WeekGridBlock => {
@@ -461,32 +468,21 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
   return (
     <div ref={rootRef} style={{ height: '100%', display: 'flex', flexDirection: 'column', background: 'var(--surface-ground)', position: 'relative' }}>
       {/* Header */}
-      <div style={{ flexShrink: 0, padding: '14px 18px 12px', borderBottom: '1px solid var(--sand-200)' }}>
+      <div style={{ flexShrink: 0, padding: '10px 16px 8px', borderBottom: '1px solid var(--sand-200)' }}>
         <SetupProgress current={4} total={4} label="계획" />
         {/* 헤더 'AI 생성 완료' 뱃지는 AiDraftCard 가 푸터에서 동일 정보 (LLM 아이콘 + 점선 +
             '수락/수정/재생성' 라벨) 를 표시하므로 중복 제거. §1.4 잠금 결정의 시각 통일. */}
-        <h2 style={{ fontWeight: 800, fontSize: 22, letterSpacing: '-0.02em', margin: '0 0 6px' }}>계획이 만들어졌어요</h2>
-        <p style={{ fontSize: 12, color: 'var(--text-2)', margin: '0 0 8px' }}>블록을 탭하면 수정, 끌면 15분 단위로 옮길 수 있어요.</p>
-        {/* 3일 뷰에선 일부 요일이 가려지므로, 승인 판단에 필요한 '이번 주 몇 개'를 함께 둔다. */}
-        <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 8 }}>
-          <span className="tnum" style={{ height: 'var(--ctrl-xs)', padding: '0 9px', background: 'var(--brand-soft)', border: '1px solid var(--coral-200)', borderRadius: 9999, fontSize: 12, fontWeight: 700, color: 'var(--brand-ink)', display: 'inline-flex', alignItems: 'center' }}>
+        {/* 제목과 '이번 주 N개'를 한 줄로 묶는다. 예전엔 제목·안내문·뱃지·3일토글이
+            각각 한 줄씩 네 줄을 먹어서, 정작 판단 근거인 시간표가 아래로 밀려 있었다. */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 3 }}>
+          <h2 style={{ fontWeight: 800, fontSize: 19, letterSpacing: '-0.02em', margin: 0, flex: 1, minWidth: 0 }}>계획이 만들어졌어요</h2>
+          <span className="tnum" style={{ flexShrink: 0, height: 'var(--ctrl-xs)', padding: '0 9px', background: 'var(--brand-soft)', border: '1px solid var(--coral-200)', borderRadius: 9999, fontSize: 12, fontWeight: 700, color: 'var(--brand-ink)', display: 'inline-flex', alignItems: 'center' }}>
             이번 주 {weekBlocks.length}개
           </span>
-          <div style={{ flex: 1 }} />
-          <div style={{ display: 'inline-flex', background: 'var(--sand-100)', borderRadius: 9999, padding: 2, gap: 2 }}>
-            {([3, 7] as const).map((n) => {
-              const on = dayView === n;
-              return (
-                <button
-                  key={n}
-                  onClick={() => setDayView(n)}
-                  className="tnum"
-                  style={{ height: 22, padding: '0 10px', borderRadius: 9999, border: 'none', background: on ? 'var(--surface-raised)' : 'transparent', color: on ? 'var(--text-1)' : 'var(--text-3)', fontSize: 12, fontWeight: 700, cursor: 'pointer' }}
-                >{n}일</button>
-              );
-            })}
-          </div>
         </div>
+        <p style={{ fontSize: 11.5, color: 'var(--text-3)', margin: '0 0 8px', lineHeight: 1.45 }}>
+          탭하면 수정 · 끌면 15분 단위로 이동{overflowsX ? ' · 옆으로 밀면 나머지 요일' : ''}
+        </p>
         {/* 다중 주 계획 주 단위 이동(#119) — 계획이 여러 주에 걸치면 이전/다음 주로 넘겨 본다.
             화살표를 양끝으로 밀지 않고 날짜와 한 덩어리로 가운데 묶는다. 이 화면은 셸이
             그리는 뒤로가기('‹')가 왼쪽 위에 있어서, 왼쪽 끝에 같은 모양의 '‹' 를 또 두면
@@ -571,7 +567,7 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
         endHour={END_H}
         hourPx={HOUR_PX}
         colWidth={COL_W}
-        visibleCols={visibleCols}
+        visibleCols={ALL_COLS}
         timeWidth={TIME_W}
         onBlockPointerDown={(e, gb) => {
           const hit = weekBlocks.find((x) => x.b.id === gb.id);
@@ -582,70 +578,47 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
       {/* AI Draft footer — Issue #12 §1.4 잠금 결정 시각화.
           onAccept 은 우리 handleContinue (plansApi.approve mock-and-replace 포함) 사용.
           onReject 는 generating=true 로 되돌려 useEffect 의 plansApi.generate 재호출. */}
-      <div style={{ flexShrink: 0, padding: '10px 14px', paddingBottom: 'max(14px, env(safe-area-inset-bottom, 14px))', background: 'var(--surface-ground)' }}>
-        {/* 계획 분량(밀도) 선택 — '재생성' 시 body.density 로 전달돼 생성되는 카드 수를 좌우한다.
-            선택만으로는 재생성하지 않는다(아래 재생성 버튼을 눌러야 반영). */}
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 10 }}>
-          <span style={{ fontSize: 11, color: 'var(--text-3)', flexShrink: 0 }}>계획 분량</span>
-          <div style={{ display: 'inline-flex', gap: 3, background: 'rgba(0,0,0,0.05)', borderRadius: 9999, padding: 3 }}>
-            {(
-              [
-                ['light', '가볍게'],
-                ['standard', '표준'],
-                ['intense', '촘촘히'],
-              ] as [PlanDensity, string][]
-            ).map(([val, label]) => {
-              const active = density === val;
-              return (
-                <button
-                  key={val}
-                  onClick={() => setDensity(val)}
-                  disabled={generating}
-                  style={{
-                    height: 'var(--ctrl-xs)',
-                    padding: '0 12px',
-                    borderRadius: 9999,
-                    border: 'none',
-                    cursor: generating ? 'default' : 'pointer',
-                    fontFamily: 'inherit',
-                    fontSize: 11,
-                    fontWeight: 600,
-                    background: active ? 'var(--text-1)' : 'transparent',
-                    color: active ? '#FAF6EE' : 'var(--text-2)',
-                    transition: 'background 120ms, color 120ms',
-                  }}
-                >
-                  {label}
-                </button>
-              );
-            })}
-          </div>
-        </div>
+      <div style={{ flexShrink: 0, padding: '8px 12px', paddingBottom: 'max(12px, env(safe-area-inset-bottom, 12px))', background: 'var(--surface-ground)' }}>
         <AiDraftCard
           isDraft={true}
           aiSource={planAiSource}
           onAccept={handleContinue}
           onEdit={addBlock}
           onReject={generatePlan}
+          // 계획 분량과 '다시 인터뷰하기' 는 대부분 한 번도 안 누르는데 카드 위아래로
+          // 80px 넘게 먹고 있었다. '⋯' 뒤 시트로 접어 시간표에 세로를 돌려준다.
+          headerAction={
+            <button
+              type="button"
+              onClick={() => setOptionsOpen(true)}
+              aria-label="계획 옵션"
+              aria-haspopup="dialog"
+              style={{ width: 26, height: 26, borderRadius: 8, border: 'none', background: 'transparent', color: 'inherit', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer', padding: 0 }}
+            >
+              <DotsThreeOutline size={14} weight="fill" />
+            </button>
+          }
           // 블록이 하나도 없으면 "이대로 시작"이 말이 안 되므로 막고, 아래 안내로 유도.
           acceptDisabled={blocks.length === 0 || approving}
           acceptLabel={approving ? '시작하는 중…' : '이대로 시작'}
           editLabel="블록 추가"
           rejectLabel="재생성"
         >
-          <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+          {/* 칩은 한 줄에 가둔다. wrap 이면 카테고리가 늘어날수록 카드가 세로로
+              자라 시간표를 밀어낸다 — 넘치면 옆으로 스크롤. */}
+          <div className="rx-hscroll" style={{ display: 'flex', gap: 6, flexWrap: 'nowrap', overflowX: 'auto', paddingBottom: 1 }}>
             {blocks.length === 0 && (
               <span style={{ fontSize: 11, color: 'var(--text-3)' }}>블록을 추가하면 시작할 수 있어요.</span>
             )}
             {blocks.length > 0 && (
-            <span className="tnum" style={{ height: 'var(--ctrl-xs)', padding: '0 10px', background: 'var(--text-1)', color: '#FAF6EE', borderRadius: 9999, fontSize: 11, fontWeight: 600, display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+            <span className="tnum" style={{ flexShrink: 0, height: 'var(--ctrl-xs)', padding: '0 10px', background: 'var(--text-1)', color: '#FAF6EE', borderRadius: 9999, fontSize: 11, fontWeight: 600, display: 'inline-flex', alignItems: 'center', gap: 4 }}>
               <Clock size={11} weight="fill" /> 총 {totalH.toFixed(1)}h
             </span>
             )}
             {Object.entries(goalCount).map(([g, mins]) => {
               const c = goalColor(g);
               return (
-                <span key={g} style={{ height: 'var(--ctrl-xs)', padding: '0 10px', background: c.bg, border: `1px solid ${c.bd}`, color: c.fg, borderRadius: 9999, fontSize: 11, fontWeight: 600, display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+                <span key={g} style={{ flexShrink: 0, height: 'var(--ctrl-xs)', padding: '0 10px', background: c.bg, border: `1px solid ${c.bd}`, color: c.fg, borderRadius: 9999, fontSize: 11, fontWeight: 600, display: 'inline-flex', alignItems: 'center', gap: 4 }}>
                   <span style={{ width: 6, height: 6, borderRadius: 9999, background: c.fg }} />
                   {categoryLabel(g)} <span className="tnum">{(mins / 60).toFixed(1)}h</span>
                 </span>
@@ -653,29 +626,21 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
             })}
           </div>
         </AiDraftCard>
-        {/* 계획을 확정하기 전 되돌아가는 길 — '재생성' 은 같은 답으로 다시 만드는 것이고,
-            답 자체를 바꾸고 싶을 땐 인터뷰를 다시 해야 한다. 이 버튼이 없어서 사용자가
-            새로고침으로 화면을 끊었고, 그러면 초안·잠정 목표가 그대로 남았다. */}
-        <button
-          onClick={handleRestartInterview}
-          disabled={discarding || approving}
-          style={{
-            marginTop: 10,
-            alignSelf: 'center',
-            padding: '8px 14px',
-            borderRadius: 10,
-            border: '1px solid var(--sand-200)',
-            background: 'transparent',
-            color: 'var(--text-2)',
-            fontSize: 12,
-            fontFamily: 'inherit',
-            cursor: discarding || approving ? 'default' : 'pointer',
-            opacity: discarding || approving ? 0.5 : 1,
-          }}
-        >
-          {discarding ? '정리하는 중…' : '답을 바꾸고 싶어요 · 다시 인터뷰하기'}
-        </button>
       </div>
+
+      {/* 계획 분량 + '다시 인터뷰하기'. 되돌아가는 길 자체는 그대로 남기고(없으면 사용자가
+          새로고침으로 화면을 끊어 초안·잠정 목표가 그대로 남는다) 위치만 '⋯' 뒤로 옮겼다. */}
+      {optionsOpen && (
+        <PlanOptionsSheet
+          density={density}
+          onDensityChange={setDensity}
+          onRegenerate={() => { setOptionsOpen(false); generatePlan(); }}
+          onRestartInterview={handleRestartInterview}
+          restarting={discarding}
+          busy={approving}
+          onClose={() => setOptionsOpen(false)}
+        />
+      )}
 
       {editing && (
         <BlockEditSheet


### PR DESCRIPTION
## 무엇을 바꿨나

주간 시간표가 **3일만 보이거나, 7일이 51px 로 찌그러지거나** 둘 중 하나였습니다. 승인 화면("계획이 만들어졌어요")에서 한 주 전체가 안 보이면 '이대로 시작'을 누를 근거가 없습니다.

- **3일/7일 토글 제거** — 주간 계획 생성 · 메인 주간 캘린더 둘 다 항상 7일
- **열 최소 84px + 가로 스크롤** — 좁으면 칸 수를 줄이는 대신 옆으로 밈
- **캘린더를 상하로 길게** — 시간 한 칸 56→72px, 헤더 4줄→2줄
- **AI 초안 카드 축소** 224px → 106px, '계획 분량'·'다시 인터뷰하기'는 `⋯` 시트로

## 왜 이렇게 했나

`WeekGrid` 의 요일 헤더가 **스크롤 컨테이너 밖 형제**였습니다. 그 구조에선 열을 넓혀 가로 스크롤이 생기는 순간 헤더만 제자리에 남아 본문 격자와 하루씩 어긋납니다. 열을 못 넓히고 3일 뷰로 우회했던 진짜 이유가 이것이었습니다.

헤더를 같은 스크롤 안으로 넣어 `sticky top`, 시간 눈금은 `sticky left` 로 고정했습니다. 7칸이 폰 폭에 다 안 들어가므로 `scrollColIntoView` 로 오늘(캘린더) · 첫 블록(생성) 칸을 가로 가운데로 보냅니다 — 3일 창이 하던 앵커 역할을 대신합니다.

곁다리로 발견한 버그 하나: 생성 화면의 `ResizeObserver` 가 deps `[]` 라 `PlanGeneratingView` early return 중엔 `rootRef` 가 null 이어서 관찰이 영영 안 붙었습니다. `rootW` 가 0 에 굳어 넓은 화면에서 격자가 남는 폭을 못 쓰고 있었습니다.

## 어떻게 검증했나

`tsc --noEmit` + `vite build` 통과. headless Chrome(390×844) 에서 API 를 목킹해 실측:

| 항목 | 결과 |
|---|---|
| 헤더 요일칸 ↔ 본문 세로선 `left` | 스크롤 0/200 양쪽에서 **완전 일치** (34,118,202,286,370,454,538) |
| 가로 스크롤 | `scrollWidth 622 / clientWidth 390` |
| 블록 글씨 | 11px, "캡스톤 발표 자료 만들기" 안 잘림 |
| 드래그 | +84px = 정확히 한 요일, +72px = 정확히 한 시간 |
| 탭 | 블록 편집 시트 열림 |
| 격자 높이 | 폰 844px 중 518px |

## 리뷰 포인트

- 데스크탑(1440px)에선 캘린더 패널이 560px 라 62px 정도 가로 스크롤이 남습니다. 열을 좁혀 맞추면 글씨가 다시 작아져서 그대로 뒀습니다.
- 메인 캘린더의 3일 창 이동(월화수/목금토/금토일) 로직을 통째로 걷어냈습니다 — 이동은 주 단위 하나뿐입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
