### PR TITLE
fix(fe): 구글 로그인이 새로고침마다 풀리던 문제 + 주간 시간표를 한 화면에

### DIFF
--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -5,7 +5,7 @@ import { LoginScreen } from '../screens/LoginScreen';
 import { NavigationContext, STATE_TO_SCREEN } from '../contexts/NavigationContext';
 import { ToastProvider } from '../contexts/ToastContext';
 import { IosInstallCard } from '../components/IosInstallCard';
-import { ApiError, authApi, friendlyError, onAuthExpired, onboardingApi, setAccessToken, stubLoginAllowed } from '../lib/api';
+import { ApiError, authApi, friendlyError, getAuthKind, onAuthExpired, onboardingApi, setAccessToken, stubLoginAllowed } from '../lib/api';
 import type { ScreenId, TabId } from '../types';
 import type { MilestoneDraft, OnboardingState, UserProfile } from '../types/api';
 
@@ -198,10 +198,15 @@ export function AppShell() {
 
       // 마이그레이션: 전용 계정(deviceId) 도입 이전의 '공유 데모 계정' 토큰이 남아있으면 버린다.
       // 그 토큰으로 /auth/me 가 성공하면 세션·락이 꼬인 공유 계정에 계속 붙어 인터뷰 409 가 반복된다.
-      // deviceId 없이 토큰만 있음 = 구버전 토큰 → 제거해 전용 계정으로 재로그인 유도.
+      //
+      // 단 이 판별은 **stub 계정에만** 해당한다. deviceId 는 stubIdToken() 안에서만 만들어지므로
+      // 실제 Google 로그인은 deviceId 를 영영 갖지 못한다. 그래서 예전 조건(토큰 있고 deviceId 없음)은
+      // 프로덕션에서 구글로 로그인한 사용자의 토큰을 **다음 부팅마다 지웠다** — 로그인이 성공해도
+      // 새로고침 한 번이면 로그인 화면으로 돌아가는 증상. 로그인 종류를 직접 보고 판단한다.
       if (
         typeof window !== 'undefined' &&
         window.localStorage.getItem('reaction.accessToken') &&
+        getAuthKind() !== 'real' &&
         !window.localStorage.getItem('reaction.deviceId')
       ) {
         setAccessToken(null);

--- a/src/components/WeekGrid.tsx
+++ b/src/components/WeekGrid.tsx
@@ -47,8 +47,8 @@ export interface WeekGridProps {
   onBlockPointerDown?: (e: React.PointerEvent, block: WeekGridBlock) => void;
   /**
    * 보여줄 요일 칸(0=월 … 6=일). 없으면 7일 전부. 여기 없는 칸의 블록은 렌더하지 않는다.
-   * 지금 두 화면 모두 7일 전부를 넘긴다 — 좁아서 제목이 깨지던 문제는 칸 수를 줄이는
-   * 대신 colWidth 를 키우고 가로로 스크롤해 푼다.
+   * 지금 두 화면 모두 7일 전부를 넘긴다 — 좁아서 제목이 깨지던 문제는 칸을 줄이거나
+   * 가로로 미는 대신, 좁은 열에서 제목을 9px 두 줄로 그려서 푼다.
    */
   visibleCols?: number[];
   /** 스크롤 위치를 밖에서 제어할 때(첫 블록으로 스크롤 등). */
@@ -95,7 +95,9 @@ export function scrollColIntoView(
  * 사용자가 자기 일주일에 여유가 있는지 없는지 판단할 수 있다.
  *
  * 배치는 전부 절대좌표다. 세로 = 시각(hourPx/60 × 분), 가로 = 요일(colWidth × col).
- * 좁다고 느끼면 colWidth 만 올리면 되고, 그러면 가로 스크롤이 생긴다.
+ * colWidth 는 호출한 쪽이 컨테이너 폭에서 계산해 넘긴다. 폰에서도 7열이 한 화면에
+ * 들어가는 값이라, 평소에는 가로 스크롤이 생기지 않는다. 태블릿처럼 넓은 화면에서는
+ * 같은 계산으로 열이 넓어지고, colWidth 가 80 을 넘으면 제목·부제가 한 단계 커진다.
  *
  * 스크롤은 가로·세로를 **한 컨테이너**가 함께 맡는다. 예전엔 요일 헤더가 스크롤
  * 바깥의 형제였는데, 그 구조에선 열을 넓혀 가로 스크롤이 생기는 순간 헤더(요일·날짜)만
@@ -147,26 +149,34 @@ export function WeekGrid({
       overflow: 'hidden',
     };
 
+    // 좁은 열(폰에서 7일을 한 화면에 넣으면 50px 안팎)의 제목을 8px 로 떨어뜨리면
+    // 사실상 안 읽힌다. 글자를 줄이는 대신 줄 수를 준다 — 9px 두 줄이 8px 한 줄보다
+    // 훨씬 많이 읽힌다. 대신 좁을 때는 시각 부제를 접는다(블록을 탭하면 다 나온다).
+    const wide = colWidth >= 80;
+    const titleLines = wide ? 3 : 2;
     const label = (
       <>
         <div
           style={{
-            fontSize: colWidth >= 80 ? 11 : 8,
+            fontSize: wide ? 11 : 9,
             fontWeight: 700,
             color: c.fg,
-            lineHeight: 1.3,
+            lineHeight: 1.25,
             overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: h > 36 || colWidth >= 80 ? 'normal' : 'nowrap',
+            // 넘치면 말줄임 — 한 줄 자르기(textOverflow)로는 두 줄째가 잘린 채 남는다.
+            display: '-webkit-box',
+            WebkitBoxOrient: 'vertical',
+            WebkitLineClamp: titleLines,
+            wordBreak: 'break-word',
           }}
         >
           {b.glyph ?? ''}
           {b.title}
         </div>
-        {(h > 36 || colWidth >= 80) && b.subLabel && (
+        {(wide || h > 52) && b.subLabel && (
           <div
             className="tnum"
-            style={{ fontSize: colWidth >= 80 ? 10 : 7, color: c.fg, opacity: 0.7, marginTop: 1 }}
+            style={{ fontSize: wide ? 10 : 8, color: c.fg, opacity: 0.7, marginTop: 1 }}
           >
             {b.subLabel}
           </div>
@@ -230,7 +240,7 @@ export function WeekGrid({
               >
                 <div
                   style={{
-                    fontSize: colWidth >= 80 ? 10 : 8,
+                    fontSize: colWidth >= 80 ? 10 : 9,
                     letterSpacing: '0',
                     color: isToday ? 'var(--coral-700)' : 'var(--text-3)',
                     marginBottom: 3,
@@ -279,7 +289,7 @@ export function WeekGrid({
                   paddingRight: 4,
                 }}
               >
-                <span className="tnum" style={{ fontSize: colWidth >= 80 ? 10 : 8, color: 'var(--text-3)' }}>
+                <span className="tnum" style={{ fontSize: colWidth >= 80 ? 10 : 9, color: 'var(--text-3)' }}>
                   {h}
                 </span>
               </div>

--- a/src/screens/WeeklyCalendarScreen.tsx
+++ b/src/screens/WeeklyCalendarScreen.tsx
@@ -184,10 +184,13 @@ export function WeeklyCalendarScreenV2() {
   const goNext = () => setWeekOffset(weekOffset + 1);
   const goToday = () => setWeekOffset(0);
 
-  // 남는 폭을 열이 나눠 갖되, 하한 아래로는 찌그러뜨리지 않고 가로 스크롤을 준다.
-  // 84 인 이유: WeekGrid 가 80px 부터 제목을 11px·부제를 10px 로 올려 그린다.
-  // 그 아래는 8px 이라 "캡스톤 발표 자료" 가 사실상 안 읽힌다.
-  const MIN_COL_W = 84;
+  // 남는 폭을 열이 나눠 갖는다. 폰(390px)에서도 7열이 한 화면에 들어가야 한다 —
+  // 가로 스크롤이 생기면 "이번 주가 어떤 모양인가" 를 한눈에 보는 이 화면의 목적이
+  // 사라지고, 화면 밖에 요일이 더 있다는 사실조차 알아채기 어렵다.
+  // 예전 하한은 84 였다. WeekGrid 가 80px 부터 제목을 11px 로 올려 그리기 때문인데,
+  // 그 아래를 8px 로 떨어뜨린 게 문제였지 열 폭 자체가 문제는 아니었다. 좁은 열에서도
+  // 9px 두 줄로 읽히게 WeekGrid 를 함께 고쳤으므로 하한을 40 으로 낮춘다.
+  const MIN_COL_W = 40;
   const COL_W = rootW > 0
     ? Math.max(MIN_COL_W, Math.floor((rootW - TIME_W) / ALL_COLS.length))
     : MIN_COL_W;


### PR DESCRIPTION
## 이슈

관련 이슈 없음. 배포본에서 재현되는 버그 2건.

## 변경

### 1. 구글 로그인이 유지되지 않던 문제

부팅 가드가 `accessToken` 은 있는데 `reaction.deviceId` 가 없으면 구버전
'공유 데모 계정' 토큰으로 보고 토큰을 지웠다. 그런데 `deviceId` 를 만드는 곳은
`stubIdToken()` 두 곳뿐이고 둘 다 stub 로그인 경로 안이다. stub 은 프로덕션에서
꺼져 있으므로 **실제 구글 로그인은 이 마커를 영영 갖지 못한다.**

결과: 로그인은 성공하지만 화면을 옮기거나 새로고침하는 순간 토큰이 지워져
로그인 화면으로 돌아간다. 배포본에서 실제로 재현했다.

- 재현: `reaction-frontend.vercel.app` 에서 구글 로그인 → 성공 → `/?force=today` 로 이동 → 로그인 화면
- 원인 확인: 로그인 직후 `localStorage.setItem('reaction.deviceId', ...)` 를 수동으로 넣으면 세션이 유지된다

로그인 종류는 이미 `AUTH_KIND` 로 저장하고 있으므로(`getAuthKind()`), `deviceId` 대신
그 값을 본다. 구버전 토큰은 `AUTH_KIND` 가 없어 그대로 걸러지고, 구글 로그인은 살아남는다.

### 2. 주간 시간표 가로 스크롤

열 폭 하한이 84px 이라 390px 화면에서 `34 + 84x7 = 622px` 이 되어 232px 이 화면
밖으로 밀려났다. 한 주의 모양을 한눈에 보는 화면인데 요일이 잘려 나가고, 잘렸다는
사실조차 알기 어려웠다.

하한을 40 으로 낮춰 항상 7일이 들어가게 했다(390px 에서 열 50px). 84 라는 값은
`WeekGrid` 가 80px 미만에서 제목을 8px 로 떨어뜨리기 때문이었으므로, 좁은 열의 제목을
9px 두 줄로 그리도록 함께 고쳤다. 같은 폭에서 읽히는 글자 수가 오히려 는다. 좁을 때는
시각 부제를 접고, 블록이 충분히 높으면(52px 초과) 다시 보여준다. 넓은 화면에서는
예전처럼 열이 넓어지고 80px 을 넘으면 11px 로 커진다.

## 어떻게 테스트했는지

- `npx tsc --noEmit` 통과, `npm run build` 통과
- 로컬 렌더 실측(390x844, DPR2): 가로 넘침 요소 0개, 문서 폭 390px, 월~일 7열 모두 표시
- 로그인 버그는 배포본에서 재현 후, `deviceId` 주입으로 세션이 유지되는 것까지 확인

## 리뷰어 체크 포인트

- `getAuthKind() !== 'real'` 조건이 구버전 토큰 정리 의도를 유지하는지
- 좁은 열 9px 두 줄이 실제 기기에서 읽히는지 (특히 제목이 긴 블록)
- `scrollColIntoView` 는 이제 대부분 no-op 이 된다. 넓은 화면에서만 의미가 있다

🤖 Generated with [Claude Code](https://claude.com/claude-code)
