### PR TITLE
fix(today): 모닝 브리프 headline 을 오늘 탭 상단에 매일 노출

### DIFF
--- a/src/screens/TodayScreen.tsx
+++ b/src/screens/TodayScreen.tsx
@@ -5,6 +5,7 @@ import {
   Check,
   X,
   Trash,
+  Sparkle,
 } from '@phosphor-icons/react';
 import type { Task, TaskStatus } from '../types';
 import type { AgendaCard, AgendaFixedSchedule, ApiGoal, WeeklyPlanResponse } from '../types/api';
@@ -179,6 +180,10 @@ export function MergedTodayScreen({ tasks: allTasks, onOpen, onMarkDone, onParti
   const [agendaLoading, setAgendaLoading] = useState(true);
   // 오늘 요일에 걸린 고정 일정(수업·알바). 카드가 아니라 하루의 테두리로 쓴다.
   const [fixedSchedules, setFixedSchedules] = useState<AgendaFixedSchedule[]>([]);
+  // agenda.brief.headline — 매일 06시 크론이 만드는 모닝 브리프의 한 줄 요약.
+  // 예전엔 온보딩 마지막(MorningBriefScreen)에서 딱 한 번만 보이고, 일상 진입인
+  // 이 화면엔 노출 자리가 없었다(#206) — 히어로 카드 위 인사말 자리로 매일 노출한다.
+  const [briefHeadline, setBriefHeadline] = useState<string | null>(null);
 
   // /today/agenda 연동. 성공 시 actions → Task[] 매핑(빈 배열이어도 연결로 간주)해
   // 부모(ReActionMerged)의 tasks 를 이걸로 교체한다 — openTask/markDone 등이 같은
@@ -191,6 +196,7 @@ export function MergedTodayScreen({ tasks: allTasks, onOpen, onMarkDone, onParti
         if (cancelled) return;
         setUsingRealAgenda(true);
         setFixedSchedules(agenda.fixedSchedules ?? []);
+        setBriefHeadline(agenda.brief?.headline ?? null);
         onAgendaLoaded((agenda.cards ?? []).map(actionToTask).sort(byPriority));
       },
       () => { /* 네트워크/오류 — 더미 그대로, usingRealAgenda=false */ },
@@ -517,6 +523,15 @@ export function MergedTodayScreen({ tasks: allTasks, onOpen, onMarkDone, onParti
             <HeaderMenu />
           </div>
         </div>
+
+        {/* 모닝 브리프 headline — 히어로 카드 위, 오늘의 인사말 자리(#206).
+            매일 브리프가 있을 때만 뜨고, 없으면(fallback 없음·미생성) 자리를 만들지 않는다. */}
+        {!agendaLoading && briefHeadline && (
+          <div style={{ display: 'flex', gap: 8, alignItems: 'flex-start', padding: '12px 14px', background: 'var(--brand-soft)', border: '1px solid var(--coral-200)', borderRadius: 16 }}>
+            <Sparkle size={14} weight="fill" color="var(--brand)" style={{ flexShrink: 0, marginTop: 2 }} />
+            <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--coral-700)', lineHeight: 1.5 }}>{briefHeadline}</div>
+          </div>
+        )}
 
         {/* 고정 일정은 할 일이 있든 없든 하루의 테두리다 — 카드 분기 바깥에 둔다.
             "오늘 등록된 일정이 없어요" 아래에 수업 3시간이 떠 있는 게 사실에 맞다. */}


### PR DESCRIPTION
## 배경

이슈 #206 은 두 부분이었다.

1. **버그**: `MorningBriefScreen.tsx` 가 존재하지 않는 `brief.greeting` 을 읽어 인사말이 항상 fallback 만 나온다는 제보.
2. **제안**: 브리프가 온보딩 마지막(MorningBriefScreen)에서 딱 한 번만 렌더되고, 일상 사용(오늘 탭)엔 노출 자리가 없다.

## 확인한 것 — 1번은 이미 고쳐져 있었다

`src/screens/MorningBriefScreen.tsx` 를 확인하니 이미 `a.brief?.headline` 을 읽고 있고(`src/types/api.ts` 의 `MorningBrief.headline` 과 정합), 관련 주석도 방향이 맞게 되어 있었다. `git log` 로 보니 `e5f5430` (#190, 2026-08-07)에서 이미 `greeting` → `headline` 으로 수정됐다. 이슈에 인용된 backward 주석("#159 는 없는 필드 headline 을 참조해...")도 현재 코드엔 없다. 저장소 전체에서 `greeting`/`DailyBrief` 를 검색해도 이제는 "예전엔 이랬다"는 히스토리 주석 두 줄만 남아 있다.

→ **이번 PR엔 1번에 대한 변경이 없다.** (BE 쪽 실측이 #190 반영 전 체크아웃 기준이었을 가능성)

## 이번에 한 것 — 2번 (일상 노출 자리)

`src/screens/TodayScreen.tsx` (`MergedTodayScreen`):

- 이미 `todayApi.agenda()` 를 호출해 카드·고정일정을 불러오고 있었으므로(#66 배선), 같은 응답의 `brief.headline` 을 새 state(`briefHeadline`)로 잡는다.
- 히어로 카드 바로 위, 고정 일정 스트립보다 앞자리에 브리프 headline 을 얹는다 — 이슈 본문이 우선 제안한 방향("오늘 탭 상단에 브리프 headline 을 아침 인사말로 노출")을 그대로 따랐다.
- 새 컴포넌트 없이 `MorningBriefScreen` 에서 이미 쓰던 `brand-soft`/`coral-200`/`Sparkle` 톤을 재사용해 톤을 맞췄다.
- 브리프가 없으면(미생성 등) 자리를 만들지 않는다 — 기존 "없는 걸 지어내지 않는다" 원칙 유지.

## 안 한 것

이슈가 함께 언급한 `bigRockActionId` 를 오늘 탭 히어로 카드 선정 힌트로 쓰는 것(현재 히어로는 promote/진행중/첫 대기 순)은 이번 범위에 넣지 않았다 — "최소한의 노출 자리"라는 지시에 맞춰 headline 노출만 먼저 하고, 히어로 선정 로직 변경은 별도로 검토하는 게 안전하다고 판단했다.

## 검증

`npm run build` (tsc + vite build) 통과.

Refs #206 (bigRockActionId 활용은 남은 범위)