### PR TITLE
feat(fe): 주간 계획 헤더에 '⋯' 메뉴 — 다시 인터뷰하기 진입점

### DIFF
--- a/src/components/ReinterviewSheet.tsx
+++ b/src/components/ReinterviewSheet.tsx
@@ -1,0 +1,48 @@
+import { ReButton } from './ReButton';
+
+export interface ReinterviewSheetProps {
+  open: boolean;
+  onClose: () => void;
+  /** 확인을 눌렀을 때. 호출한 화면이 interviewReturnTo 를 자기 자신으로 세팅한 뒤 인터뷰로 보낸다. */
+  onConfirm: () => void;
+}
+
+/**
+ * 다시 인터뷰하기 확인 시트(#216).
+ *
+ * 진입점이 여러 곳(목표 관리, 주간 계획)이라 문구를 각 화면에 복사해 두면 언젠가 갈라진다.
+ * "무슨 일이 일어나는가"를 밝히는 문장이 이 기능의 핵심이라 한 곳에서만 관리한다 —
+ * 인터뷰는 처음부터 새로 시작되고 이전 답변은 대체되지만, 이미 만든 목표와 일정은 남는다.
+ * (GoalIntakeScreen 은 진입할 때마다 기존 세션을 finish 하고 새로 시작한다.)
+ */
+export function ReinterviewSheet({ open, onClose, onConfirm }: ReinterviewSheetProps) {
+  if (!open) return null;
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="다시 인터뷰하기"
+      style={{ position: 'absolute', inset: 0, zIndex: 40, background: 'rgba(28,25,23,.35)', display: 'flex', alignItems: 'flex-end' }}
+      onClick={onClose}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{ width: '100%', background: 'var(--surface-raised)', borderRadius: '18px 18px 0 0', padding: '18px 18px max(24px, env(safe-area-inset-bottom, 24px))', display: 'flex', flexDirection: 'column', gap: 10 }}
+      >
+        <div style={{ fontSize: 16, fontWeight: 800, color: 'var(--text-1)' }}>목표의 결이 바뀌었나요?</div>
+        <p style={{ margin: 0, fontSize: 13, lineHeight: 1.6, color: 'var(--text-2)' }}>
+          몇 가지만 다시 묻고 계획을 새로 세울게요. <b>인터뷰는 처음부터 새로 시작</b>되고,
+          지금까지의 인터뷰 답변은 새 답변으로 대체돼요. 이미 만들어진 목표와 일정은 그대로 남아요.
+        </p>
+        <div style={{ display: 'flex', gap: 8, marginTop: 4 }}>
+          <ReButton variant="ghost" size="sm" onClick={onClose}>지금은 그대로</ReButton>
+          <div style={{ flex: 1 }}>
+            <ReButton variant="primary" size="sm" full onClick={onConfirm}>
+              다시 인터뷰하기
+            </ReButton>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/screens/GoalsScreen.tsx
+++ b/src/screens/GoalsScreen.tsx
@@ -10,6 +10,7 @@ import { IconAction } from '../components/IconAction';
 import { EmptyState } from '../components/EmptyState';
 import { ErrorBanner } from '../components/ErrorBanner';
 import { SkeletonBlock } from '../components/SkeletonBlock';
+import { ReinterviewSheet } from '../components/ReinterviewSheet';
 
 // Focus ≤ 3 / Maintain ≤ 5. Parked 는 한도 자유 (백엔드 _TIER_LIMITS 와 동일).
 const TIER_LIMIT: Record<GoalTier, number | null> = { focus: 3, maintain: 5, parked: null };
@@ -397,46 +398,17 @@ export function GoalsScreen() {
         )}
       </div>
 
