### PR TITLE
feat(recovery): PARK/CARRY_OVER 수락 시 재관여 앵커 UI

### DIFF
--- a/src/components/ReEngagementAnchorPicker.tsx
+++ b/src/components/ReEngagementAnchorPicker.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { CalendarCheck, PencilSimple } from '@phosphor-icons/react';
+import { TimeDial } from './TimeDial';
+
+// PARK("지금은 접어두기") / CARRY_OVER("내일 이어서") 카드를 수락할 때 "다음에 다시
+// 만날 시점"을 정하는 자리(#221). 매번 직접 고르게 하면 마찰이 생기니 시스템이 다음
+// 주간 리뷰 시점을 기본값으로 먼저 보여주고, 원하면 [바꾸기]로 직접 조정하게 한다
+// (근거 A3 — 보류·이월 후 안 돌아오는 사용자를 붙잡을 재관여 장치 부재).
+//
+// ⚠️ 여기서 고른 값은 아직 백엔드로 전송되지 않는다 — `re_engagement_anchor_at` 이
+// openapi 스펙에 없다(백엔드 컬럼·저장 로직 미착수, 이슈 #221 참고). 연결 지점은
+// src/lib/api.ts 의 recoveryApi.decide 세 번째 인자.
+
+const DOW_KO = ['일', '월', '화', '수', '목', '금', '토'];
+
+function formatAnchorLabel(dateStr: string, timeStr: string): string {
+  const d = new Date(`${dateStr}T00:00:00`);
+  if (Number.isNaN(d.getTime())) return `${dateStr} ${timeStr}`;
+  return `${d.getMonth() + 1}월 ${d.getDate()}일(${DOW_KO[d.getDay()]}) ${timeStr}`;
+}
+
+export interface ReEngagementAnchorPickerProps {
+  date: string; // YYYY-MM-DD
+  time: string; // HH:MM
+  minDate: string; // YYYY-MM-DD — 오늘보다 이전으로는 못 고르게
+  onChangeDate: (v: string) => void;
+  onChangeTime: (v: string) => void;
+}
+
+export function ReEngagementAnchorPicker({ date, time, minDate, onChangeDate, onChangeTime }: ReEngagementAnchorPickerProps) {
+  const [editing, setEditing] = React.useState(false);
+
+  return (
+    <div
+      style={{
+        marginTop: 10,
+        padding: '10px 12px',
+        background: 'var(--sand-100)',
+        border: '1px solid var(--sand-200)',
+        borderRadius: 12,
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <CalendarCheck size={15} color="var(--text-2)" style={{ flexShrink: 0 }} />
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ fontSize: 11, fontWeight: 700, color: 'var(--text-2)' }}>다음엔 언제 다시 볼까요?</div>
+          <div style={{ fontSize: 12, color: 'var(--text-1)', fontWeight: 600, marginTop: 1 }}>
+            {formatAnchorLabel(date, time)} 에 다시 확인할게요
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={() => setEditing((v) => !v)}
+          style={{
+            flexShrink: 0,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 3,
+            background: 'transparent',
+            border: 'none',
+            color: 'var(--coral-700)',
+            fontSize: 11,
+            fontWeight: 700,
+            fontFamily: 'inherit',
+            cursor: 'pointer',
+            padding: '4px 0 4px 8px',
+          }}
+        >
+          <PencilSimple size={11} /> {editing ? '접기' : '바꾸기'}
+        </button>
+      </div>
+
+      {editing && (
+        <div style={{ marginTop: 10, display: 'flex', flexDirection: 'column', gap: 8 }}>
+          <input
+            type="date"
+            value={date}
+            min={minDate}
+            onChange={(e) => onChangeDate(e.target.value)}
+            aria-label="다시 만날 날짜"
+            style={{
+              width: '100%',
+              boxSizing: 'border-box',
+              padding: '9px 12px',
+              borderRadius: 10,
+              border: '1.5px solid var(--sand-200)',
+              background: 'var(--surface-raised)',
+              color: 'var(--text-1)',
+              fontSize: 13,
+              fontFamily: 'inherit',
+              outline: 'none',
+            }}
+          />
+          <TimeDial value={time} onChange={onChangeTime} minuteStep={30} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -726,12 +726,19 @@ export const recoveryApi = {
       body: { executionId } satisfies RecoveryGenerateRequest,
     }),
 
-  decide: (body: RecoveryDecisionRequest, idempotencyKey: string) =>
-    request<RecoveryDecisionResponse>('/recovery/decisions', {
+  // reEngagementAnchorAt — PARK/CARRY_OVER 카드를 accepted 로 결정할 때 "다음에 다시
+  // 볼 시점"(#221). 백엔드에 `re_engagement_anchor_at` 컬럼·저장 로직이 아직 없고
+  // openapi 스펙에도 없어(0건, 확인함) 지금 보내면 4xx 를 유발한다. 그래서 인자로는
+  // 받아 두되 body 엔 아직 싣지 않는다 — 스펙에 필드가 생기면 아래 스프레드 뒤에
+  // `reEngagementAnchorAt` 한 줄만 추가해 연결한다.
+  decide: (body: RecoveryDecisionRequest, idempotencyKey: string, reEngagementAnchorAt?: string | null) => {
+    void reEngagementAnchorAt; // TODO(#221): 스펙에 필드 추가되면 request body 에 연결
+    return request<RecoveryDecisionResponse>('/recovery/decisions', {
       method: 'POST',
       body,
       idempotencyKey,
-    }),
+    });
+  },
 };
 
 export const replanApi = {

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -18,3 +18,13 @@ export function weekStartStr(d: Date): string {
   monday.setDate(monday.getDate() - ((monday.getDay() + 6) % 7));
   return localDateStr(monday);
 }
+
+// PARK/CARRY_OVER 회복 카드를 수락할 때 "다음에 다시 볼 시점"의 기본값(#221).
+// 매번 직접 고르게 하면 마찰이 생기니, 다음 주간 리뷰 시점(다음 주 월요일 아침)을
+// 시스템이 먼저 제안하고 원하면 바꾸게 한다. 09:00 은 SetupScreen 의 기본 아침 시각과 동일.
+export function defaultReEngagementAnchorDate(d: Date = new Date()): string {
+  const nextMonday = new Date(d);
+  nextMonday.setDate(nextMonday.getDate() - ((nextMonday.getDay() + 6) % 7) + 7);
+  return localDateStr(nextMonday);
+}
+export const DEFAULT_REENGAGEMENT_TIME = '09:00';

--- a/src/screens/RecoveryScreen.tsx
+++ b/src/screens/RecoveryScreen.tsx
@@ -9,10 +9,17 @@ import {
 import { ApiError, friendlyError, recoveryApi } from '../lib/api';
 import { DemoNotice } from '../components/DemoNotice';
 import { RecoveryOptionCard } from '../components/RecoveryOptionCard';
+import { ReEngagementAnchorPicker } from '../components/ReEngagementAnchorPicker';
 import { EmptyState } from '../components/EmptyState';
 import { ErrorBanner } from '../components/ErrorBanner';
+import { localDateStr, defaultReEngagementAnchorDate, DEFAULT_REENGAGEMENT_TIME } from '../lib/dates';
 import type { Task, RecoveryProposal } from '../types';
 import type { RecoveryCard } from '../types/api';
+
+// 이 optionGroup 은 "보류·이월" 계열 — 수락 시 재관여 앵커(#221)를 같이 정한다.
+// PARK("지금은 접어두기") / CARRY_OVER("내일 이어서") 만 해당. DOWNSCOPE/RESCHEDULE 는
+// 바로 다음 실행이 다시 잡히므로 별도 재관여 장치가 필요 없다.
+const REENGAGEMENT_GROUPS = new Set(['PARK', 'CARRY_OVER']);
 
 // 옵션 그룹별 카드 색상 (백엔드 RecoveryCard 엔 색이 없어 클라이언트가 지정).
 const GROUP_COLOR: Record<string, { bg: string; bc: string; ac: string }> = {
@@ -113,6 +120,13 @@ export function MergedRecoveryScreen({ task, failReason, onAccept, onDismiss, ex
   const [decideError, setDecideError] = useState<string | null>(null);
   // 이 실행은 이미 회복 결정을 마침(generate 409) — 오류가 아니라 정상 상태.
   const [alreadyDecided, setAlreadyDecided] = useState(false);
+  // 재관여 앵커(#221) — PARK/CARRY_OVER 수락 시 "다음에 다시 볼 시점". 기본값은 다음
+  // 주간 리뷰(다음 주 월요일 09:00)로 미리 채워, 마찰 없이 그대로 확인만 해도 되게 한다.
+  const [anchorDate, setAnchorDate] = useState(() => defaultReEngagementAnchorDate());
+  const [anchorTime, setAnchorTime] = useState(DEFAULT_REENGAGEMENT_TIME);
+
+  const selectedProposal = proposals.find((p) => p.id === sel);
+  const needsAnchor = !!selectedProposal && REENGAGEMENT_GROUPS.has(selectedProposal.type);
 
   // 진입 시 + "다른 제안" 버튼에서 LLM 회복 제안 생성. executionId 있을 때만(데모 task 는 skip).
   // 4 UX 그룹당 ≤1 로 dedup. hooks 는 early-return 앞에 둔다(호출 순서 고정).
@@ -186,10 +200,14 @@ export function MergedRecoveryScreen({ task, failReason, onAccept, onDismiss, ex
     if (executionId) {
       setDeciding(true);
       setDecideError(null);
+      // PARK/CARRY_OVER 는 재관여 앵커(#221)를 함께 넘긴다 — 지금은 스펙 대기라
+      // recoveryApi.decide 안에서 버려지지만, 값 자체는 여기서부터 만들어 둔다.
+      const reEngagementAnchorAt = needsAnchor ? `${anchorDate}T${anchorTime}:00+09:00` : null;
       try {
         await recoveryApi.decide(
           { executionId, decision: 'accepted', acceptedAttemptId: sel },
           `rec-${executionId}-${sel}`,
+          reEngagementAnchorAt,
         );
       } catch (err) {
         setDecideError(friendlyError(err, '회복 계획을 저장하지 못했어요. 잠시 후 다시 시도해 주세요.'));
@@ -280,6 +298,16 @@ export function MergedRecoveryScreen({ task, failReason, onAccept, onDismiss, ex
               />
             ))}
           </div>
+
+          {needsAnchor && (
+            <ReEngagementAnchorPicker
+              date={anchorDate}
+              time={anchorTime}
+              minDate={localDateStr(new Date())}
+              onChangeDate={setAnchorDate}
+              onChangeTime={setAnchorTime}
+            />
+          )}
 
           <div style={{ marginTop: 14, fontSize: 11, color: 'var(--text-3)', textAlign: 'center' }}>실패는 데이터예요. 다시 한 번이면 충분해요.</div>
 


### PR DESCRIPTION
## 요약

- #221 요청대로 PARK/CARRY_OVER 회복 카드를 수락할 때 "다음에 다시 만날 시점"을 정하는 UI를 추가했습니다.
- 이슈가 제시한 두 방식 중 마찰이 적은 **(b) 시스템 기본값 제안 + 원하면 바꾸기**를 구현했습니다.
  - 기본값: 다음 주간 리뷰 시점(다음 주 월요일 09:00, `src/lib/dates.ts`의 `defaultReEngagementAnchorDate`)
  - `src/components/ReEngagementAnchorPicker.tsx`: 기본값을 카드 형태로 보여주고, `[바꾸기]`를 누르면 날짜(`<input type="date">`)와 시간(기존 `TimeDial` 재사용)을 직접 조정할 수 있습니다.
  - `src/screens/RecoveryScreen.tsx`: 선택된 제안의 `optionGroup`이 `PARK`/`CARRY_OVER`일 때만 노출합니다(DOWNSCOPE/RESCHEDULE는 바로 다음 실행이 재생성되므로 제외).

## 백엔드 `re_engagement_anchor_at` 대기

- `openapi.json` / `src/types/openapi.d.ts`에 `re_engagement_anchor_at` 필드가 아직 없습니다(grep 0건 확인). 이슈 본문도 "컬럼·저장 로직은 아직 없다"고 명시합니다.
- 그래서 스펙에 없는 필드를 요청 본문에 임의로 넣지 않았습니다. 대신 값 생성까지만 FE에서 끝내고, 전송 지점을 한 곳(`src/lib/api.ts`의 `recoveryApi.decide` 세 번째 인자 `reEngagementAnchorAt`)으로 좁혀 뒀습니다. 지금은 `void`로 버려집니다.
- **스펙에 필드가 추가되면**: `api.ts`의 `decide` 함수 안 `TODO(#221)` 주석 자리에 `re_engagement_anchor_at: reEngagementAnchorAt` 한 줄만 body에 추가하면 연결됩니다.

## 확인

- `npm run build` 통과
- `node scripts/check-api-contract.mjs` PASS (기존 계약 위반 없음, 새 필드도 미전송이라 드리프트 없음)

## 테스트 플랜

- [ ] PARK 카드를 선택하고 앵커 카드가 기본값(다음 주 월요일 09:00)으로 뜨는지 확인
- [ ] `[바꾸기]`로 날짜/시간을 바꾼 뒤 다시 접었다 펴도 값이 유지되는지 확인
- [ ] DOWNSCOPE/RESCHEDULE 카드를 선택했을 때 앵커 UI가 안 뜨는지 확인
- [ ] "이 방법으로" 수락 시 기존 `/recovery/decisions` 흐름(422/409 처리 포함)이 그대로 동작하는지 확인

Refs #221