### PR TITLE
주간 리뷰 — 최근 4주 자주 겹친 상황 섹션 추가

### DIFF
--- a/src/components/TopFailureContexts.tsx
+++ b/src/components/TopFailureContexts.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { SectionHeader } from './SectionHeader';
+import { Chip } from './Chip';
+import type { TopFailureContext } from '../types/api';
+
+interface TopFailureContextsProps {
+  contexts: TopFailureContext[];
+}
+
+// 0~1 비율이면 %로, 이미 0~100이면 그대로 (WeeklyReviewScreen 의 toPct 와 동일 규칙).
+function toPct(v: number): number {
+  return Math.round(v <= 1 ? v * 100 : v);
+}
+
+/**
+ * "최근 4주 자주 겹친 상황" — 주간 리뷰 신규 섹션(#225).
+ *
+ * 백엔드가 top_failure_contexts 를 아직 API 로 노출하지 않아(쿼리는 검증됐지만
+ * 엔드포인트 미배포) 이 컴포넌트는 미리 만들어만 두고, 호출부(WeeklyReviewScreen)가
+ * `real?.topFailureContexts` 가 실제로 채워졌을 때만 렌더한다. 필드가 없으면(undefined)
+ * 아무것도 그리지 않는다 — 빈 껍데기·가짜 데이터를 보여주지 않는다.
+ *
+ * 표현 형태는 칩(Chip.tsx)을 골랐다: 이 섹션은 "당신은 이런 사람이다"라는 자아 수준
+ * 특성형 백분율(E2 근거 — 노출 시 성과가 떨어짐)이 아니라 "이런 상황에서 자주 걸렸다"는
+ * 상황 라벨 나열이라, 막대그래프처럼 크기를 정밀 비교하게 만드는 대신 태그처럼 가볍게
+ * 훑고 넘어가게 하는 칩이 더 맞다. 위 카테고리별 성공률 섹션은 연속값(%) 비교가
+ * 핵심이라 막대를 쓰지만, 여긴 이산적인 상위 3개 상황 나열이라 다른 표현을 쓴다.
+ */
+export function TopFailureContexts({ contexts }: TopFailureContextsProps) {
+  if (contexts.length === 0) return null;
+  const top3 = contexts.slice(0, 3);
+
+  return (
+    <div style={{ background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', borderRadius: 14, padding: '12px 14px' }}>
+      <SectionHeader>최근 4주 자주 겹친 상황</SectionHeader>
+      <p style={{ margin: '0 0 10px', fontSize: 11, color: 'var(--text-3)', lineHeight: 1.5 }}>
+        완료율이 아니라, 실패했을 때 자주 겹친 상황이에요 — 다음 주 계획을 세울 때 참고해보세요.
+      </p>
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+        {top3.map((ctx, i) => (
+          <Chip key={ctx.tagCode} tone={i === 0 ? 'coral' : 'neutral'}>
+            {ctx.labelKo}
+            <span className="tnum" style={{ fontWeight: 700 }}>{toPct(ctx.share)}%</span>
+          </Chip>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/screens/WeeklyReviewScreen.tsx
+++ b/src/screens/WeeklyReviewScreen.tsx
@@ -1,5 +1,6 @@
 import { ScoreDonut } from '../components/ScoreDonut';
 import { SectionHeader } from '../components/SectionHeader';
+import { TopFailureContexts } from '../components/TopFailureContexts';
 import React, { useEffect, useState } from 'react';
 import { Sparkle, ArrowRight } from '@phosphor-icons/react';
 import { reviewsApi } from '../lib/api';
@@ -284,6 +285,12 @@ export function WeeklyReviewScreenV2() {
             </div>
           </div>
         )}
+
+        {/* 최근 4주 자주 겹친 상황 — #225. 백엔드가 top_failure_contexts 를 아직 API 로
+            노출하지 않는다(쿼리는 검증됐지만 엔드포인트 대기) → 필드가 응답에 없으면
+            real.topFailureContexts 는 undefined 라 TopFailureContexts 가 아예 렌더되지
+            않는다(빈 껍데기·가짜 데이터 금지). 엔드포인트가 열리면 이 한 줄만 살아난다. */}
+        {real?.topFailureContexts && <TopFailureContexts contexts={real.topFailureContexts} />}
 
         {/* 다음 주 정책 자동 보정 후보 — 건수만 정직하게 표시(백엔드 정책 스냅샷 연동 전이라
             from→to 구체 내용은 아직 없음). */}

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1004,6 +1004,18 @@ export interface BlockEditResponse {
   goalId?: string | null;
 }
 
+// 최근 27일(4주) 창에서 가장 자주 겹치는 실패 사유 태그 1건 — 빈도(count)·비중(share, 0~1
+// 또는 0~100 둘 다 허용) (#225). 쿼리는 reaction-backend 에서 실 Postgres 로 검증됐지만
+// (tests/test_recovery_evidence_sql.py) 아직 API 엔드포인트로 노출되지 않았다 — 필드 모양은
+// FailureTagMaster(tagCode/labelKo) 응답 관례를 따라 잠정 추정한 것. 백엔드가 엔드포인트를
+// 열면 이 타입과 WeeklyReviewResponse.topFailureContexts 만 실제 계약과 맞춰주면 된다.
+export interface TopFailureContext {
+  tagCode: FailureTagCode | string;
+  labelKo: string;
+  count: number;
+  share: number;
+}
+
 // ── Reviews (S21·S22) — GET /reviews/weekly (#21 구현됨) ───────
 export interface WeeklyReviewResponse {
   weekStart: string;
@@ -1021,6 +1033,9 @@ export interface WeeklyReviewResponse {
   peakWindow?: string | null;
   drainWindow?: string | null;
   policyUpdateCandidates?: unknown[] | null;
+  // #225 — 백엔드 엔드포인트 노출 대기(openapi.json 에 아직 없음). 응답에 필드가 없으면
+  // undefined 로 와서 화면 쪽 섹션이 자동으로 숨는다(가짜 데이터 렌더 금지).
+  topFailureContexts?: TopFailureContext[] | null;
 }
 export interface WeeklyGenerateRequest {
   weekStart?: string;


### PR DESCRIPTION
## 배경

이슈 #225: 주간 리뷰가 완료율 백분율만 보여줘 "어떤 상황에서 자주 실패했는지" 요약이
없다(BCT 2.3 Self-monitoring 공백, 근거 A5). 최근 27일(4주) 창에서 가장 자주 겹치는
실패 사유 태그 상위 3개(빈도·비중)를 보여주는 섹션을 추가한다.

## 표현 형태 결정 — 칩(Chip.tsx)

이슈가 요청한 "어떤 형태가 좋을지(리스트/칩/짧은 문장 요약)"에 대한 판단 근거:

- 이 섹션은 이산적인 상위 3개 **상황** 나열이다. 기존 "카테고리별 성공률" 섹션처럼
  연속값(%) 간 정밀 비교가 목적이 아니라서 막대그래프는 과한 정밀도를 암시한다.
- `Chip.tsx` 는 이미 이 화면 곳곳에서 "가볍게 훑고 넘어가는 태그"용으로 쓰이는
  컴포넌트라 기존 정보 위계에 자연스럽게 붙는다. 리스트(세로 나열)는 카드 하나에
  3항목뿐인 이 데이터엔 세로 공간을 과하게 쓴다.
- 짧은 문장 요약(예: "이번 주는 시간 부족 상황이 잦았어요")은 3개 중 1개만 보여줘
  "상위 3개" 요구를 satisfy 못 한다.

**카피는 자아 수준(특성형) 백분율을 그대로 노출하지 않는다** — 근거 E2(trait-level
노출 시 성과 저하)에 따라 "당신은 이런 사람이다"가 아니라 "이런 **상황**에서 자주
겹쳤다"로 읽히게 헤더/서브카피를 썼다:

- 헤더: "최근 4주 자주 겹친 상황"
- 서브카피: "완료율이 아니라, 실패했을 때 자주 겹친 상황이에요 — 다음 주 계획을 세울
  때 참고해보세요."
- 칩 안엔 상황 태그 라벨 + 비중(%)만 — "당신은 N% 이런 사람" 문구 없음.

## 백엔드 상태 — 엔드포인트 노출 대기

`top_failure_contexts` 쿼리는 reaction-backend 에서 실 Postgres 로 검증됐지만
(`tests/test_recovery_evidence_sql.py`, [reaction-backend#270](https://github.com/hanium-reaction/reaction-backend/pull/270))
**API 엔드포인트로는 아직 노출되지 않았다** — `openapi.json`/`src/types/openapi.d.ts` 에
0건 확인.

그래서 이번 PR은:

- `WeeklyReviewResponse.topFailureContexts?: TopFailureContext[] | null` 를
  `src/types/api.ts` 에 옵셔널로 추가만 해두고,
- 렌더 컴포넌트 `src/components/TopFailureContexts.tsx` 를 미리 만들어 두되,
- `WeeklyReviewScreen.tsx` 는 `real?.topFailureContexts` 가 실제로 채워졌을 때만
  렌더한다 — 스펙에 없는 필드를 호출하지 않고, 필드가 없으면 섹션 자체가 렌더되지
  않는다(빈 껍데기·가짜 데이터 없음).
- 백엔드가 엔드포인트를 열면 `openapi.json` 갱신 후 이 한 줄
  (`{real?.topFailureContexts && <TopFailureContexts contexts={real.topFailureContexts} />}`)
  만 살아난다 — 다른 곳을 손댈 필요 없음.

## 변경 파일

- `src/types/api.ts` — `TopFailureContext` 타입 추가, `WeeklyReviewResponse` 에
  `topFailureContexts` 옵셔널 필드 추가
- `src/components/TopFailureContexts.tsx` — 신규 렌더 컴포넌트(Chip + SectionHeader)
- `src/screens/WeeklyReviewScreen.tsx` — 조건부 렌더 배선

## 테스트

- [x] `npm run build` 통과 (tsc + vite build)
- [ ] 백엔드 엔드포인트 배포 후 실 데이터로 재확인 필요 (현재는 필드가 없어 섹션이
      항상 숨겨진 상태로 검증됨)

Refs #225