-      {/* 재인터뷰 확인(#216) — 새 세션은 처음부터 다시 묻는다는 사실을 숨기지 않는다.
-          (GoalIntakeScreen 은 진입할 때마다 기존 세션을 finish 하고 새로 시작한다) */}
-      {confirmReinterview && (
-        <div
-          role="dialog"
-          aria-modal="true"
-          aria-label="다시 인터뷰하기"
-          style={{ position: 'absolute', inset: 0, zIndex: 40, background: 'rgba(28,25,23,.35)', display: 'flex', alignItems: 'flex-end' }}
-          onClick={() => setConfirmReinterview(false)}
-        >
-          <div
-            onClick={(e) => e.stopPropagation()}
-            style={{ width: '100%', background: 'var(--surface-raised)', borderRadius: '18px 18px 0 0', padding: '18px 18px max(24px, env(safe-area-inset-bottom, 24px))', display: 'flex', flexDirection: 'column', gap: 10 }}
-          >
-            <div style={{ fontSize: 16, fontWeight: 800, color: 'var(--text-1)' }}>목표의 결이 바뀌었나요?</div>
-            <p style={{ margin: 0, fontSize: 13, lineHeight: 1.6, color: 'var(--text-2)' }}>
-              몇 가지만 다시 묻고 계획을 새로 세울게요. <b>인터뷰는 처음부터 새로 시작</b>되고,
-              지금까지의 인터뷰 답변은 새 답변으로 대체돼요. 이미 만들어진 목표와 일정은 그대로 남아요.
-            </p>
-            <div style={{ display: 'flex', gap: 8, marginTop: 4 }}>
-              <ReButton variant="ghost" size="sm" onClick={() => setConfirmReinterview(false)}>지금은 그대로</ReButton>
-              <div style={{ flex: 1 }}>
-                <ReButton
-                  variant="primary"
-                  size="sm"
-                  full
-                  onClick={() => {
-                    setConfirmReinterview(false);
-                    // 끝나면 온보딩 체인이 아니라 이 화면으로 돌아오게 표시해둔다.
-                    setInterviewReturnTo('goals');
-                    setScreen('goal-intake');
-                  }}
-                >
-                  다시 인터뷰하기
-                </ReButton>
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
+      {/* 재인터뷰 확인(#216) — 문구와 동작은 주간 계획 화면과 공유한다(ReinterviewSheet). */}
+      <ReinterviewSheet
+        open={confirmReinterview}
+        onClose={() => setConfirmReinterview(false)}
+        onConfirm={() => {
+          setConfirmReinterview(false);
+          // 끝나면 온보딩 체인이 아니라 이 화면으로 돌아오게 표시해둔다.
+          setInterviewReturnTo('goals');
+          setScreen('goal-intake');
+        }}
+      />
     </div>
   );
 }

--- a/src/screens/WeeklyCalendarScreen.tsx
+++ b/src/screens/WeeklyCalendarScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Plus } from '@phosphor-icons/react';
+import { Plus, DotsThree, ChatCircleDots } from '@phosphor-icons/react';
 import { DEFAULT_GOAL_CATEGORY, goalColor } from '../data';
 import { ApiError, goalsApi, plansApi } from '../lib/api';
 import { localDateStr } from '../lib/dates';
@@ -8,6 +8,7 @@ import { BlockEditSheet } from '../components/BlockEditSheet';
 import { WeekGrid, scrollColIntoView, type WeekGridBlock } from '../components/WeekGrid';
 import { EmptyState } from '../components/EmptyState';
 import { Toast } from '../components/Toast';
+import { ReinterviewSheet } from '../components/ReinterviewSheet';
 import { useNavigation } from '../contexts/NavigationContext';
 import type { Block } from '../types';
 import type { WeeklyPlanResponse, BlockEditRequest, ApiGoal } from '../types/api';
@@ -56,7 +57,10 @@ type BlockWithStatus = Block & { status: string };
 
 export function WeeklyCalendarScreenV2() {
   // 보여줄 주차: 0=이번 주, 1=다음 주 (주간 리뷰의 "다음 주 계획 확인" 진입).
-  const { weekOffset, setWeekOffset } = useNavigation();
+  const { weekOffset, setWeekOffset, setScreen, setInterviewReturnTo } = useNavigation();
+  // 헤더 '⋯' 메뉴와 재인터뷰 확인 시트.
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [confirmReinterview, setConfirmReinterview] = useState(false);
   const isThisWeek = weekOffset === 0;
 
   // planId 추적 — drag 종료 시 plansApi.updateBlock 호출용. 백엔드 404 면 mock.
@@ -523,6 +527,16 @@ export function WeeklyCalendarScreenV2() {
               >오늘</button>
             )}
           </div>
