### PR TITLE
T1 인앱 배지 — 블록 종료 +20분 미체크 넛지 (#224)

### DIFF
--- a/src/app/ReActionMerged.tsx
+++ b/src/app/ReActionMerged.tsx
@@ -117,6 +117,9 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
   const [recoveryCount, setRecoveryCount] = useState(0);
   // 사용자가 회복 화면에서 고른 제안 — RecoveredScreen 의 before→after 카드용.
   const [appliedRecovery, setAppliedRecovery] = useState<AppliedRecovery | null>(null);
+  // 블록 종료 +20분 미체크 개수(#224 T1) — TodayScreen 안에서 계산되고, 탭바 배지는
+  // 이 화면 밖(형제 컴포넌트)에 있어서 개수만 끌어올린다.
+  const [uncheckedCount, setUncheckedCount] = useState(0);
 
   const showTabs = !hideTabs && TAB_SCREENS.includes(screen);
 
@@ -270,6 +273,7 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
             // /today/agenda 실데이터가 오면 부모 tasks 자체를 교체 — openTask 등이
             // 실제 카드 id 를 찾을 수 있게 단일 소스로 유지한다(#66).
             onAgendaLoaded={setTasks}
+            onUncheckedChange={setUncheckedCount}
           />
         )}
         {screen === 'focus' && (
@@ -341,7 +345,14 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
         {screen === 'my-info' && <MyInfoScreen />}
       </div>
 
-      {showTabs && <MergedTabBar active={tab} onChange={handleTabChange} />}
+      {showTabs && (
+        <MergedTabBar
+          active={tab}
+          onChange={handleTabChange}
+          // 확인 안 한 작업이 있을 때만 '오늘 실행' 탭에 점을 찍는다(#224 T1).
+          dotTabs={uncheckedCount > 0 ? ['today'] : []}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -9,6 +9,8 @@ import type { TabId } from '../types';
 interface MergedTabBarProps {
   active: TabId;
   onChange: (tab: TabId) => void;
+  /** 점만 찍는 배지가 필요한 탭 id 목록(#224 T1 — 블록 종료 후 미체크 인앱 넛지). */
+  dotTabs?: TabId[];
 }
 
 // 주간 계획 + 주간 리뷰는 '주간' 탭 하나로 통합(화면 내 계획/리뷰 토글).
@@ -30,7 +32,7 @@ const tabs: { id: TabId; label: string; Icon: React.ElementType }[] = [
  * 걸리는 장식이었고, 한국 앱의 관용은 "버튼이 무엇을 하는지 말로 적는" 쪽이다.
  * 그래서 '주간' 도 '주간 계획' 으로 늘렸다.
  */
-export function MergedTabBar({ active, onChange }: MergedTabBarProps) {
+export function MergedTabBar({ active, onChange, dotTabs = [] }: MergedTabBarProps) {
   return (
     <nav
       aria-label="주요 화면"
@@ -47,11 +49,13 @@ export function MergedTabBar({ active, onChange }: MergedTabBarProps) {
     >
       {tabs.map((t) => {
         const isActive = active === t.id;
+        const showDot = dotTabs.includes(t.id);
         return (
           <button
             key={t.id}
             onClick={() => onChange(t.id)}
             aria-current={isActive ? 'page' : undefined}
+            aria-label={showDot ? `${t.label} — 확인 안 한 작업 있음` : undefined}
             style={{
               flex: 1,
               display: 'flex',
@@ -72,11 +76,30 @@ export function MergedTabBar({ active, onChange }: MergedTabBarProps) {
               transition: 'color 140ms',
             }}
           >
-            <t.Icon
-              size={22}
-              weight={isActive ? 'fill' : 'regular'}
-              color={isActive ? 'var(--brand-ink)' : 'var(--text-3)'}
-            />
+            <span style={{ position: 'relative', display: 'inline-flex' }}>
+              <t.Icon
+                size={22}
+                weight={isActive ? 'fill' : 'regular'}
+                color={isActive ? 'var(--brand-ink)' : 'var(--text-3)'}
+              />
+              {/* 확인 안 한 작업이 있음을 알리는 점. 개수를 세지 않는다 — 탭바에서 필요한 건
+                  "볼 게 있다/없다" 뿐, 정확한 건수는 화면 안 배너가 말해준다. */}
+              {showDot && (
+                <span
+                  aria-hidden
+                  style={{
+                    position: 'absolute',
+                    top: -1,
+                    right: -3,
+                    width: 8,
+                    height: 8,
+                    borderRadius: 9999,
+                    background: 'var(--coral-700)',
+                    border: '1.5px solid var(--surface-raised)',
+                  }}
+                />
+              )}
+            </span>
             {t.label}
           </button>
         );

--- a/src/lib/uncheckedBlocks.ts
+++ b/src/lib/uncheckedBlocks.ts
@@ -1,0 +1,107 @@
+import type { Task, TaskStatus } from '../types';
+import type { WeeklyPlanResponse } from '../types/api';
+
+// T1 인앱 배지(#224) — 계획된 블록이 끝난 뒤 +20분이 지났는데 체크인이 없으면 인앱으로
+// 넛지한다. 푸시가 아니다: 알림 클래스가 3종으로 DB CHECK 제약까지 걸려 잠겨 있고,
+// 주간 발송 예산(PUSH_WEEKLY_BUDGET=3)을 이 넛지가 먹으면 저녁 회고 푸시가 막히는
+// 부작용이 생겨(이슈 #224 참고) 백엔드 새 API 없이 프론트 계산으로 대체했다.
+//
+// 근거 없이 20분을 고른 게 아니다 — docs/research/recovery-evidence-base.md 의 근접 창
+// 60분(D3) 안에서, 실험 계획(L3-2)이 잡은 값을 그대로 쓴다.
+export const UNCHECKED_GRACE_MINUTES = 20;
+
+// AgendaCard.status(=Task.status) 중 "이미 체크인함"으로 보는 값들. done/partial_done/failed
+// 는 /today/check-ins 로 기록된 상태이고, recovery_pending 은 partial_done 이후 회복 제안을
+// 기다리는 중이라 이미 체크인은 끝난 상태다. 남는 todo/in_progress 만 "미체크".
+const CHECKED_STATUSES: ReadonlySet<TaskStatus> = new Set(['done', 'partial_done', 'failed', 'recovery_pending']);
+
+export interface UncheckedBlock {
+  actionId: string;
+  title: string;
+  /** 계획된 블록 종료 시각 (WeeklyBlock.endAt, KST ISO). */
+  endAt: string;
+}
+
+/**
+ * 오늘(todayStr) 블록 중 "종료 +20분 지났는데 미체크"인 것을 찾는다 (#224 T1).
+ *
+ * 백엔드에 새 API가 없어 프론트에서만 판정한다 — GET /today/agenda 의 AgendaCard 에는
+ * 종료 시각이 없고, GET /plans/weekly 의 WeeklyBlock 에는 체크인 여부가 없다. TodayScreen 이
+ * 이미 이 둘을 actionId 로 조인해 시각 칩을 채우고 있어(todayBlockIndex, #66 계열), 같은
+ * 조인을 여기서도 쓴다.
+ *
+ * 순수 함수 — 네트워크·localStorage 를 건드리지 않는다. 호출자가 /today/agenda 로 얻은
+ * Task[] 와 /plans/weekly 응답을 그대로 넘긴다.
+ *
+ * @param tasks    agenda 카드에서 매핑한 Task[] (status 는 AgendaCard.status 를 그대로 반영).
+ * @param plan     GET /plans/weekly 응답. 아직 못 받았으면 null — 판정을 보류하고 빈 배열.
+ * @param todayStr 오늘 날짜(YYYY-MM-DD, 로컬 기준 — lib/dates 의 localDateStr).
+ * @param now      기준 시각. 테스트 주입용, 기본은 현재 시각.
+ */
+export function findUncheckedBlocks(
+  tasks: Task[],
+  plan: WeeklyPlanResponse | null,
+  todayStr: string,
+  now: Date = new Date(),
+): UncheckedBlock[] {
+  if (!plan) return [];
+  const todayBlocks = plan.days?.find((d) => d.date === todayStr)?.blocks ?? [];
+  if (todayBlocks.length === 0) return [];
+
+  const taskByAction = new Map(tasks.map((t) => [t.id, t]));
+  const graceMs = UNCHECKED_GRACE_MINUTES * 60_000;
+  const nowMs = now.getTime();
+
+  const result: UncheckedBlock[] = [];
+  for (const b of todayBlocks) {
+    const task = taskByAction.get(b.actionId);
+    if (!task) continue; // 취소됐거나(BE #214) agenda 에 없는 블록 — 판정 대상 아님
+    if (CHECKED_STATUSES.has(task.status)) continue;
+    const endMs = new Date(b.endAt).getTime();
+    if (Number.isNaN(endMs)) continue;
+    if (nowMs - endMs >= graceMs) {
+      result.push({ actionId: b.actionId, title: task.title, endAt: b.endAt });
+    }
+  }
+  return result;
+}
+
+// ── 로컬 dismiss 상태 ────────────────────────────────────────────
+// 위 판정 함수는 순수하지만, "한 번 확인한 건 다시 안 뜬다"(반복 노출 방지)는 세션을
+// 넘어 남아야 하므로 localStorage 에 actionId 를 쌓는다. IosInstallCard(#11) 와 같은
+// 패턴 — 서버 상태가 아니라 기기 로컬 플래그다(기기를 바꾸면 다시 보일 수 있음).
+const DISMISSED_KEY = 'reaction.uncheckedNudgeDismissed';
+// 무한정 쌓이지 않도록 최근 N개만 보존.
+const DISMISSED_MAX = 200;
+
+function readDismissed(): Set<string> {
+  try {
+    const raw = window.localStorage.getItem(DISMISSED_KEY);
+    if (!raw) return new Set();
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? new Set(parsed) : new Set();
+  } catch {
+    return new Set();
+  }
+}
+
+/** dismiss 되지 않은 것만 남긴다 — 배지·배너 렌더 직전에 판정 결과에 걸어 쓴다. */
+export function filterDismissedBlocks(blocks: UncheckedBlock[]): UncheckedBlock[] {
+  if (blocks.length === 0) return blocks;
+  const dismissed = readDismissed();
+  if (dismissed.size === 0) return blocks;
+  return blocks.filter((b) => !dismissed.has(b.actionId));
+}
+
+/** 사용자가 넛지를 닫으면(또는 확인하면) 같은 블록이 다시 뜨지 않게 기록한다. */
+export function dismissUncheckedBlocks(actionIds: string[]): void {
+  if (actionIds.length === 0) return;
+  try {
+    const dismissed = readDismissed();
+    for (const id of actionIds) dismissed.add(id);
+    const trimmed = Array.from(dismissed).slice(-DISMISSED_MAX);
+    window.localStorage.setItem(DISMISSED_KEY, JSON.stringify(trimmed));
+  } catch {
+    /* localStorage 없음/쿼터 초과 — 이번 세션만 다시 뜨는 정도라 무시해도 안전 */
+  }
+}

--- a/src/screens/TodayScreen.tsx
+++ b/src/screens/TodayScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   ArrowsClockwise,
   CaretRight,
@@ -6,6 +6,7 @@ import {
   X,
   Trash,
   Sparkle,
+  BellRinging,
 } from '@phosphor-icons/react';
 import type { Task, TaskStatus } from '../types';
 import type { AgendaCard, AgendaFixedSchedule, ApiGoal, WeeklyPlanResponse } from '../types/api';
@@ -13,6 +14,7 @@ import { FAIL_REASONS, GOAL_CATEGORY_OPTIONS } from '../data';
 import { useNavigation } from '../contexts/NavigationContext';
 import { friendlyError, goalsApi, habitsApi, plansApi, reflectionApi, todayApi } from '../lib/api';
 import { localDateStr } from '../lib/dates';
+import { dismissUncheckedBlocks, filterDismissedBlocks, findUncheckedBlocks } from '../lib/uncheckedBlocks';
 import { categoryLabel, goalColor } from '../data';
 import { DemoNotice } from '../components/DemoNotice';
 import { Segmented } from '../components/Segmented';
@@ -84,6 +86,9 @@ interface MergedTodayScreenProps {
   // (기존엔 이 화면이 자체 로컬 tasks 상태로만 반영해, 부모가 들고 있는 openTask 등이
   // 실제 카드 id 를 못 찾아 무반응이었다 — #66 대응)
   onAgendaLoaded: (tasks: Task[]) => void;
+  // 블록 종료 +20분 미체크 개수(#224 T1) — 탭바 배지는 이 화면 밖(부모)에 있어서 올려보낸다.
+  // dismiss 된 것은 이미 뺀 값이라, 부모는 그대로 "볼 게 있다/없다"로만 쓰면 된다.
+  onUncheckedChange?: (count: number) => void;
 }
 
 // 화면용 Habit — 백엔드 Habit + 이번 주 HabitInstance 를 평탄화한 모양.
@@ -170,7 +175,7 @@ function todayShortKo(): string {
   return `${d.getMonth() + 1}월 ${d.getDate()}일 · ${days[d.getDay()]}요일`;
 }
 
-export function MergedTodayScreen({ tasks: allTasks, onOpen, onMarkDone, onPartial, onFail, onOpenRecovery, onEvening, onAgendaLoaded }: MergedTodayScreenProps) {
+export function MergedTodayScreen({ tasks: allTasks, onOpen, onMarkDone, onPartial, onFail, onOpenRecovery, onEvening, onAgendaLoaded, onUncheckedChange }: MergedTodayScreenProps) {
   const { user } = useNavigation();
   const userName = user?.name ?? '친구';
 
@@ -212,11 +217,14 @@ export function MergedTodayScreen({ tasks: allTasks, onOpen, onMarkDone, onParti
   // agenda 렌더를 막지 않는다 — 늦게 도착하면 그때 칩이 붙는다(없으면 안 붙을 뿐).
   const [blockInfo, setBlockInfo] = useState<Map<string, { time: string; durMin: number; goalId?: string | null }>>(new Map());
   const [goalTitles, setGoalTitles] = useState<Map<string, ApiGoal>>(new Map());
+  // 원본 주간 계획도 따로 들고 있는다 — blockInfo 는 시간을 "HH:MM" 문자열로 뭉개서
+  // #224 T1(블록 종료 +20분 미체크 판정)에 필요한 endAt 원본이 없다.
+  const [weeklyPlan, setWeeklyPlan] = useState<WeeklyPlanResponse | null>(null);
   useEffect(() => {
     let cancelled = false;
     const today = localDateStr(new Date());
     plansApi.weekly(thisMonday()).then(
-      (plan) => { if (!cancelled) setBlockInfo(todayBlockIndex(plan, today)); },
+      (plan) => { if (!cancelled) { setBlockInfo(todayBlockIndex(plan, today)); setWeeklyPlan(plan); } },
       () => { /* 계획 없음/오류 — 시각 칩만 안 붙는다 */ },
     );
     goalsApi.list().then(
@@ -229,6 +237,26 @@ export function MergedTodayScreen({ tasks: allTasks, onOpen, onMarkDone, onParti
     );
     return () => { cancelled = true; };
   }, []);
+
+  // 블록 종료 +20분 미체크 인앱 넛지(#224 T1). 시간이 지나는 것만으로도 조건이 바뀌므로
+  // 1분마다 재평가한다 — 화면을 새로고침해야만 뜨면 "앱을 열어보게" 만드는 목적에 안 맞는다.
+  const [nudgeNow, setNudgeNow] = useState(() => new Date());
+  useEffect(() => {
+    const id = setInterval(() => setNudgeNow(new Date()), 60_000);
+    return () => clearInterval(id);
+  }, []);
+  // dismiss 는 localStorage 만 건드리고 tasks/weeklyPlan 을 바꾸지 않아 useMemo 가
+  // 재계산할 이유가 없다 — 즉시 화면에서 빼려고 이 카운터를 dep 에 끼워 강제로 재실행한다.
+  const [nudgeDismissTick, setNudgeDismissTick] = useState(0);
+  const uncheckedBlocks = useMemo(
+    () => filterDismissedBlocks(findUncheckedBlocks(tasks, weeklyPlan, localDateStr(nudgeNow), nudgeNow)),
+    [tasks, weeklyPlan, nudgeNow, nudgeDismissTick],
+  );
+  useEffect(() => { onUncheckedChange?.(uncheckedBlocks.length); }, [uncheckedBlocks.length, onUncheckedChange]);
+  const dismissNudge = () => {
+    dismissUncheckedBlocks(uncheckedBlocks.map((b) => b.actionId));
+    setNudgeDismissTick((n) => n + 1);
+  };
 
   // 화면에 붙일 부가 정보. 없는 건 없는 대로 둔다(빈 값을 지어내지 않는다).
   const metaFor = (t: Task) => {
@@ -303,6 +331,11 @@ export function MergedTodayScreen({ tasks: allTasks, onOpen, onMarkDone, onParti
   );
   // hero 카드가 가리키는 task — row 클릭으로 promote 만, 실제 시작 X.
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
+  // 미체크 넛지를 탭하면 첫 카드를 hero 로 올린다 — 기존 row 클릭(promote)과 같은
+  // 동작이라 새로운 진입 경로를 또 익힐 필요가 없다.
+  const openFirstUnchecked = () => {
+    if (uncheckedBlocks[0]) setSelectedTaskId(uncheckedBlocks[0].actionId);
+  };
   // 실패 사유 태그 — 최대 2개 선택(S18). memo 는 선택 자유 텍스트.
   const [failTags, setFailTags] = useState<{ code: string; labelKo: string }[]>([]);
   const [failMemo, setFailMemo] = useState('');
@@ -540,6 +573,37 @@ export function MergedTodayScreen({ tasks: allTasks, onOpen, onMarkDone, onParti
           <div style={{ display: 'flex', gap: 8, alignItems: 'flex-start', padding: '12px 14px', background: 'var(--brand-soft)', border: '1px solid var(--coral-200)', borderRadius: 16 }}>
             <Sparkle size={14} weight="fill" color="var(--brand)" style={{ flexShrink: 0, marginTop: 2 }} />
             <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--coral-700)', lineHeight: 1.5 }}>{briefHeadline}</div>
+          </div>
+        )}
+
+        {/* 블록 종료 +20분 미체크 인앱 넛지(#224 T1) — 푸시가 막혀 대체된 것이라 앱을 열었을
+            때만 보인다. 닫으면(X) 같은 블록은 localStorage 로 다시 안 뜬다(반복 노출 방지). */}
+        {!agendaLoading && uncheckedBlocks.length > 0 && (
+          <div
+            role="status"
+            style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '10px 12px', borderRadius: 12, border: '1px solid var(--coral-200)', background: 'var(--brand-soft)' }}
+          >
+            <BellRinging size={16} color="var(--brand-ink)" weight="fill" style={{ flexShrink: 0 }} />
+            <button
+              onClick={openFirstUnchecked}
+              style={{ flex: 1, minWidth: 0, textAlign: 'left', background: 'none', border: 'none', padding: 0, cursor: 'pointer', fontFamily: 'inherit' }}
+            >
+              <div style={{ fontSize: 12, fontWeight: 700, color: 'var(--brand-ink)' }}>
+                확인 안 한 작업이 있어요
+              </div>
+              <div style={{ fontSize: 11, color: 'var(--text-2)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                {uncheckedBlocks.length === 1
+                  ? uncheckedBlocks[0].title
+                  : `${uncheckedBlocks[0].title} 외 ${uncheckedBlocks.length - 1}건`}
+              </div>
+            </button>
+            <button
+              onClick={dismissNudge}
+              aria-label="닫기"
+              style={{ width: 26, height: 26, borderRadius: 9999, border: 'none', background: 'transparent', color: 'var(--text-2)', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}
+            >
+              <X size={12} weight="bold" />
+            </button>
           </div>
         )}
 


### PR DESCRIPTION
## 요약

이슈 #224 (T1) 구현 — 계획된 블록이 끝난 뒤 +20분이 지났는데 체크인(성공/실패 기록)이
없으면, 앱을 열었을 때 인앱으로만 알려준다. **푸시가 아니다** — 알림 클래스 3종 DB
CHECK 제약과 주간 발송 예산(`PUSH_WEEKLY_BUDGET=3`)에 막혀서 대체한 것이라
`/notifications/*` 는 건드리지 않았다.

## 판정 로직 — 백엔드 새 API 없이 프론트 계산

`src/types/openapi.d.ts` 확인 결과:
- `GET /today/agenda` 의 `AgendaCard` 에는 **종료 시각이 없다** (estimatedMinutes 만 있음, status 는 있음)
- `GET /plans/weekly` 의 `WeeklyBlock` 에는 **체크인 여부가 없다** (startAt/endAt 은 있음, status 없음)

TodayScreen 이 이미 이 둘을 `actionId` 로 조인해 시각 칩을 채우고 있어(`todayBlockIndex`,
#66 계열), 같은 조인을 판정에도 재사용했다. 새 엔드포인트·새 필드를 지어내지 않았다.

순수 함수로 분리: `src/lib/uncheckedBlocks.ts`
- `findUncheckedBlocks(tasks, plan, todayStr, now)` — "종료 +20분 지났는데 status 가
  done/partial_done/failed/recovery_pending 이 아님(=체크인 안 함)" 인 블록을 찾는다.
  네트워크·localStorage 를 건드리지 않는 순수 함수.
- `filterDismissedBlocks` / `dismissUncheckedBlocks` — 닫은 항목은 localStorage 에
  actionId 로 남겨 반복 노출을 막는다 (`IosInstallCard` #11 과 같은 패턴).

20분 유예는 이슈에 적힌 실험 계획(L3-2) 값을 그대로 썼다 (근거: 근접 창 60분, D3).

## 노출 위치 — 왜 인박스가 아니라 TodayScreen + 탭바인가

기존 `InboxScreen`/`InboxItemCard` 는 `inboxApi` 로 영속되는 실제 `InboxItem`(할 일/
처리됨/보관 3-상태)을 다루는 화면이다. 이번 넛지는 서버에 아무것도 쓰지 않는
**프론트 전용 계산값**이라 인박스의 상태 모델(status/필터/승격)에 억지로 끼워 넣으면
개념이 어긋난다. 대신:

1. **TodayScreen 안 배너** — 체크인 흐름(할 일/부분/실패, 자세히)이 이미 이 화면에
   있으므로, 넛지를 탭하면 기존 "row 클릭 → hero 로 promote" 동작을 그대로 재사용해
   바로 체크인으로 이어진다. 새 컴포넌트 없이 인라인으로 구현.
2. **탭바('오늘 실행') 점 배지** — `TabBar.tsx` 에 `dotTabs` prop 을 추가(기존 컴포넌트
   확장, 새 컴포넌트 아님). 앱 진입 시 탭을 보자마자 "확인 안 한 게 있다/없다"만
   전달하고, 정확한 건수·내용은 화면 안 배너가 말해준다.

## 반복 노출 방지

배너를 닫으면(X) 그 블록의 `actionId` 를 localStorage(`reaction.uncheckedNudgeDismissed`)에
남긴다. 실제로 체크인하면(status 변경) 판정 자체가 빠지므로 자연히 사라진다. 최근
200개까지만 보존해 무한정 쌓이지 않는다.

## 확인

- `npm run build` (tsc + vite build) 통과
- 이 저장소엔 테스트 러너가 설정돼 있지 않아(vitest/jest 없음) 별도 유닛 테스트는
  추가하지 않았다 — `findUncheckedBlocks` 는 순수 함수라 러너가 생기면 바로 테스트
  가능한 형태로 분리해 뒀다.

## 못 한 것

- BE 쪽 `push_gate` 차단 사유 로깅(quiet_hours/class_dedup/weekly_budget)은 이슈에
  적힌 대로 이 PR과 무관한 별도 선행 작업이라 손대지 않았다.

Refs #224