### PR TITLE
feat(fe): 홈 C안 타임라인 · 다음 할 일 고정 · 음성 인터뷰 · 전용 입력 · 재인터뷰 복귀

### DIFF
--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -55,6 +55,8 @@ export function AppShell() {
   const [weekOffset, setWeekOffset] = useState(0);
   const [interviewSessionId, setInterviewSessionId] = useState<string | null>(null);
   const [plannedMilestones, setPlannedMilestones] = useState<MilestoneDraft[] | null>(null);
+  // 앱 사용 중 딥 인터뷰로 진입했을 때 돌아갈 화면(#216). 온보딩 경로면 null.
+  const [interviewReturnTo, setInterviewReturnTo] = useState<ScreenId | null>(null);
   // 실제 로그인 화면(구글/데모)을 보여줘야 하는지 — stub 자동 로그인이 꺼졌거나(?login=1) 401 뒤 재로그인 필요할 때.
   const [needsLogin, setNeedsLogin] = useState(false);
   const [authBusy, setAuthBusy] = useState(false);
@@ -279,7 +281,7 @@ export function AppShell() {
 
   return (
     <NavigationContext.Provider
-      value={{ screen, tab, setScreen, setTab, user, onboardingState, isBootstrapping, weekOffset, setWeekOffset, interviewSessionId, setInterviewSessionId, plannedMilestones, setPlannedMilestones }}
+      value={{ screen, tab, setScreen, setTab, user, onboardingState, isBootstrapping, weekOffset, setWeekOffset, interviewSessionId, setInterviewSessionId, plannedMilestones, setPlannedMilestones, interviewReturnTo, setInterviewReturnTo }}
     >
       <ToastProvider>
         {/* 뷰포트에 맞는 트리 하나만 마운트(둘 다 마운트 후 CSS 로만 숨기면 데이터 페칭이 2배로 나감). */}

--- a/src/app/ReActionMerged.tsx
+++ b/src/app/ReActionMerged.tsx
@@ -94,7 +94,7 @@ interface ReActionMergedProps {
 }
 
 export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
-  const { screen, tab, setScreen, setTab, setWeekOffset } = useNavigation();
+  const { screen, tab, setScreen, setTab, setWeekOffset, interviewReturnTo, setInterviewReturnTo } = useNavigation();
 
   // 초기값 비움 → /today/agenda 로딩 중엔 TodayScreen 의 스켈레톤이 대신 표시된다.
   // 실패 시에도 더미로 가리지 않고 빈 목록 + 정직 배너를 보여준다.
@@ -195,7 +195,20 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
   // 탭으로 주간 계획에 들어오면 항상 이번 주부터 (다음 주는 리뷰 버튼으로만 진입).
   const handleTabChange = (id: TabId) => { if (id === 'weekly') setWeekOffset(0); setTab(id); setScreen(id); };
 
+  // 딥 인터뷰를 마치고(또는 중간에 나가서) 돌아갈 곳(#216).
+  // 앱 사용 중 재인터뷰로 들어온 경우엔 온보딩 체인이 아니라 들어온 화면으로 돌려보낸다.
+  const leaveInterview = (fallback: ScreenId) => {
+    const back = interviewReturnTo;
+    setInterviewReturnTo(null);
+    setScreen(back ?? fallback);
+  };
+
   const goBack = () => {
+    // 재인터뷰 중 뒤로가기가 NAV_META 의 온보딩 체인을 따르면 사용자를 intro 로 떨어뜨린다.
+    if (screen === 'goal-intake' && interviewReturnTo) {
+      leaveInterview('today');
+      return;
+    }
     const meta = NAV_META[screen];
     if (meta?.back) setScreen(meta.back);
     else setScreen('today');
@@ -220,7 +233,7 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
           <SystemIntroScreen onDone={() => setScreen('goal-intake')} />
         )}
         {screen === 'goal-intake' && (
-          <GoalIntakeScreen onDone={() => setScreen('goal-classify')} onOutcome={setInterviewOutcome} />
+          <GoalIntakeScreen onDone={() => leaveInterview('goal-classify')} onOutcome={setInterviewOutcome} />
         )}
         {screen === 'goal-classify' && (
           <GoalClassificationScreen onNext={() => setScreen('setup')} outcome={interviewOutcome} />

--- a/src/components/NextUpStrip.tsx
+++ b/src/components/NextUpStrip.tsx
@@ -1,0 +1,136 @@
+import { Play } from '@phosphor-icons/react';
+import type { Task } from '../types';
+
+// 오늘 화면 상단에 붙어 있는 [다음 할 일] 스트립(#214).
+//
+// 오늘 화면은 스크롤 컨테이너 하나에 헤더 → 히어로 카드 → 나머지 카드 → 습관 순으로 쌓여 있어,
+// "지금 할 일" 을 알려주는 유일한 장치인 히어로 카드가 조금만 내리면 화면에서 사라졌다.
+// 실패 회복이 이 제품의 정체성이라면 다음 한 걸음은 항상 보여야 한다.
+//
+// 스크롤 흐름 안에 넣으면(sticky) 나타나는 순간 아래 내용이 그만큼 밀려 화면이 튄다.
+// 그래서 스크롤 컨테이너 위에 겹쳐 띄운다(absolute) — 레이아웃은 전혀 건드리지 않는다.
+
+export interface NextUpStripProps {
+  /** 히어로 카드와 반드시 같은 카드여야 한다 — 둘이 다른 걸 가리키면 그 순간 신뢰를 잃는다. */
+  task: Task;
+  /** 보이기/숨기기. 히어로 카드가 화면에 있는 동안엔 false(같은 정보 2중 표시 방지). */
+  visible: boolean;
+  time?: string;
+  dur?: string;
+  goalLabel?: string;
+  goalColor?: { bg: string; bd: string; fg: string };
+  done: number;
+  total: number;
+  onStart: (id: string) => void;
+}
+
+export function NextUpStrip({
+  task,
+  visible,
+  time,
+  dur,
+  goalLabel,
+  goalColor,
+  done,
+  total,
+  onStart,
+}: NextUpStripProps) {
+  // 시각·소요·목표를 가운뎃점으로 잇는다. 없는 건 자리를 만들지 않는다.
+  const meta = [time, dur, goalLabel].filter(Boolean).join(' · ');
+
+  return (
+    <div
+      // 숨겨진 동안에는 보조기술과 포인터 양쪽에서 완전히 빠져야 한다 —
+      // opacity 만 0 으로 두면 안 보이는 버튼을 누를 수 있다.
+      aria-hidden={!visible}
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        right: 0,
+        zIndex: 20,
+        padding: '8px 12px',
+        background: 'rgba(250,246,238,.94)',
+        backdropFilter: 'blur(18px)',
+        borderBottom: '1px solid var(--sand-200)',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 10,
+        transform: visible ? 'translateY(0)' : 'translateY(-100%)',
+        opacity: visible ? 1 : 0,
+        pointerEvents: visible ? 'auto' : 'none',
+        transition: 'transform 180ms ease, opacity 180ms ease',
+      }}
+    >
+      {/* 목표 색 점 — 색만으로 구분하지 않도록 아래 라벨과 항상 함께 쓴다. */}
+      <span
+        aria-hidden
+        style={{
+          width: 8,
+          height: 8,
+          borderRadius: 9999,
+          flexShrink: 0,
+          background: goalColor?.fg ?? 'var(--brand-surface)',
+        }}
+      />
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ display: 'flex', alignItems: 'baseline', gap: 6 }}>
+          <span style={{ fontSize: 10, fontWeight: 700, color: 'var(--text-3)', flexShrink: 0 }}>다음 할 일</span>
+          <span className="tnum" style={{ fontSize: 10, color: 'var(--text-3)', flexShrink: 0 }}>
+            {done}/{total}
+          </span>
+        </div>
+        <div
+          style={{
+            fontSize: 13,
+            fontWeight: 700,
+            color: 'var(--text-1)',
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+          }}
+        >
+          {task.title}
+        </div>
+        {meta && (
+          <div
+            className="tnum"
+            style={{
+              fontSize: 11,
+              color: 'var(--text-3)',
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+            }}
+          >
+            {meta}
+          </div>
+        )}
+      </div>
+      <button
+        onClick={() => onStart(task.id)}
+        // 숨겨진 동안 탭 순서에서도 빠진다.
+        tabIndex={visible ? 0 : -1}
+        style={{
+          height: 34,
+          padding: '0 14px',
+          borderRadius: 9999,
+          border: 'none',
+          background: 'var(--brand-surface)',
+          color: '#FFFCF6',
+          fontSize: 12,
+          fontWeight: 700,
+          fontFamily: 'inherit',
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 5,
+          cursor: 'pointer',
+          flexShrink: 0,
+        }}
+      >
+        <Play size={12} weight="fill" />
+        {task.status === 'in_progress' ? '이어서' : '시작'}
+      </button>
+    </div>
+  );
+}