+          {/* 가끔 쓰는 선택지는 '⋯' 뒤로. 계획 초안 화면(PlanOptionsSheet)과 같은 방식이다 —
+              한 번도 안 누르는 버튼을 헤더에 펼쳐두면 정작 봐야 할 시간표가 눌린다. */}
+          <button
+            onClick={() => setMenuOpen(true)}
+            aria-label="더 보기"
+            aria-haspopup="dialog"
+            style={{ width: 28, height: 28, flexShrink: 0, borderRadius: 8, border: '1px solid var(--sand-200)', background: 'var(--surface-raised)', color: 'var(--text-2)', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+          >
+            <DotsThree size={16} weight="bold" />
+          </button>
         </div>
         {/* 조작 안내는 상시 UI 로 두지 않는다 — 헤더가 화면의 35% 를 먹던 원인 중 하나.
             블록을 처음 만졌을 때 한 번만 토스트로 알려준다. */}
@@ -602,6 +616,44 @@ export function WeeklyCalendarScreenV2() {
           onClose={() => setEditing(null)}
         />
       )}
+
+      {/* '⋯' 메뉴 — 지금은 재인터뷰 하나뿐이지만, 주 단위로 가끔 하는 조작이 늘면 여기에 모은다. */}
+      {menuOpen && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label="주간 계획 메뉴"
+          style={{ position: 'absolute', inset: 0, zIndex: 40, background: 'rgba(28,25,23,.35)', display: 'flex', alignItems: 'flex-end' }}
+          onClick={() => setMenuOpen(false)}
+        >
+          <div
+            onClick={(e) => e.stopPropagation()}
+            style={{ width: '100%', background: 'var(--surface-raised)', borderRadius: '18px 18px 0 0', padding: '10px 12px max(20px, env(safe-area-inset-bottom, 20px))' }}
+          >
+            <div style={{ width: 36, height: 4, borderRadius: 9999, background: 'var(--sand-300)', margin: '2px auto 10px' }} />
+            <button
+              onClick={() => { setMenuOpen(false); setConfirmReinterview(true); }}
+              style={{ width: '100%', height: 48, borderRadius: 12, border: 'none', background: 'transparent', color: 'var(--text-1)', fontFamily: 'inherit', fontSize: 14, fontWeight: 600, cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 10, padding: '0 10px' }}
+            >
+              <ChatCircleDots size={17} weight="fill" color="var(--coral-700)" />
+              <span style={{ flex: 1, textAlign: 'left' }}>다시 인터뷰하기</span>
+              <span style={{ fontSize: 11, color: 'var(--text-3)', fontWeight: 500 }}>목표가 바뀌었을 때</span>
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* 확인 문구는 목표 관리 화면과 공유한다 — 같은 행동이 화면마다 다르게 설명되면 안 된다. */}
+      <ReinterviewSheet
+        open={confirmReinterview}
+        onClose={() => setConfirmReinterview(false)}
+        onConfirm={() => {
+          setConfirmReinterview(false);
+          // 끝나면 온보딩 체인이 아니라 이 화면(주간 계획)으로 돌아온다.
+          setInterviewReturnTo('weekly');
+          setScreen('goal-intake');
+        }}
+      />
 
       {toast && (
         <Toast


### PR DESCRIPTION
## 이슈

관련 이슈 없음. #216(재인터뷰)의 진입점 보강.

## 변경

주간 계획 탭에는 재인터뷰 진입점이 없었다. 지금까지는 목표 관리 화면, 설정,
온보딩의 계획 초안 화면(`PlanOptionsSheet` 의 '⋯') 세 곳뿐이라, 시간표를 보다가
"목표가 바뀌었다"고 느낀 사용자가 갈 곳이 없었다.

- 헤더 오른쪽에 `⋯` 버튼을 추가하고 시트로 연다. 계획 초안 화면과 같은 방식이다 —
  가끔 쓰는 선택지를 헤더에 펼쳐두면 정작 봐야 할 시간표가 눌린다.
- 확인 문구와 동작을 `ReinterviewSheet` 로 뽑아 목표 관리 화면과 공유한다. 같은 행동이
  화면마다 다르게 설명되면 안 되고, 복사해 두면 언젠가 갈라진다.
- 끝나면 온보딩 체인이 아니라 주간 계획으로 돌아오도록 `interviewReturnTo='weekly'`
  를 세팅한다(#216 의 복귀 경로 재사용).

메뉴 항목은 지금 하나지만, 주 단위로 가끔 하는 조작이 늘면 여기에 모은다.

## 어떻게 테스트했는지

- `npx tsc --noEmit` 통과, `npm run build` 통과
- 헤더 가로 배치 계산: 390px 에서 `‹`28 + `›`28 + '오늘' 자리 41 + `⋯`28 + 간격 32 = 157px 고정,
  나머지는 주차 라벨이 가변으로 차지 — 넘치지 않는다
- 실제 동작(시트 열기 → 확인 → 인터뷰 → 주간으로 복귀)은 이 브랜치의 Vercel 프리뷰에서
  확인 부탁드립니다. 재인터뷰는 인터뷰 세션을 새로 시작하므로 계정 데이터가 바뀝니다

## 리뷰어 체크 포인트

- `ReinterviewSheet` 추출로 목표 관리 화면의 기존 동작이 그대로인지 (문구, 버튼 순서, 닫기)
- `⋯` 가 '오늘' 버튼과 붙어 보이지 않는지 (다른 주로 이동했을 때 둘 다 나타난다)
- 주간 계획에서 재인터뷰가 적절한 위치인지, 아니면 목표 관리로 유도하는 게 나은지

🤖 Generated with [Claude Code](https://claude.com/claude-code)