--- a/src/components/TaskRow.tsx
+++ b/src/components/TaskRow.tsx
@@ -12,6 +12,8 @@ export interface TaskRowProps {
   goalLabel?: string;
   /** 목표 카테고리 색. 라벨과 항상 함께 쓴다(색만으로 구분하지 않는다). */
   goalColor?: { bg: string; bd: string; fg: string };
+  /** 타임라인처럼 바깥 시간 축이 시각을 그리는 경우 row 안 시각을 숨긴다. */
+  hideTime?: boolean;
   /** todo 를 눌렀을 때 — 주역 카드로 올린다(시작은 그쪽 CTA 에서). */
   onSelect: () => void;
   /** failed 를 눌렀을 때 — 회복 제안으로 보낸다. */
@@ -38,6 +40,7 @@ export function TaskRow({
   dur,
   goalLabel,
   goalColor,
+  hideTime = false,
   onSelect,
   onFailedRecover,
   onPartialRecover,
@@ -127,7 +130,7 @@ export function TaskRow({
           </span>
         )}
       </span>
-      {shownTime && (
+      {shownTime && !hideTime && (
         <span className="tnum" style={{ fontSize: 12, color: 'var(--text-3)', flexShrink: 0, fontWeight: 600 }}>
           {shownTime}
         </span>

--- a/src/components/TodayTimeline.tsx
+++ b/src/components/TodayTimeline.tsx
@@ -1,0 +1,62 @@
+import type { Task } from '../types';
+import { TaskRow } from './TaskRow';
+
+interface TimelineItem {
+  task: Task;
+  time?: string;
+  dur?: string;
+  goalLabel?: string;
+  goalColor?: { bg: string; bd: string; fg: string };
+}
+
+interface TodayTimelineProps {
+  items: TimelineItem[];
+  onSelect: (id: string) => void;
+  onFailedRecover: (id: string, reason: string) => void;
+  onPartialRecover: () => void;
+}
+
+function statusColor(task: Task): string {
+  if (task.status === 'done') return 'var(--success)';
+  if (task.status === 'failed') return 'var(--danger)';
+  if (task.status === 'in_progress' || task.status === 'partial_done' || task.status === 'recovery_pending') return 'var(--brand)';
+  return 'var(--sand-300)';
+}
+
+/** 홈 C안의 시간축 목록. 카드 묶음보다 오늘이 어떤 순서로 흐르는지를 먼저 읽게 한다. */
+export function TodayTimeline({ items, onSelect, onFailedRecover, onPartialRecover }: TodayTimelineProps) {
+  if (items.length === 0) return null;
+
+  return (
+    <section aria-labelledby="today-timeline-title">
+      <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', marginBottom: 8 }}>
+        <h2 id="today-timeline-title" style={{ margin: 0, fontSize: 14, fontWeight: 750, color: 'var(--text-1)' }}>오늘의 타임라인</h2>
+        <span style={{ fontSize: 11, color: 'var(--text-3)' }}>시간순</span>
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column' }}>
+        {items.map(({ task, time, dur, goalLabel, goalColor }, index) => {
+          const shownTime = time ?? task.time;
+          const last = index === items.length - 1;
+          return (
+            <div key={task.id} style={{ display: 'grid', gridTemplateColumns: '46px 18px minmax(0, 1fr)', alignItems: 'stretch' }}>
+              <span className="tnum" style={{ paddingTop: 12, paddingRight: 8, textAlign: 'right', fontSize: 11, fontWeight: 650, color: shownTime ? 'var(--text-2)' : 'var(--text-4)' }}>
+                {shownTime || '미정'}
+              </span>
+              <span aria-hidden style={{ position: 'relative', display: 'flex', justifyContent: 'center' }}>
+                {!last && <span style={{ position: 'absolute', top: 19, bottom: -1, width: 1, background: 'var(--sand-200)' }} />}
+                <span style={{ zIndex: 1, width: 9, height: 9, marginTop: 15, borderRadius: 9999, background: statusColor(task), boxShadow: '0 0 0 3px var(--surface-ground)' }} />
+              </span>
+              <div style={{ minWidth: 0, paddingBottom: last ? 0 : 2 }}>
+                <TaskRow task={task} time={shownTime} dur={dur} goalLabel={goalLabel} goalColor={goalColor} hideTime
+                  onSelect={() => onSelect(task.id)}
+                  onFailedRecover={() => onFailedRecover(task.id, task.failReason || '')}
+                  onPartialRecover={onPartialRecover}
+                />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/components/TypedAnswerField.tsx
+++ b/src/components/TypedAnswerField.tsx
@@ -1,0 +1,185 @@
+import { useMemo } from 'react';
+import { TimeDial } from './TimeDial';
+import { localDateStr } from '../lib/dates';
+
+// 인터뷰 질문의 answerType 이 date_picker / time_range 일 때 쓰는 전용 입력(#217).
+//
+// 백엔드는 질문마다 "이건 날짜다 / 이건 시간 범위다" 를 answerType 으로 이미 알려준다.
+// 그런데 FE 는 chip/select 만 특별 취급하고 나머지는 전부 맨 텍스트 입력으로 떨어뜨려,
+// 사용자가 모바일 키보드로 `2026-11-30` 을 치고 `09:00-23:00` 의 하이픈까지 맞춰야 했다.
+// 마감일자와 선호 시간대는 계획 생성의 두 축이라, 여기서 어긋나면 계획 전체가 어긋난다.
+//
+// 전송 문자열 형식은 기존과 동일하게 유지한다(YYYY-MM-DD / HH:MM-HH:MM) — 백엔드 계약 무변경.
+
+const CHIP_BASE: React.CSSProperties = {
+  padding: '8px 12px',
+  borderRadius: 9999,
+  fontSize: 12,
+  fontWeight: 600,
+  fontFamily: 'inherit',
+  cursor: 'pointer',
+  whiteSpace: 'nowrap',
+};
+
+function chipStyle(active: boolean): React.CSSProperties {
+  return {
+    ...CHIP_BASE,
+    border: `1px solid ${active ? 'var(--coral-200)' : 'var(--sand-200)'}`,
+    background: active ? 'var(--brand-soft)' : 'var(--surface-raised)',
+    color: active ? 'var(--coral-700)' : 'var(--text-2)',
+  };
+}
+
+function addDays(base: Date, n: number): Date {
+  const d = new Date(base);
+  d.setDate(d.getDate() + n);
+  return d;
+}
+
+function addMonths(base: Date, n: number): Date {
+  const d = new Date(base);
+  d.setMonth(d.getMonth() + n);
+  return d;
+}
+
+// 다가오는 일요일(오늘이 일요일이면 오늘).
+function upcomingSunday(base: Date): Date {
+  const day = base.getDay();
+  return addDays(base, day === 0 ? 0 : 7 - day);
+}
+
+export function DateAnswerField({
+  value,
+  onChange,
+  disabled,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  disabled?: boolean;
+}) {
+  // 렌더마다 new Date() 를 다시 만들면 자정을 넘길 때 칩 값이 흔들린다 — 마운트 시점에 고정.
+  const { today, presets } = useMemo(() => {
+    const now = new Date();
+    return {
+      today: localDateStr(now),
+      presets: [
+        { label: '오늘', date: localDateStr(now) },
+        { label: '이번 주말', date: localDateStr(upcomingSunday(now)) },
+        { label: '2주 뒤', date: localDateStr(addDays(now, 14)) },
+        { label: '한 달 뒤', date: localDateStr(addMonths(now, 1)) },
+        { label: '3개월 뒤', date: localDateStr(addMonths(now, 3)) },
+      ],
+    };
+  }, []);
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+        {presets.map((p) => (
+          <button
+            key={p.label}
+            type="button"
+            onClick={() => onChange(p.date)}
+            disabled={disabled}
+            style={{ ...chipStyle(value === p.date), opacity: disabled ? 0.5 : 1 }}
+          >
+            {p.label}
+          </button>
+        ))}
+      </div>
+      <input
+        type="date"
+        value={value}
+        // 지난 날짜를 마감으로 잡으면 계획이 세워질 수 없다.
+        min={today}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={disabled}
+        aria-label="마감 날짜"
+        style={{
+          width: '100%',
+          boxSizing: 'border-box',
+          padding: '11px 14px',
+          borderRadius: 12,
+          border: '1.5px solid var(--sand-200)',
+          background: 'var(--surface-raised)',
+          color: 'var(--text-1)',
+          fontSize: 14,
+          fontFamily: 'inherit',
+          outline: 'none',
+        }}
+      />
+    </div>
+  );
+}
+
+// "09:00-23:00" 을 시작/종료로 가른다. 형식이 아니면 기본값(09:00~18:00).
+export function parseRange(v: string): { start: string; end: string } {
+  const m = /^(\d{2}:\d{2})\s*[-~]\s*(\d{2}:\d{2})$/.exec(v.trim());
+  if (m) return { start: m[1], end: m[2] };
+  return { start: '09:00', end: '18:00' };
+}
+
+export function formatRange(start: string, end: string): string {
+  return `${start}-${end}`;
+}
+
+// 같은 날 안의 범위만 표현한다. 시작 ≥ 종료면 유효하지 않다(자정을 넘는 범위는
+// 이 필드로 못 만든다 — 그 경우를 위해 호출부가 "직접 입력" 탈출구를 준다).
+export function isValidRange(start: string, end: string): boolean {
+  return start < end;
+}
+
+const RANGE_PRESETS: { label: string; start: string; end: string }[] = [
+  { label: '오전형 09–18', start: '09:00', end: '18:00' },
+  { label: '저녁형 18–23', start: '18:00', end: '23:00' },
+  { label: '하루 종일 08–22', start: '08:00', end: '22:00' },
+];
+
+export function TimeRangeAnswerField({
+  value,
+  onChange,
+  disabled,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  disabled?: boolean;
+}) {
+  const { start, end } = parseRange(value);
+  const valid = isValidRange(start, end);
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+        {RANGE_PRESETS.map((p) => (
+          <button
+            key={p.label}
+            type="button"
+            onClick={() => onChange(formatRange(p.start, p.end))}
+            disabled={disabled}
+            style={{
+              ...chipStyle(start === p.start && end === p.end),
+              opacity: disabled ? 0.5 : 1,
+            }}
+          >
+            {p.label}
+          </button>
+        ))}
+      </div>
+      <div style={{ display: 'flex', alignItems: 'stretch', gap: 8 }}>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ fontSize: 11, fontWeight: 700, color: 'var(--text-3)', marginBottom: 4 }}>시작</div>
+          <TimeDial value={start} onChange={(v) => onChange(formatRange(v, end))} minuteStep={30} />
+        </div>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ fontSize: 11, fontWeight: 700, color: 'var(--text-3)', marginBottom: 4 }}>종료</div>
+          <TimeDial value={end} onChange={(v) => onChange(formatRange(start, v))} minuteStep={30} />
+        </div>
+      </div>
+      {!valid && (
+        <span role="alert" style={{ fontSize: 12, color: 'var(--coral-700)' }}>
+          종료가 시작보다 빠르거나 같아요. 자정을 넘는 시간대는 아래 '직접 입력' 으로 적어주세요.
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/contexts/NavigationContext.tsx
+++ b/src/contexts/NavigationContext.tsx
@@ -25,6 +25,11 @@ export interface NavigationContextType {
   // milestones 로 넘겨 그 구조대로 계획을 세운다. 마일스톤 없이 자동 생성이면 null.
   plannedMilestones: MilestoneDraft[] | null;
   setPlannedMilestones: (m: MilestoneDraft[] | null) => void;
+  // 온보딩이 아니라 앱 사용 중에 딥 인터뷰로 들어왔을 때 끝나고 돌아갈 화면(#216).
+  // null 이면 기존 온보딩 체인(goal-intake → goal-classify) 그대로다.
+  // 이게 없으면 목표가 바뀌어 다시 인터뷰한 사용자가 온보딩 한복판에 떨어진다.
+  interviewReturnTo: ScreenId | null;
+  setInterviewReturnTo: (s: ScreenId | null) => void;
 }
 
 export const NavigationContext = createContext<NavigationContextType>({
@@ -41,6 +46,8 @@ export const NavigationContext = createContext<NavigationContextType>({
   setInterviewSessionId: () => {},
   plannedMilestones: null,
   setPlannedMilestones: () => {},
+  interviewReturnTo: null,
+  setInterviewReturnTo: () => {},
 });
 
 export const useNavigation = () => useContext(NavigationContext);

--- a/src/lib/useSpeechInput.ts
+++ b/src/lib/useSpeechInput.ts
@@ -1,0 +1,169 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+// 브라우저 음성 인식(Web Speech API) 훅 — 온보딩 인터뷰의 타이핑 피로를 줄인다(#215).
+//
+// 백엔드에 음성 업로드 엔드포인트가 아직 없어서(openapi.json 기준) 추가 인프라 없이
+// 붙일 수 있는 브라우저 API 를 쓴다. 나중에 서버 STT 가 준비되면 이 훅 내부만 갈아끼우면
+// 되고 화면 코드는 그대로다.
+//
+// lib.dom.d.ts 에 SpeechRecognition 이 없는 TS 버전이 아직 흔해서 전역 선언 대신
+// 최소 구조만 로컬로 정의한다(전역 declare 는 lib 이 이미 정의한 환경에서 충돌한다).
+
+interface SpeechAlternative {
+  transcript: string;
+}
+interface SpeechResult {
+  readonly length: number;
+  isFinal: boolean;
+  [index: number]: SpeechAlternative;
+}
+interface SpeechResultList {
+  readonly length: number;
+  [index: number]: SpeechResult;
+}
+interface SpeechEvent {
+  resultIndex: number;
+  results: SpeechResultList;
+}
+interface SpeechErrorEvent {
+  error: string;
+}
+interface SpeechRecognitionLike {
+  lang: string;
+  continuous: boolean;
+  interimResults: boolean;
+  maxAlternatives: number;
+  start(): void;
+  stop(): void;
+  abort(): void;
+  onresult: ((e: SpeechEvent) => void) | null;
+  onerror: ((e: SpeechErrorEvent) => void) | null;
+  onend: (() => void) | null;
+}
+type SpeechRecognitionCtor = new () => SpeechRecognitionLike;
+
+function getCtor(): SpeechRecognitionCtor | null {
+  if (typeof window === 'undefined') return null;
+  const w = window as unknown as {
+    SpeechRecognition?: SpeechRecognitionCtor;
+    webkitSpeechRecognition?: SpeechRecognitionCtor;
+  };
+  return w.SpeechRecognition ?? w.webkitSpeechRecognition ?? null;
+}
+
+// 인식 실패 코드 → 사용자가 읽고 다음 행동을 정할 수 있는 문장.
+function messageFor(code: string): string {
+  switch (code) {
+    case 'not-allowed':
+    case 'service-not-allowed':
+      return '마이크 권한이 막혀 있어요. 브라우저 설정에서 허용한 뒤 다시 시도해주세요.';
+    case 'no-speech':
+      return '소리가 들리지 않았어요. 다시 눌러서 말해주세요.';
+    case 'audio-capture':
+      return '마이크를 찾지 못했어요. 연결 상태를 확인해주세요.';
+    case 'network':
+      return '네트워크 문제로 음성 인식이 중단됐어요.';
+    case 'aborted':
+      return '';
+    default:
+      return '음성 인식에 실패했어요. 직접 입력해주세요.';
+  }
+}
+
+export interface SpeechInput {
+  /** 이 브라우저가 음성 인식을 지원하는지. false 면 마이크 버튼을 아예 그리지 않는다. */
+  supported: boolean;
+  listening: boolean;
+  /** 아직 확정되지 않은 인식 결과 — 말하는 도중 미리보기용. */
+  interim: string;
+  /** 마지막 오류 메시지(사용자 노출용). 없으면 null. */
+  error: string | null;
+  start: () => void;
+  stop: () => void;
+}
+
+/**
+ * @param onFinal 확정된 문장이 나올 때마다 호출된다. 여기서 입력창에 이어붙인다.
+ *                자동 전송하지 않는 것은 의도다 — 잘못 인식된 답 하나가 계획 전체를 가른다.
+ */
+export function useSpeechInput(onFinal: (text: string) => void): SpeechInput {
+  const [supported] = useState(() => getCtor() !== null);
+  const [listening, setListening] = useState(false);
+  const [interim, setInterim] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const recRef = useRef<SpeechRecognitionLike | null>(null);
+  // onFinal 이 매 렌더 새 함수여도 인식기를 다시 만들지 않도록 ref 로 최신값만 들고 있는다.
+  const onFinalRef = useRef(onFinal);
+  useEffect(() => { onFinalRef.current = onFinal; }, [onFinal]);
+
+  const stop = useCallback(() => {
+    const rec = recRef.current;
+    if (!rec) return;
+    recRef.current = null;
+    // stop() 은 onend 를 태우지만, 이미 끊긴 인스턴스면 예외가 난다 — 무시해도 되는 종류.
+    try { rec.stop(); } catch { /* 이미 종료됨 */ }
+    setListening(false);
+    setInterim('');
+  }, []);
+
+  const start = useCallback(() => {
+    const Ctor = getCtor();
+    if (!Ctor) return;
+    if (recRef.current) { stop(); return; }
+
+    setError(null);
+    setInterim('');
+
+    const rec = new Ctor();
+    rec.lang = 'ko-KR';
+    rec.continuous = true;
+    rec.interimResults = true;
+    rec.maxAlternatives = 1;
+
+    rec.onresult = (e) => {
+      let pending = '';
+      for (let i = e.resultIndex; i < e.results.length; i += 1) {
+        const r = e.results[i];
+        const text = r[0]?.transcript ?? '';
+        if (r.isFinal) {
+          const trimmed = text.trim();
+          if (trimmed) onFinalRef.current(trimmed);
+        } else {
+          pending += text;
+        }
+      }
+      setInterim(pending);
+    };
+
+    rec.onerror = (e) => {
+      const msg = messageFor(e.error);
+      if (msg) setError(msg);
+      // 오류가 나면 브라우저가 알아서 끊는다 — 상태만 맞춰둔다.
+      recRef.current = null;
+      setListening(false);
+      setInterim('');
+    };
+
+    rec.onend = () => {
+      // 사용자가 멈췄든 브라우저가 침묵으로 끊었든, 듣고 있지 않다는 사실은 같다.
+      recRef.current = null;
+      setListening(false);
+      setInterim('');
+    };
+
+    try {
+      rec.start();
+      recRef.current = rec;
+      setListening(true);
+    } catch {
+      // 같은 인스턴스를 연달아 start 하면 InvalidStateError. 조용히 무시하고 꺼진 상태 유지.
+      recRef.current = null;
+      setListening(false);
+    }
+  }, [stop]);
+
+  // 화면을 벗어나면 마이크를 놓는다 — 안 그러면 인식기가 백그라운드에서 계속 돈다.
+  useEffect(() => stop, [stop]);
+
+  return { supported, listening, interim, error, start, stop };
+}

--- a/src/screens/GoalIntakeScreen.tsx
+++ b/src/screens/GoalIntakeScreen.tsx
@@ -1,10 +1,12 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { Sparkle, ArrowUp, ArrowRight, X } from '@phosphor-icons/react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Sparkle, ArrowUp, ArrowRight, X, Microphone, Stop } from '@phosphor-icons/react';
 import { ApiError, friendlyError, interviewApi } from '../lib/api';
 import type { InterviewOutcome, InterviewQuestion, InterviewSession, SlotCatalogEntry } from '../types/api';
 import { SetupProgress } from '../components/SetupProgress';
 import { useNavigation } from '../contexts/NavigationContext';
 import { ErrorBanner } from '../components/ErrorBanner';
+import { DateAnswerField, TimeRangeAnswerField, isValidRange, parseRange } from '../components/TypedAnswerField';
+import { useSpeechInput } from '../lib/useSpeechInput';
 
 interface GoalIntakeScreenProps {
   onDone: () => void;
@@ -189,6 +191,9 @@ export function GoalIntakeScreen({ onDone, onOutcome }: GoalIntakeScreenProps) {
     if (!trimmed) return;
 
     const answeredKey = currentQuestion.slotKey;
+    // 답을 보내는 순간 마이크를 놓는다. 같은 슬롯이 재질문되면 slotKey 가 그대로라
+    // 아래 정리 effect 가 안 돌아, 이전 답의 뒷말이 다음 답에 흘러들어간다.
+    speech.stop();
     setMessages((m) => [...m, { id: newMsgId('u'), who: 'user', text: trimmed }]);
     setInputText('');
     setIsTyping(true);
@@ -287,6 +292,58 @@ export function GoalIntakeScreen({ onDone, onOutcome }: GoalIntakeScreenProps) {
     currentQuestion &&
     (currentQuestion.answerType === 'chip' || currentQuestion.answerType === 'select') &&
     currentQuestion.options.length > 0;
+
+  // ── answerType 전용 입력(#217) ──
+  // 백엔드가 "이건 날짜다 / 이건 시간 범위다" 를 이미 알려주는데도 맨 텍스트 입력으로
+  // 떨어뜨려, 마감일과 선호 시간대를 사용자가 형식까지 맞춰 타이핑하고 있었다.
+  // 자료 붙여넣기 슬롯은 기존 textarea 특례를 그대로 둔다.
+  const typedKind: 'date' | 'range' | null =
+    currentQuestion && currentQuestion.slotKey !== 'goals.materials'
+      ? currentQuestion.answerType === 'date_picker'
+        ? 'date'
+        : currentQuestion.answerType === 'time_range'
+          ? 'range'
+          : null
+      : null;
+  // 자정을 넘는 시간대처럼 전용 입력으로 표현 못 하는 답을 위한 탈출구.
+  const [manualEntry, setManualEntry] = useState(false);
+  const useTypedField = typedKind !== null && !manualEntry;
+
+  // 질문이 바뀌면 탈출구 상태를 되돌린다 — 이전 질문에서 열어둔 게 다음 질문까지 따라오면 안 된다.
+  useEffect(() => {
+    setManualEntry(false);
+  }, [currentQuestion?.slotKey]);
+
+  // 시간 범위는 다이얼이 항상 무언가를 가리키고 있다. 입력값이 비어 있으면 화면에 보이는 것과
+  // 전송되는 값이 달라지므로(보이는 건 09:00~18:00, 보내는 건 빈 문자열) 기본값을 실제로 채운다.
+  useEffect(() => {
+    if (useTypedField && typedKind === 'range' && inputText.trim() === '') {
+      const { start, end } = parseRange('');
+      setInputText(`${start}-${end}`);
+    }
+  }, [useTypedField, typedKind, inputText]);
+
+  // 전송 가능 여부 — 시간 범위는 형식이 맞아야만 보낼 수 있다.
+  const range = typedKind === 'range' ? parseRange(inputText) : null;
+  const canSubmit =
+    inputText.trim() !== '' &&
+    !isTyping &&
+    (!useTypedField || typedKind !== 'range' || (range !== null && isValidRange(range.start, range.end)));
+
+  // ── 음성 입력(#215) ──
+  // 확정된 문장은 입력창에 이어붙이기만 한다. 자동 전송하지 않는 건 의도다 —
+  // 잘못 인식된 답 하나가 계획 전체를 가르는데 되돌릴 방법이 없다.
+  const appendSpoken = useCallback((text: string) => {
+    setInputText((prev) => (prev.trim() === '' ? text : `${prev.trimEnd()} ${text}`));
+  }, []);
+  const speech = useSpeechInput(appendSpoken);
+  // 전용 입력(날짜·시간)에서는 마이크가 할 일이 없다. 자유서술 질문에서만 띄운다.
+  const showMic = speech.supported && !useTypedField && !isFinished;
+
+  // 질문이 바뀌면 듣기를 멈춘다 — 다음 질문에 이전 답이 흘러들어가면 안 된다.
+  useEffect(() => {
+    speech.stop();
+  }, [currentQuestion?.slotKey]);
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100%', background: 'var(--surface-ground)' }}>
@@ -440,8 +497,34 @@ export function GoalIntakeScreen({ onDone, onOutcome }: GoalIntakeScreenProps) {
                 ))}
               </div>
             )}
+            {/* 날짜·시간 범위 전용 입력(#217). 자유 텍스트 입력과 같이 두면 어느 쪽 값이
+                전송되는지 알 수 없으므로 한 번에 하나만 보여준다. */}
+            {useTypedField && (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                {typedKind === 'date' ? (
+                  <DateAnswerField value={inputText} onChange={setInputText} disabled={isTyping} />
+                ) : (
+                  <TimeRangeAnswerField value={inputText} onChange={setInputText} disabled={isTyping} />
+                )}
+                <button
+                  onClick={() => { setInputText(''); setManualEntry(true); }}
+                  style={{ alignSelf: 'flex-start', fontSize: 12, fontWeight: 600, color: 'var(--text-3)', background: 'none', border: 'none', padding: '2px 0', cursor: 'pointer', fontFamily: 'inherit', textDecoration: 'underline' }}
+                >
+                  직접 입력할게요
+                </button>
+              </div>
+            )}
+            {/* 말하는 중 인식 결과 미리보기 — 확정되면 위 입력창으로 옮겨간다. */}
+            {speech.listening && (
+              <div style={{ fontSize: 12, color: 'var(--text-3)', lineHeight: 1.5, minHeight: 18 }} aria-live="polite">
+                {speech.interim ? `“${speech.interim}”` : '듣고 있어요…'}
+              </div>
+            )}
+            {speech.error && (
+              <span role="alert" style={{ fontSize: 12, color: 'var(--coral-700)' }}>{speech.error}</span>
+            )}
             <div style={{ display: 'flex', gap: 8, marginTop: showQuickReplies ? 4 : 0, alignItems: 'flex-end' }}>
-              {currentQuestion.slotKey === 'goals.materials' ? (
+              {useTypedField ? null : currentQuestion.slotKey === 'goals.materials' ? (
                 // 자료 원문 붙여넣기 — 여러 줄 붙여넣기가 편하도록 textarea (Enter=줄바꿈, 전송은 버튼).
                 <textarea
                   value={inputText}
@@ -488,7 +571,7 @@ export function GoalIntakeScreen({ onDone, onOutcome }: GoalIntakeScreenProps) {
               )}
               {/* 담은 걸 한 번에 비우기 — 여러 개 골라 담다 보면 지우려고 백스페이스를
                   길게 누르고 있어야 했다. 비어 있으면 자리를 만들지 않는다. */}
-              {inputText.trim() !== '' && (
+              {!useTypedField && inputText.trim() !== '' && (
                 <button
                   onClick={() => setInputText('')}
                   disabled={isTyping}
@@ -498,11 +581,58 @@ export function GoalIntakeScreen({ onDone, onOutcome }: GoalIntakeScreenProps) {
                   <X size={13} weight="bold" />
                 </button>
               )}
+              {/* 말로 답하기(#215) — 지원하지 않는 브라우저에서는 아예 그리지 않는다.
+                  눌렀는데 아무 일도 안 일어나는 버튼이 없는 버튼보다 나쁘다. */}
+              {showMic && (
+                <button
+                  onClick={() => (speech.listening ? speech.stop() : speech.start())}
+                  disabled={isTyping}
+                  aria-label={speech.listening ? '음성 입력 멈추기' : '말로 답하기'}
+                  aria-pressed={speech.listening}
+                  title={speech.listening ? '멈추기' : '말로 답하기'}
+                  style={{
+                    width: 44,
+                    height: 44,
+                    borderRadius: 9999,
+                    border: `1px solid ${speech.listening ? 'transparent' : 'var(--coral-200)'}`,
+                    background: speech.listening ? 'var(--brand-surface)' : 'var(--brand-soft)',
+                    color: speech.listening ? '#FFFCF6' : 'var(--coral-700)',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    cursor: isTyping ? 'wait' : 'pointer',
+                    flexShrink: 0,
+                    opacity: isTyping ? 0.5 : 1,
+                  }}
+                >
+                  {speech.listening ? <Stop size={14} weight="fill" /> : <Microphone size={16} weight="fill" />}
+                </button>
+              )}
               <button
                 onClick={() => submit(inputText)}
-                disabled={isTyping || !inputText.trim()}
-                style={{ width: 44, height: 44, borderRadius: 9999, border: 'none', background: 'var(--brand-surface)', color: '#FFFCF6', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer', flexShrink: 0, opacity: isTyping || !inputText.trim() ? 0.5 : 1 }}
+                disabled={!canSubmit}
+                aria-label="답변 보내기"
+                style={{
+                  width: useTypedField ? undefined : 44,
+                  flex: useTypedField ? 1 : undefined,
+                  height: 44,
+                  borderRadius: useTypedField ? 12 : 9999,
+                  border: 'none',
+                  background: 'var(--brand-surface)',
+                  color: '#FFFCF6',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  gap: 6,
+                  fontSize: 14,
+                  fontWeight: 700,
+                  fontFamily: 'inherit',
+                  cursor: canSubmit ? 'pointer' : 'not-allowed',
+                  flexShrink: 0,
+                  opacity: canSubmit ? 1 : 0.5,
+                }}
               >
+                {useTypedField && <span>이 답으로 보내기</span>}
                 <ArrowUp size={14} weight="fill" />
               </button>
             </div>

--- a/src/screens/GoalsScreen.tsx
+++ b/src/screens/GoalsScreen.tsx
@@ -1,8 +1,9 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { Plus, Trash, PencilSimple, TreeStructure, Target } from '@phosphor-icons/react';
+import { Plus, Trash, PencilSimple, TreeStructure, Target, ChatCircleDots } from '@phosphor-icons/react';
 import { ApiError, friendlyError, goalsApi } from '../lib/api';
 import type { ApiGoal, GoalDecomposition, GoalTier } from '../types/api';
 import { GOAL_STATUS_META, GOAL_CATEGORY_OPTIONS, categoryLabel } from '../data';
+import { useNavigation } from '../contexts/NavigationContext';
 import { ReButton } from '../components/ReButton';
 import { GoalCard } from '../components/GoalCard';
 import { IconAction } from '../components/IconAction';
@@ -23,6 +24,10 @@ interface EditDraft {
 }
 
 export function GoalsScreen() {
+  // 목표의 결이 바뀌면 계획의 전제(가용 시간·역량·마감·회복 톤)가 통째로 무너진다.
+  // 여기서 딥 인터뷰로 되돌아갈 수 있어야 하고, 끝나면 온보딩이 아니라 이 화면으로 와야 한다(#216).
+  const { setScreen, setInterviewReturnTo } = useNavigation();
+  const [confirmReinterview, setConfirmReinterview] = useState(false);
   // 초기값 비움 → 로딩 중 스켈레톤, 실패 시엔 빈 목록 + 에러(더미로 가리지 않는다).
   const [goals, setGoals] = useState<ApiGoal[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -198,7 +203,7 @@ export function GoalsScreen() {
   };
 
   return (
-    <div style={{ height: '100%', display: 'flex', flexDirection: 'column', background: 'var(--surface-ground)' }}>
+    <div style={{ position: 'relative', height: '100%', display: 'flex', flexDirection: 'column', background: 'var(--surface-ground)' }}>
       <div style={{ flex: 1, overflowY: 'auto', padding: '14px 18px 28px', display: 'flex', flexDirection: 'column', gap: 14 }}>
         {/* 헤더 + tier 사용량 */}
         <div>
@@ -222,6 +227,15 @@ export function GoalsScreen() {
               );
             })}
           </div>
+          {/* 목표의 결이 바뀌었을 때의 탈출구(#216). 강제로 끌고 가지 않는다 —
+              누를지 말지는 사용자가 정하고, 무슨 일이 일어나는지는 시트에서 밝힌다. */}
+          <button
+            onClick={() => setConfirmReinterview(true)}
+            style={{ marginTop: 10, alignSelf: 'flex-start', height: 'var(--ctrl-sm)', padding: '0 12px', borderRadius: 9999, border: '1px solid var(--coral-200)', background: 'var(--brand-soft)', color: 'var(--coral-700)', fontSize: 12, fontWeight: 700, fontFamily: 'inherit', cursor: 'pointer', display: 'inline-flex', alignItems: 'center', gap: 5 }}
+          >
+            <ChatCircleDots size={13} weight="fill" />
+            목표가 바뀌었어요 · 다시 인터뷰하기
+          </button>
         </div>
 
         {error && (
@@ -382,6 +396,47 @@ export function GoalsScreen() {
           </button>
         )}
       </div>
+
+      {/* 재인터뷰 확인(#216) — 새 세션은 처음부터 다시 묻는다는 사실을 숨기지 않는다.
+          (GoalIntakeScreen 은 진입할 때마다 기존 세션을 finish 하고 새로 시작한다) */}
+      {confirmReinterview && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label="다시 인터뷰하기"
+          style={{ position: 'absolute', inset: 0, zIndex: 40, background: 'rgba(28,25,23,.35)', display: 'flex', alignItems: 'flex-end' }}
+          onClick={() => setConfirmReinterview(false)}
+        >
+          <div
+            onClick={(e) => e.stopPropagation()}
+            style={{ width: '100%', background: 'var(--surface-raised)', borderRadius: '18px 18px 0 0', padding: '18px 18px max(24px, env(safe-area-inset-bottom, 24px))', display: 'flex', flexDirection: 'column', gap: 10 }}
+          >
+            <div style={{ fontSize: 16, fontWeight: 800, color: 'var(--text-1)' }}>목표의 결이 바뀌었나요?</div>
+            <p style={{ margin: 0, fontSize: 13, lineHeight: 1.6, color: 'var(--text-2)' }}>
+              몇 가지만 다시 묻고 계획을 새로 세울게요. <b>인터뷰는 처음부터 새로 시작</b>되고,
+              지금까지의 인터뷰 답변은 새 답변으로 대체돼요. 이미 만들어진 목표와 일정은 그대로 남아요.
+            </p>
+            <div style={{ display: 'flex', gap: 8, marginTop: 4 }}>
+              <ReButton variant="ghost" size="sm" onClick={() => setConfirmReinterview(false)}>지금은 그대로</ReButton>
+              <div style={{ flex: 1 }}>
+                <ReButton
+                  variant="primary"
+                  size="sm"
+                  full
+                  onClick={() => {
+                    setConfirmReinterview(false);
+                    // 끝나면 온보딩 체인이 아니라 이 화면으로 돌아오게 표시해둔다.
+                    setInterviewReturnTo('goals');
+                    setScreen('goal-intake');
+                  }}
+                >
+                  다시 인터뷰하기
+                </ReButton>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/screens/TodayScreen.tsx
+++ b/src/screens/TodayScreen.tsx
@@ -15,7 +15,7 @@ import { localDateStr } from '../lib/dates';
 import { categoryLabel, goalColor } from '../data';
 import { DemoNotice } from '../components/DemoNotice';
 import { HeroTaskCard } from '../components/HeroTaskCard';
-import { TaskRow } from '../components/TaskRow';
+import { TodayTimeline } from '../components/TodayTimeline';
 import { ProgressSheet } from '../components/ProgressSheet';
 import { EmptyState } from '../components/EmptyState';
 import { SkeletonBlock } from '../components/SkeletonBlock';
@@ -445,6 +445,20 @@ export function MergedTodayScreen({ tasks: allTasks, onOpen, onMarkDone, onParti
   const heroTask =
     tasks.find((t) => t.id === selectedTaskId) ?? activeTask ?? pendingTasks[0] ?? null;
 
+  // C안: 히어로 아래 나머지 일은 카드 더미가 아니라 시간축으로 읽힌다.
+  // 시간 있는 항목만 먼저 오름차순, 미정 항목은 서버가 준 상대 순서를 유지한다.
+  const timelineTasks = tasks
+    .filter((t) => t.id !== heroTask?.id)
+    .map((task, index) => ({ task, index, meta: metaFor(task) }))
+    .sort((a, b) => {
+      const at = a.meta.time ?? a.task.time;
+      const bt = b.meta.time ?? b.task.time;
+      if (at && bt) return at.localeCompare(bt) || a.index - b.index;
+      if (at) return -1;
+      if (bt) return 1;
+      return a.index - b.index;
+    });
+
   // 히어로 카드가 화면 밖으로 나가면 상단 스트립을 띄운다(#214). 스트립이 가리키는 카드는
   // 항상 heroTask 그 자체다 — 선정 로직을 복제하면 언젠가 조용히 어긋난다.
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -543,22 +557,13 @@ export function MergedTodayScreen({ tasks: allTasks, onOpen, onMarkDone, onParti
             />
             </div>
 
-            {/* 나머지 카드 — 모두 한 줄 row 통일. hero 에 떠 있는 카드는 제외. */}
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-              {tasks
-                .filter((t) => t.id !== heroTask?.id)
-                .map((t) => (
-                  <TaskRow
-                    key={t.id}
-                    task={t}
-                    {...metaFor(t)}
-                    // 대기/진행 row 클릭 = hero 로 promote (실제 시작 X)
-                    onSelect={() => setSelectedTaskId(t.id)}
-                    onFailedRecover={() => onFail(t.id, t.failReason || '')}
-                    onPartialRecover={onOpenRecovery}
-                  />
-                ))}
-            </div>
+            {/* C안 — 나머지 할 일을 예정 시각 기준의 하루 타임라인으로 보여준다. */}
+            <TodayTimeline
+              items={timelineTasks.map(({ task, meta }) => ({ task, ...meta }))}
+              onSelect={setSelectedTaskId}
+              onFailedRecover={onFail}
+              onPartialRecover={onOpenRecovery}
+            />
           </>
         )}
 

--- a/src/screens/TodayScreen.tsx
+++ b/src/screens/TodayScreen.tsx
@@ -21,6 +21,7 @@ import { EmptyState } from '../components/EmptyState';
 import { SkeletonBlock } from '../components/SkeletonBlock';
 import { Toast } from '../components/Toast';
 import { FixedScheduleStrip } from '../components/FixedScheduleStrip';
+import { NextUpStrip } from '../components/NextUpStrip';
 import { Gear, Target, DotsThreeVertical } from '@phosphor-icons/react';
 
 // Today 헤더 우상단 — 목표 관리·설정을 하나의 ⋮ 메뉴로 통합 (아이콘 2개 → 1개).
@@ -444,9 +445,41 @@ export function MergedTodayScreen({ tasks: allTasks, onOpen, onMarkDone, onParti
   const heroTask =
     tasks.find((t) => t.id === selectedTaskId) ?? activeTask ?? pendingTasks[0] ?? null;
 
+  // 히어로 카드가 화면 밖으로 나가면 상단 스트립을 띄운다(#214). 스트립이 가리키는 카드는
+  // 항상 heroTask 그 자체다 — 선정 로직을 복제하면 언젠가 조용히 어긋난다.
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const heroRef = useRef<HTMLDivElement>(null);
+  const [heroVisible, setHeroVisible] = useState(true);
+  useEffect(() => {
+    const root = scrollRef.current;
+    const target = heroRef.current;
+    // 히어로가 없으면(빈 상태·로딩) 스트립도 뜰 이유가 없다 — 보이는 것으로 취급해 숨긴다.
+    if (!root || !target) {
+      setHeroVisible(true);
+      return;
+    }
+    const io = new IntersectionObserver(
+      ([entry]) => setHeroVisible(entry.isIntersecting),
+      { root, threshold: 0 },
+    );
+    io.observe(target);
+    return () => io.disconnect();
+  }, [heroTask?.id, agendaLoading, tasks.length]);
+
   return (
     <div style={{ position: 'relative', height: '100%' }}>
-      <div style={{ height: '100%', overflowY: 'auto', padding: '12px 18px 32px', background: 'var(--surface-ground)', display: 'flex', flexDirection: 'column', gap: 18 }}>
+      {/* 스크롤 흐름 밖(absolute)에 겹쳐 띄운다 — 나타날 때 아래 내용이 밀리지 않게. */}
+      {!agendaLoading && heroTask && (
+        <NextUpStrip
+          task={heroTask}
+          visible={!heroVisible}
+          {...metaFor(heroTask)}
+          done={doneTasks.length}
+          total={tasks.length}
+          onStart={(id) => onOpen(id)}
+        />
+      )}
+      <div ref={scrollRef} style={{ height: '100%', overflowY: 'auto', padding: '12px 18px 32px', background: 'var(--surface-ground)', display: 'flex', flexDirection: 'column', gap: 18 }}>
         {/* Header — 한 줄로 압축. 열품타식 미니멀. */}
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
           <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, minWidth: 0 }}>
@@ -494,7 +527,9 @@ export function MergedTodayScreen({ tasks: allTasks, onOpen, onMarkDone, onParti
           )
         ) : (
           <>
-            {/* Hero — 지금 할 일. row 에서 promote 한 카드 또는 진행 중 카드. */}
+            {/* Hero — 지금 할 일. row 에서 promote 한 카드 또는 진행 중 카드.
+                ref 는 상단 스트립 노출 판정(IntersectionObserver)용. */}
+            <div ref={heroRef}>
             <HeroTaskCard
               task={heroTask}
               done={doneTasks.length}
@@ -506,6 +541,7 @@ export function MergedTodayScreen({ tasks: allTasks, onOpen, onMarkDone, onParti
               onStart={(id) => onOpen(id)}
               onDetail={() => heroTask && setDetailTask(heroTask)}
             />
+            </div>
 
             {/* 나머지 카드 — 모두 한 줄 row 통일. hero 에 떠 있는 카드는 제외. */}
             <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>


### PR DESCRIPTION
한이음 개발 회의의 **프론트엔드 액션 아이템**을 반영합니다. 회의록 3줄을 실행 가능한 4건으로 나눠 이슈로 올린 뒤(#214 #215 #216 #217) 한 번에 구현했습니다.

파일이 겹쳐(인터뷰 화면에 #215/#217 이 같이 붙음) 한 PR 로 묶었습니다. 리뷰가 부담되면 섹션 단위로 쪼개 드릴 수 있습니다.

---

## 1. 오늘 화면 상단 [다음 할 일] 고정 — #214

**문제.** "지금 할 일" 을 알려주는 유일한 장치인 히어로 카드가 스크롤 흐름 안에 있어서, 습관 트래커를 보려고 조금만 내리면 다음 한 걸음이 화면에서 사라졌습니다. 실패 회복이 이 제품의 정체성이라면 다음 한 걸음은 항상 보여야 합니다.

**푼 방식.**
- `NextUpStrip` 을 스크롤 컨테이너 **위에 겹쳐** 띄웁니다(`position: absolute`). `sticky` 로 흐름 안에 넣으면 나타나는 순간 아래 내용이 그만큼 밀려 화면이 튑니다.
- 노출 판정은 `IntersectionObserver` 로 히어로 가시성을 관찰 — 히어로가 보이는 동안엔 숨깁니다(같은 정보 2중 표시 방지).
- 스트립이 가리키는 카드는 `heroTask` **그 자체**입니다. 선정 로직(promote → in_progress → 첫 대기)을 복제하면 언젠가 조용히 어긋납니다.
- 숨겨진 동안 `pointer-events`/`tabIndex`/`aria-hidden` 으로 완전히 빠집니다 — 안 보이는 버튼이 눌리지 않게.
- 로딩 중·빈 상태에서는 그리지 않습니다.

## 2. 인터뷰 음성(STT) 입력 — #215

**문제.** 필수 슬롯이 14개 전후인데 선택지 칩이 붙는 건 `chip`/`select` 질문뿐이고, 자유서술(역량·상황 설명)은 전부 모바일 타이핑이었습니다. 코드베이스에 음성 입력은 **한 줄도 없었습니다**.

**푼 방식.**
- `src/lib/useSpeechInput.ts` — Web Speech API 훅 (`ko-KR`, `continuous`, interim 결과).
  백엔드에 음성 업로드 엔드포인트가 없어(openapi.json 기준) 추가 인프라 없이 붙는 쪽을 골랐습니다. 서버 STT 가 생기면 **훅 내부만** 교체하면 되고 화면 코드는 그대로입니다.
- 확정 문장은 입력창에 **이어붙이기만** 하고 자동 전송하지 않습니다. 잘못 인식된 답 하나가 계획 전체를 가르는데 되돌릴 방법이 없습니다(원터치 대답을 '담기' 로 바꾼 #202 와 같은 이유).
- **미지원 브라우저에서는 버튼을 아예 그리지 않습니다.** 눌렀는데 아무 일도 안 일어나는 버튼이 없는 버튼보다 나쁩니다.
- 권한 거부·무음·마이크 없음은 각각 사실대로 안내하고 타이핑으로 계속할 수 있게 둡니다.
- 답을 보내거나 질문이 바뀌면 마이크를 놓습니다 — 같은 슬롯이 재질문될 땐 `slotKey` 가 안 바뀌므로 전송 시점에도 정리합니다.

## 3. answerType 별 전용 입력 — #217

**문제.** 백엔드는 질문마다 `answerType` 으로 "이건 날짜다 / 이건 시간 범위다" 를 **이미 알려주는데**, FE 는 `chip`/`select` 만 특별 취급하고 나머지를 맨 텍스트로 떨어뜨렸습니다. 그래서 사용자가 `2026-11-30` 을 직접 치고 `09:00-23:00` 의 하이픈까지 맞춰야 했고, 형식이 어긋나도 그대로 슬롯에 들어갔습니다. 마감일과 선호 시간대는 계획 생성의 두 축이라 여기서 어긋나면 계획 전체가 어긋납니다.

**푼 방식.**
- `date_picker` → 상대 날짜 칩(오늘/이번 주말/2주 뒤/한 달 뒤/3개월 뒤) + `input[type=date]`(`min` = 오늘).
- `time_range` → **기존 `TimeDial` 재사용**(시작/종료 두 개) + 프리셋 칩. 시작 ≥ 종료면 사유를 띄우고 전송을 막습니다.
- **전송 문자열 형식은 기존과 동일**(`YYYY-MM-DD` / `HH:MM-HH:MM`) — 백엔드 계약 무변경.
- 자정을 넘는 시간대처럼 전용 입력으로 표현 못 하는 답을 위해 **'직접 입력할게요' 탈출구**를 둡니다.
- 전용 입력과 자유 텍스트를 같이 두지 않습니다 — 두 개가 같이 있으면 어느 값이 전송되는지 알 수 없습니다.
- `goals.materials` textarea 특례는 그대로 둡니다.

## 4. 딥 인터뷰 복귀 라우팅 — #216

**문제.** 앱 사용 중(`ACTIVE`) 딥 인터뷰로 들어갈 경로가 아예 없었고, `NAV_META` 의 `back` 은 온보딩 단방향 체인만 알고 있어 들어가더라도 뒤로가기가 사용자를 `intro`(온보딩 시작)로 떨어뜨렸습니다.

**푼 방식.**
- `NavigationContext` 에 `interviewReturnTo` 추가. 인터뷰를 마치거나 뒤로가면 그 화면으로 돌아갑니다. 없으면 기존 온보딩 체인 그대로입니다.
- 목표 관리 화면에 **'목표가 바뀌었어요 · 다시 인터뷰하기'** 진입점 + 확인 시트.
  강제로 끌고 가지 않고, **새 세션이 처음부터 다시 묻는다는 사실을 시트에서 밝힙니다**(`GoalIntakeScreen` 은 진입할 때마다 기존 세션을 `finish` 하고 새로 시작하는 "항상 새 세션" 정책).

### ⚠️ 회의 항목 중 못 넣은 것 — BE 필요

회의록의 **"목표 테마 변경 시"** 라는 트리거 자체는 넣지 못했습니다. 백엔드 `GoalUpdateRequest` 가 `title` / `deadline` / `goalTier` / `priorityLevel` 만 받고 **`category` 가 없습니다**(`openapi.json` 확인). 즉 지금 API 로는 목표의 테마를 바꿀 수 없어서, 바뀌는 걸 감지할 방법도 없습니다.

그래서 **막히지 않은 절반(복귀 라우팅 + 사용자 주도 재인터뷰 진입점)을 먼저 완성**했습니다. BE 에 `category` 가 추가되면 이 진입점 위에 ① 편집 폼의 테마 select ② "테마가 바뀐 경우에만 제안" 조건만 얹으면 됩니다. 자세한 내용은 #216 에 적어 두었습니다.

---

## 검증

- `tsc --noEmit` 통과
- `vite build` (프로덕션) 통과
- 브라우저 실물 확인은 하지 않았습니다 — 확장 프로그램 사이트 권한 때문에 로컬 dev 서버 페이지를 열지 못했습니다(서버 자체는 200 응답 확인). 미리보기 배포에서 봐주세요.

Closes #214
Closes #215
Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## 0. 홈 UI C안 채택 — 시간축 타임라인

회의 결정대로 홈은 **C안 베이스**로 확정했습니다. 기존의 평면 카드 목록 대신, 히어로 아래 나머지 할 일을 예정 시각 기준의 세로 타임라인으로 표시합니다.

- 예정 시각이 있는 일은 시간순 정렬
- 시각 미정 항목은 `미정` 구간에서 서버 순서 유지
- 상태별 타임라인 점: 완료/실패/진행·회복/대기
- 행을 누르는 기존 동작(히어로 승격·실패 회복·부분완료 회복)은 그대로 유지
- 히어로와 상단 `[다음 할 일]` 고정 위젯도 그대로 유지

즉 C안의 정보 구조는 **지금 할 일 히어로 → 오늘의 시간축 → 습관**입니다.
