### PR TITLE
feat(goals): 궁극적 목표 만다라트 4개 화면(S29~S32)

### DIFF
--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -57,6 +57,8 @@ export function AppShell() {
   const [plannedMilestones, setPlannedMilestones] = useState<MilestoneDraft[] | null>(null);
   // 앱 사용 중 딥 인터뷰로 진입했을 때 돌아갈 화면(#216). 온보딩 경로면 null.
   const [interviewReturnTo, setInterviewReturnTo] = useState<ScreenId | null>(null);
+  // 만다라트 화면이 볼 궁극목표 id(#220). 목표 화면에서 진입하면 채워지고, 직접 진입하면 null.
+  const [mandalaGoalId, setMandalaGoalId] = useState<string | null>(null);
   // 실제 로그인 화면(구글/데모)을 보여줘야 하는지 — stub 자동 로그인이 꺼졌거나(?login=1) 401 뒤 재로그인 필요할 때.
   const [needsLogin, setNeedsLogin] = useState(false);
   const [authBusy, setAuthBusy] = useState(false);
@@ -286,7 +288,7 @@ export function AppShell() {
 
   return (
     <NavigationContext.Provider
-      value={{ screen, tab, setScreen, setTab, user, onboardingState, isBootstrapping, weekOffset, setWeekOffset, interviewSessionId, setInterviewSessionId, plannedMilestones, setPlannedMilestones, interviewReturnTo, setInterviewReturnTo }}
+      value={{ screen, tab, setScreen, setTab, user, onboardingState, isBootstrapping, weekOffset, setWeekOffset, interviewSessionId, setInterviewSessionId, plannedMilestones, setPlannedMilestones, interviewReturnTo, setInterviewReturnTo, mandalaGoalId, setMandalaGoalId }}
     >
       <ToastProvider>
         {/* 뷰포트에 맞는 트리 하나만 마운트(둘 다 마운트 후 CSS 로만 숨기면 데이터 페칭이 2배로 나감). */}

--- a/src/app/ReActionMerged.tsx
+++ b/src/app/ReActionMerged.tsx
@@ -10,6 +10,9 @@ import { WeeklyPlanGenerationScreen } from '../screens/WeeklyPlanGenerationScree
 import { MorningBriefScreen } from '../screens/MorningBriefScreen';
 import { InboxScreen } from '../screens/InboxScreen';
 import { GoalsScreen } from '../screens/GoalsScreen';
+import { UltimateGoalInterviewScreen } from '../screens/UltimateGoalInterviewScreen';
+import { MandalaDraftScreen } from '../screens/MandalaDraftScreen';
+import { MandalaScreen } from '../screens/MandalaScreen';
 import { SettingsScreen } from '../screens/SettingsScreen';
 import { MyInfoScreen } from '../screens/MyInfoScreen';
 import { MergedTodayScreen } from '../screens/TodayScreen';
@@ -46,6 +49,9 @@ const NAV_META: Record<ScreenId, { label: string; back: ScreenId | null }> = {
   'inbox':                  { label: 'LIFE INBOX',     back: null },
   'review':                 { label: '주간 리뷰',      back: null },
   'goals':                  { label: '목표 관리',      back: 'today' },
+  'ultimate-interview':     { label: '궁극적 목표',    back: 'goals' },
+  'mandala-draft':          { label: '만다라트 초안',  back: 'goals' },
+  'mandala':                { label: '만다라트',       back: 'goals' },
   'settings':               { label: '설정',           back: 'today' },
   'my-info':                { label: '내 정보',        back: 'settings' },
 };
@@ -94,7 +100,7 @@ interface ReActionMergedProps {
 }
 
 export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
-  const { screen, tab, setScreen, setTab, setWeekOffset, interviewReturnTo, setInterviewReturnTo } = useNavigation();
+  const { screen, tab, setScreen, setTab, setWeekOffset, interviewReturnTo, setInterviewReturnTo, mandalaGoalId, setMandalaGoalId } = useNavigation();
 
   // 초기값 비움 → /today/agenda 로딩 중엔 TodayScreen 의 스켈레톤이 대신 표시된다.
   // 실패 시에도 더미로 가리지 않고 빈 목록 + 정직 배너를 보여준다.
@@ -298,6 +304,35 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
         {screen === 'inbox' && <InboxScreen />}
         {screen === 'review' && <WeeklyReviewScreenV2 />}
         {screen === 'goals' && <GoalsScreen />}
+        {/* 궁극적 목표 만다라트(#220) — S29 인터뷰 → S30 초안 승인 → S31 상시 뷰. */}
+        {screen === 'ultimate-interview' && (
+          <UltimateGoalInterviewScreen
+            onGoalReady={(goalId) => { setMandalaGoalId(goalId); setScreen('mandala-draft'); }}
+            onCancel={() => setScreen('goals')}
+          />
+        )}
+        {screen === 'mandala-draft' && (
+          // goalId 없이 들어오면 초안을 만들 대상이 없다 — 인터뷰부터 다시 시작한다.
+          mandalaGoalId ? (
+            <MandalaDraftScreen
+              goalId={mandalaGoalId}
+              onApproved={(goalId) => { setMandalaGoalId(goalId); setScreen('mandala'); }}
+              onLeave={() => setScreen('goals')}
+            />
+          ) : (
+            <UltimateGoalInterviewScreen
+              onGoalReady={(goalId) => { setMandalaGoalId(goalId); setScreen('mandala-draft'); }}
+              onCancel={() => setScreen('goals')}
+            />
+          )
+        )}
+        {screen === 'mandala' && (
+          <MandalaScreen
+            goalId={mandalaGoalId}
+            onStartUltimate={() => setScreen('ultimate-interview')}
+            onBuildMandala={(goalId) => { setMandalaGoalId(goalId); setScreen('mandala-draft'); }}
+          />
+        )}
         {screen === 'settings' && <SettingsScreen />}
         {screen === 'my-info' && <MyInfoScreen />}
       </div>

--- a/src/components/MandalaCellSheet.tsx
+++ b/src/components/MandalaCellSheet.tsx
@@ -1,0 +1,330 @@
+import React, { useEffect, useState } from 'react';
+import { X, LockSimple, Sparkle, PencilSimple, Check, ArrowUpRight, Gauge } from '@phosphor-icons/react';
+import { friendlyError, goalsApi } from '../lib/api';
+import { GOAL_STATUS_META } from '../data';
+import { SOURCE_LABEL, type MandalaBoard, type MandalaSlot } from '../lib/mandala';
+import type { ApiGoal, GoalTier, MandalaNode } from '../types/api';
+import { ErrorBanner } from './ErrorBanner';
+
+// S32 — 셀 상세 바텀시트.
+//
+// 두 곳에서 쓴다:
+//  · mode="tree"  승인된 만다라(S31). 저장은 즉시 서버로(U9), 축은 승격(U10) 가능.
+//  · mode="draft" 승인 전 초안(S30). 서버 호출 없이 로컬 편집만 — 최종 승인(U6) body 에 실려 나간다.
+//
+// 어느 모드든 누가 썼는지(source)·왜 그런지(whyText)·직접 체크했는지(completedAt)는 계속 보존해 보여준다.
+
+export type CellSheetMode = 'tree' | 'draft';
+
+interface MandalaCellSheetProps {
+  board: MandalaBoard;
+  slot: MandalaSlot;
+  mode: CellSheetMode;
+  onClose: () => void;
+  /** tree 모드 — U9 응답 노드를 상위로 올려 격자를 갱신한다. */
+  onUpdated?: (node: MandalaNode) => void;
+  /** tree 모드 — U10 승격 성공. */
+  onPromoted?: (goal: ApiGoal, slot: MandalaSlot) => void;
+  /** draft 모드 — 로컬 편집본 반영(서버 호출 없음). */
+  onLocalSave?: (slot: MandalaSlot, patch: { title: string; whyText: string | null }) => void;
+}
+
+const TIER_CHOICES: GoalTier[] = ['focus', 'maintain', 'parked'];
+
+export function MandalaCellSheet({ board, slot, mode, onClose, onUpdated, onPromoted, onLocalSave }: MandalaCellSheetProps) {
+  const [title, setTitle] = useState(slot.title);
+  const [whyText, setWhyText] = useState(slot.whyText ?? '');
+  const [busy, setBusy] = useState<null | 'save' | 'complete' | 'promote'>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [promoted, setPromoted] = useState<ApiGoal | null>(null);
+  const [tier, setTier] = useState<GoalTier>('focus');
+
+  // 다른 칸을 눌러 시트 내용이 바뀌면 편집 버퍼도 그 칸으로 되돌린다.
+  useEffect(() => {
+    setTitle(slot.title);
+    setWhyText(slot.whyText ?? '');
+    setError(null);
+    setPromoted(null);
+  }, [slot.nodeId, slot.role, slot.axisIndex, slot.cellIndex, slot.title, slot.whyText]);
+
+  const axisTitle = slot.axisIndex >= 0 ? board.axes[slot.axisIndex]?.slot.title : null;
+  const position =
+    slot.role === 'core'
+      ? '가운데 칸 · 궁극적 목표'
+      : slot.role === 'axis'
+        ? `${slot.axisIndex + 1}번 축 · 하위 목표`
+        : `${axisTitle || `${slot.axisIndex + 1}번 축`} · ${slot.cellIndex + 1}번째 칸`;
+
+  // 중앙 칸은 궁극목표 본문이라 여기서 고치지 않는다(재인터뷰로 다듬는다).
+  const canEdit = slot.role !== 'core' && (mode === 'draft' || slot.nodeId != null);
+  const canComplete = mode === 'tree' && slot.nodeId != null && slot.role === 'leaf';
+  // 승격은 축(depth=1)만 — 중앙·개별 셀을 승격하려 하면 서버가 422 를 준다.
+  const canPromote = mode === 'tree' && slot.role === 'axis' && slot.nodeId != null && slot.filled;
+
+  const dirty = title !== slot.title || (whyText.trim() || null) !== (slot.whyText ?? null);
+
+  const save = async () => {
+    if (!canEdit) return;
+    const patch = { title: title.trim(), whyText: whyText.trim() || null };
+    if (mode === 'draft') {
+      onLocalSave?.(slot, patch);
+      onClose();
+      return;
+    }
+    if (!slot.nodeId) return;
+    setBusy('save');
+    setError(null);
+    try {
+      const node = await goalsApi.updateMandalaNode(slot.nodeId, patch);
+      onUpdated?.(node);
+      onClose();
+    } catch (err: unknown) {
+      setError(friendlyError(err, '칸을 저장하지 못했어요.'));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const toggleComplete = async () => {
+    if (!canComplete || !slot.nodeId) return;
+    setBusy('complete');
+    setError(null);
+    try {
+      const node = await goalsApi.updateMandalaNode(slot.nodeId, { completed: slot.completedAt == null });
+      onUpdated?.(node);
+    } catch (err: unknown) {
+      setError(friendlyError(err, '완료 상태를 바꾸지 못했어요.'));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const promote = async () => {
+    if (!canPromote || !slot.nodeId) return;
+    setBusy('promote');
+    setError(null);
+    try {
+      const goal = await goalsApi.promoteMandalaNode(slot.nodeId, { goalTier: tier });
+      setPromoted(goal);
+      onPromoted?.(goal, slot);
+    } catch (err: unknown) {
+      setError(friendlyError(err, '이 축을 목표로 올리지 못했어요.'));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  return (
+    <div
+      onClick={onClose}
+      style={{ position: 'absolute', inset: 0, background: 'rgba(26,23,20,.45)', zIndex: 60, display: 'flex', alignItems: 'flex-end' }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-label="칸 상세"
+        style={{ background: 'var(--surface-raised)', width: '100%', borderRadius: '24px 24px 0 0', padding: '12px 20px 32px', boxShadow: 'var(--shadow-xl)', maxHeight: '86%', overflowY: 'auto' }}
+      >
+        <div style={{ width: 36, height: 4, borderRadius: 9999, background: 'var(--sand-300)', margin: '0 auto 14px' }} />
+
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 10, marginBottom: 12 }}>
+          <div style={{ minWidth: 0 }}>
+            <div style={{ fontSize: 11, fontWeight: 700, color: 'var(--text-3)', marginBottom: 3 }}>{position}</div>
+            <h3 style={{ fontSize: 17, fontWeight: 800, margin: 0, letterSpacing: '-0.01em', wordBreak: 'keep-all', overflowWrap: 'anywhere', lineHeight: 1.4 }}>
+              {slot.filled ? slot.title : '아직 비어 있는 칸'}
+            </h3>
+          </div>
+          <button onClick={onClose} aria-label="닫기" style={{ width: 44, height: 44, flexShrink: 0, borderRadius: 9999, border: 'none', background: 'var(--sand-100)', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer' }}>
+            <X size={12} color="var(--text-2)" />
+          </button>
+        </div>
+
+        {/* 출처·상태 배지 — 승인 후에도 누가 썼는지, 직접 체크했는지를 계속 보존해 보여준다. */}
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 5, marginBottom: 12 }}>
+          <Badge icon={slot.source === 'user' ? <PencilSimple size={10} weight="fill" /> : <Sparkle size={10} weight="fill" />}>
+            {SOURCE_LABEL[slot.source]}
+          </Badge>
+          {slot.locked && <Badge icon={<LockSimple size={10} weight="fill" />}>내가 직접 말한 축 · 재생성 제외</Badge>}
+          {slot.completedAt && <Badge tone="success" icon={<Check size={10} weight="bold" />}>{formatDone(slot.completedAt)} 완료</Badge>}
+          {slot.role === 'axis' && slot.progress != null && (
+            <Badge icon={<Gauge size={10} weight="fill" />}>
+              깊이 {Math.round(slot.progress * 100)}% · 폭 {slot.coverage == null ? '—' : `${Math.round(slot.coverage * 100)}%`}
+            </Badge>
+          )}
+          {slot.promotedGoalId && <Badge tone="brand" icon={<ArrowUpRight size={10} weight="bold" />}>이미 학기 목표로 올린 축</Badge>}
+        </div>
+
+        {!slot.filled && (
+          <div style={{ padding: '12px 14px', borderRadius: 12, border: '1px dashed var(--sand-300)', background: 'var(--surface-ground)', fontSize: 12, color: 'var(--text-2)', lineHeight: 1.6, marginBottom: 12 }}>
+            {slot.gapReason
+              ? `AI가 이 칸을 비워 뒀어요 — ${slot.gapReason}`
+              : '이 칸은 비어 있어요. 억지로 채우기보다, 정말 할 일이 생겼을 때 직접 적는 게 좋아요.'}
+          </div>
+        )}
+
+        {error && <div style={{ marginBottom: 12 }}><ErrorBanner>{error}</ErrorBanner></div>}
+
+        {canEdit && (
+          <>
+            <Field label="제목">
+              <input
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                placeholder={slot.role === 'axis' ? '축 이름 (10자 이내)' : '이 칸에서 할 일 (16자 이내)'}
+                style={inputStyle}
+              />
+            </Field>
+            <Field label="왜 이 칸인가 (선택)">
+              <textarea
+                value={whyText}
+                onChange={(e) => setWhyText(e.target.value)}
+                rows={3}
+                placeholder="나중의 내가 이 칸을 왜 골랐는지 알 수 있게"
+                style={{ ...inputStyle, height: 'auto', padding: '10px 14px', resize: 'vertical', lineHeight: 1.55 }}
+              />
+            </Field>
+            <p style={{ fontSize: 11, color: 'var(--text-3)', margin: '0 0 14px', lineHeight: 1.5 }}>
+              {mode === 'draft'
+                ? '승인 전 편집은 이 기기에만 저장돼요. 마지막에 [이대로 확정]을 눌러야 서버에 남아요.'
+                : '저장하면 이 칸의 출처가 “내가 씀”으로 바뀌어요.'}
+            </p>
+          </>
+        )}
+
+        {/* 완료 체크 — 셀(leaf)만. 축·중앙은 롤업이라 직접 체크하지 않는다. */}
+        {canComplete && (
+          <button
+            onClick={toggleComplete}
+            disabled={busy != null}
+            style={{
+              width: '100%',
+              minHeight: 44,
+              marginBottom: 10,
+              borderRadius: 12,
+              border: `1.5px solid ${slot.completedAt ? 'var(--success)' : 'var(--sand-200)'}`,
+              background: slot.completedAt ? 'var(--success-soft)' : 'var(--surface-ground)',
+              color: slot.completedAt ? 'var(--text-1)' : 'var(--text-2)',
+              fontFamily: 'inherit',
+              fontSize: 13,
+              fontWeight: 700,
+              cursor: busy ? 'wait' : 'pointer',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 6,
+              opacity: busy === 'complete' ? 0.6 : 1,
+            }}
+          >
+            <Check size={14} weight="bold" />
+            {slot.completedAt ? '완료 취소하기' : '이 칸 완료로 체크'}
+          </button>
+        )}
+
+        {/* 승격(U10) — 축만. 이미 승격했으면 새로 만들지 않고 기존 목표를 그대로 돌려준다(멱등). */}
+        {canPromote && (
+          <div style={{ marginTop: 4, marginBottom: 12, padding: '12px 14px', borderRadius: 14, background: 'var(--brand-soft)', border: '1px solid var(--coral-200)' }}>
+            <div style={{ fontSize: 12, fontWeight: 800, color: 'var(--coral-700)', marginBottom: 4 }}>이번 학기 목표로 올리기</div>
+            <p style={{ fontSize: 11, color: 'var(--coral-700)', margin: '0 0 9px', lineHeight: 1.55, opacity: 0.9 }}>
+              이 축을 이번 학기에 굴릴 목표로 올려요. 같은 축을 다시 눌러도 목표가 중복으로 쌓이지는 않아요.
+            </p>
+            <div style={{ display: 'flex', gap: 5, marginBottom: 9 }}>
+              {TIER_CHOICES.map((t) => {
+                const meta = GOAL_STATUS_META[t];
+                const active = tier === t;
+                return (
+                  <button
+                    key={t}
+                    onClick={() => setTier(t)}
+                    style={{ flex: 1, minHeight: 36, borderRadius: 9999, fontSize: 11, fontWeight: 700, fontFamily: 'inherit', background: active ? meta.color : 'var(--surface-raised)', color: active ? '#FFFCF6' : 'var(--text-3)', border: `1px solid ${active ? meta.color : 'var(--sand-200)'}`, cursor: 'pointer' }}
+                  >
+                    {meta.label}
+                  </button>
+                );
+              })}
+            </div>
+            {promoted ? (
+              <div style={{ fontSize: 12, color: 'var(--coral-700)', fontWeight: 700, lineHeight: 1.55 }}>
+                「{promoted.title}」을(를) 목표로 올렸어요. 목표 화면에서 이어서 계획을 세울 수 있어요.
+              </div>
+            ) : (
+              <button
+                onClick={promote}
+                disabled={busy != null}
+                style={{ width: '100%', minHeight: 44, borderRadius: 12, border: 'none', background: 'var(--brand-surface)', color: '#FFFCF6', fontFamily: 'inherit', fontSize: 13, fontWeight: 700, cursor: busy ? 'wait' : 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6, opacity: busy === 'promote' ? 0.6 : 1 }}
+              >
+                <ArrowUpRight size={14} weight="bold" />
+                {busy === 'promote' ? '올리는 중…' : '이 축을 목표로 올리기'}
+              </button>
+            )}
+          </div>
+        )}
+
+        <div style={{ display: 'flex', gap: 8 }}>
+          <button onClick={onClose} style={{ flex: 1, minHeight: 48, borderRadius: 12, border: '1px solid var(--sand-200)', background: 'transparent', color: 'var(--text-2)', fontWeight: 600, fontSize: 13, fontFamily: 'inherit', cursor: 'pointer' }}>
+            닫기
+          </button>
+          {canEdit && (
+            <button
+              onClick={save}
+              disabled={busy != null || !dirty}
+              style={{ flex: 2, minHeight: 48, borderRadius: 12, border: 'none', background: 'var(--brand-surface)', color: '#FFFCF6', fontWeight: 700, fontSize: 14, fontFamily: 'inherit', cursor: busy || !dirty ? 'default' : 'pointer', opacity: busy != null || !dirty ? 0.45 : 1 }}
+            >
+              {busy === 'save' ? '저장 중…' : '저장'}
+            </button>
+          )}
+        </div>
+        {slot.role === 'core' && (
+          <p style={{ fontSize: 11, color: 'var(--text-3)', margin: '10px 0 0', lineHeight: 1.55 }}>
+            가운데 칸은 궁극적 목표 본문이라 여기서 고치지 않아요. 목표 화면에서 다시 인터뷰하면 이 문장을 다듬을 수 있어요.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label style={{ display: 'block', marginBottom: 12 }}>
+      <span style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-3)', letterSpacing: '0.04em', display: 'block', marginBottom: 6 }}>{label}</span>
+      {children}
+    </label>
+  );
+}
+
+function Badge({ children, icon, tone = 'neutral' }: { children: React.ReactNode; icon?: React.ReactNode; tone?: 'neutral' | 'success' | 'brand' }) {
+  const palette =
+    tone === 'success'
+      ? { bg: 'var(--success-soft)', fg: 'var(--text-1)', bd: 'var(--success)' }
+      : tone === 'brand'
+        ? { bg: 'var(--brand-soft)', fg: 'var(--coral-700)', bd: 'var(--coral-200)' }
+        : { bg: 'var(--sand-100)', fg: 'var(--text-2)', bd: 'var(--sand-200)' };
+  return (
+    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4, minHeight: 24, padding: '0 9px', borderRadius: 9999, background: palette.bg, color: palette.fg, border: `1px solid ${palette.bd}`, fontSize: 11, fontWeight: 600, lineHeight: 1.4 }}>
+      {icon}
+      {children}
+    </span>
+  );
+}
+
+// 서버가 KST ISO 로 내려준다. 시각까지 보여줄 자리는 없어 날짜만 쓴다.
+function formatDone(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso.slice(0, 10);
+  return `${d.getMonth() + 1}월 ${d.getDate()}일`;
+}
+
+const inputStyle: React.CSSProperties = {
+  width: '100%',
+  minHeight: 44,
+  borderRadius: 12,
+  border: '1px solid var(--sand-200)',
+  background: 'var(--surface-ground)',
+  padding: '0 14px',
+  fontSize: 14,
+  fontFamily: 'inherit',
+  color: 'var(--text-1)',
+  outline: 'none',
+  boxSizing: 'border-box',
+};

--- a/src/components/MandalaGrid.tsx
+++ b/src/components/MandalaGrid.tsx
@@ -1,0 +1,484 @@
+import React from 'react';
+import { Check, LockSimple, Sparkle, PencilSimple, CaretRight } from '@phosphor-icons/react';
+import {
+  AXIS_COUNT,
+  CELL_COUNT,
+  SOURCE_LABEL,
+  axisDoneCount,
+  axisFilledCount,
+  blockOf,
+  fullGrid,
+  slotAriaLabel,
+  type MandalaBoard,
+  type MandalaSlot,
+} from '../lib/mandala';
+
+// 만다라트 격자 — 이 기능의 핵심은 격자가 아니라 **여백**이다.
+// AI가 못 채운 칸은 억지로 채우지 않고 점선 빈 칸으로 두고, 사용자가 직접 말한 축은
+// 자물쇠로 표시해 재생성이 못 건드린다는 걸 보인다(#220).
+//
+// 색만으로 완료/미완료/빈칸/AI폴백을 구분하지 않는다 — 테두리(실선/점선)와 아이콘을 함께 쓴다.
+
+// ── 셀 한 칸 ──────────────────────────────────────────────────
+
+interface CellProps {
+  board: MandalaBoard;
+  slot: MandalaSlot;
+  /** 이 칸이 블록 한가운데인지 — 조금 더 강조한다. */
+  center?: boolean;
+  /** 9×9 조망처럼 아주 작게 그릴 때. 텍스트를 줄이고 터치 타겟도 작아진다. */
+  compact?: boolean;
+  onClick?: () => void;
+  disabled?: boolean;
+}
+
+function cellVisual(slot: MandalaSlot, center: boolean) {
+  if (!slot.filled) {
+    return {
+      background: 'transparent',
+      border: '1.5px dashed var(--sand-300)',
+      color: 'var(--text-4)',
+    };
+  }
+  if (slot.completedAt) {
+    return {
+      background: 'var(--success-soft)',
+      border: '1.5px solid var(--success)',
+      color: 'var(--text-1)',
+    };
+  }
+  // 규칙 폴백(source='rule')은 AI가 제대로 못 채운 칸이다 — 확정된 칸처럼 보이면 안 된다.
+  if (slot.source === 'rule') {
+    return {
+      background: 'var(--surface-sunken)',
+      border: '1.5px dashed var(--sand-300)',
+      color: 'var(--text-2)',
+    };
+  }
+  if (center) {
+    return {
+      background: 'var(--brand-soft)',
+      border: '1.5px solid var(--coral-200)',
+      color: 'var(--coral-700)',
+    };
+  }
+  return {
+    background: 'var(--surface-raised)',
+    border: '1px solid var(--sand-200)',
+    color: 'var(--text-1)',
+  };
+}
+
+export function MandalaCellButton({ board, slot, center = false, compact = false, onClick, disabled }: CellProps) {
+  const v = cellVisual(slot, center);
+  const label = slotAriaLabel(board, slot);
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={label}
+      // 전체 조망(compact)은 컨테이너가 aria-hidden 이다 — 그 안의 버튼이 포커스를
+      // 받으면 스크린리더가 "이름 없는 버튼"에 갇힌다. 탭 순서에서 빼둔다.
+      tabIndex={compact ? -1 : undefined}
+      style={{
+        position: 'relative',
+        aspectRatio: '1 / 1',
+        width: '100%',
+        minWidth: 0,
+        borderRadius: compact ? 6 : 12,
+        padding: compact ? 2 : '8px 6px',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 3,
+        fontFamily: 'inherit',
+        fontSize: compact ? 8 : center ? 12 : 11,
+        fontWeight: center ? 800 : slot.filled ? 600 : 500,
+        lineHeight: 1.3,
+        textAlign: 'center',
+        wordBreak: 'keep-all',
+        overflowWrap: 'anywhere',
+        cursor: disabled ? 'default' : 'pointer',
+        overflow: 'hidden',
+        ...v,
+      }}
+    >
+      {/* 상태 아이콘 — 색만으로 구분하지 않기 위한 병행 표시. */}
+      {!compact && (slot.completedAt || slot.locked || (slot.filled && slot.source === 'user')) && (
+        <span
+          aria-hidden
+          style={{
+            position: 'absolute',
+            top: 4,
+            right: 4,
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 2,
+            color: slot.completedAt ? 'var(--success)' : 'var(--text-3)',
+          }}
+        >
+          {slot.locked && <LockSimple size={9} weight="fill" />}
+          {slot.filled && slot.source === 'user' && !slot.completedAt && <PencilSimple size={9} weight="fill" />}
+          {slot.completedAt && <Check size={10} weight="bold" />}
+        </span>
+      )}
+      <span
+        style={{
+          display: '-webkit-box',
+          WebkitLineClamp: compact ? 2 : 3,
+          WebkitBoxOrient: 'vertical',
+          overflow: 'hidden',
+          textDecoration: slot.completedAt ? 'line-through' : undefined,
+          opacity: slot.completedAt ? 0.75 : 1,
+        }}
+      >
+        {slot.filled ? slot.title : compact ? '' : '빈 칸'}
+      </span>
+      {/* 축 칸은 진행률을 얇은 막대로 함께 — 진척은 깊이(progress), 폭은 coverage. */}
+      {!compact && slot.role === 'axis' && slot.progress != null && (
+        <span aria-hidden style={{ width: '70%', height: 3, borderRadius: 9999, background: 'var(--sand-200)', overflow: 'hidden' }}>
+          <span style={{ display: 'block', height: '100%', width: `${Math.round(slot.progress * 100)}%`, background: 'var(--brand)' }} />
+        </span>
+      )}
+    </button>
+  );
+}
+
+// ── ① 3×3 드릴다운 (기본 뷰) ─────────────────────────────────
+// 375~430pt 폭에서 81칸을 균등 배치하면 셀 한 변이 ≈38pt — 최소 터치 타겟(44pt) 미달에
+// 한글도 찌그러진다. 기본은 3×3 한 블록만 크게 그린다.
+
+interface BlockViewProps {
+  board: MandalaBoard;
+  /** null = 중앙 블록(궁극목표 + 8축). 숫자 = 그 축이 한가운데로 오는 블록. */
+  axisIndex: number | null;
+  onSelect: (slot: MandalaSlot) => void;
+}
+
+export function MandalaBlockView({ board, axisIndex, onSelect }: BlockViewProps) {
+  const { center, ring } = blockOf(board, axisIndex);
+  // 3×3 자리 배치 — 가운데(4)는 center, 나머지는 읽기 순서대로 ring.
+  const cells: (MandalaSlot | null)[] = [];
+  let r = 0;
+  for (let i = 0; i < 9; i += 1) {
+    if (i === 4) cells.push(null);
+    else {
+      cells.push(ring[r] ?? null);
+      r += 1;
+    }
+  }
+
+  return (
+    <div
+      style={{ display: 'grid', gridTemplateColumns: 'repeat(3, minmax(0, 1fr))', gap: 6 }}
+    >
+      {cells.map((slot, i) => {
+        if (i === 4) {
+          return (
+            <MandalaCellButton
+              key="center"
+              board={board}
+              slot={center}
+              center
+              onClick={() => onSelect(center)}
+            />
+          );
+        }
+        if (!slot) return <div key={i} />;
+        return (
+          <MandalaCellButton key={`${slot.role}-${slot.axisIndex}-${slot.cellIndex}`} board={board} slot={slot} onClick={() => onSelect(slot)} />
+        );
+      })}
+    </div>
+  );
+}
+
+// ── ② 9×9 전체 조망 (읽기 전용) ──────────────────────────────
+// 셀 탭 = 그 블록으로 줌인. 편집은 여기서 하지 않는다 — 터치 타겟이 너무 작다.
+
+interface FullViewProps {
+  board: MandalaBoard;
+  onZoom: (axisIndex: number | null) => void;
+}
+
+export function MandalaFullView({ board, onZoom }: FullViewProps) {
+  const placed = fullGrid(board);
+  return (
+    <div>
+      {/* 81칸을 role="grid" 로 그대로 노출하면 스크린리더로는 사실상 조작이 불가능하다.
+          여기는 시각 전용으로 감추고, 의미는 목록 뷰(MandalaListView)가 담당한다. */}
+      <div
+        aria-hidden="true"
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(9, minmax(0, 1fr))',
+          gap: 2,
+          padding: 6,
+          borderRadius: 14,
+          background: 'var(--surface-sunken)',
+          border: '1px solid var(--sand-200)',
+        }}
+      >
+        {placed.map((p) => {
+          // 3×3 블록 경계를 시각적으로 드러낸다 — 없으면 81칸이 그냥 한 덩어리로 뭉친다.
+          const blockGapTop = p.row % 3 === 0 && p.row !== 0;
+          const blockGapLeft = p.col % 3 === 0 && p.col !== 0;
+          const targetAxis = p.isAxisInCore ? p.slot.axisIndex : p.slot.role === 'core' ? null : p.slot.axisIndex;
+          return (
+            <div
+              key={p.key}
+              style={{
+                gridRow: p.row + 1,
+                gridColumn: p.col + 1,
+                marginTop: blockGapTop ? 3 : 0,
+                marginLeft: blockGapLeft ? 3 : 0,
+              }}
+            >
+              <MandalaCellButton
+                board={board}
+                slot={p.slot}
+                compact
+                center={p.slot.role === 'core' || (p.slot.role === 'axis' && !p.isAxisInCore)}
+                onClick={() => onZoom(targetAxis)}
+              />
+            </div>
+          );
+        })}
+      </div>
+      <p style={{ fontSize: 11, color: 'var(--text-3)', margin: '8px 4px 0', lineHeight: 1.5 }}>
+        전체 조망은 읽기 전용이에요. 칸을 누르면 그 블록으로 확대돼요.
+      </p>
+    </div>
+  );
+}
+
+// ── ③ 아코디언 목록 ──────────────────────────────────────────
+// prefers-reduced-motion / 스크린리더에서 기본이 되는 뷰이자, 격자의 의미 소스.
+
+interface ListViewProps {
+  board: MandalaBoard;
+  onSelect: (slot: MandalaSlot) => void;
+  openAxis: number | null;
+  onToggleAxis: (index: number | null) => void;
+}
+
+export function MandalaListView({ board, onSelect, openAxis, onToggleAxis }: ListViewProps) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      <button
+        type="button"
+        onClick={() => onSelect(board.core)}
+        style={{
+          textAlign: 'left',
+          padding: '12px 14px',
+          borderRadius: 14,
+          border: '1.5px solid var(--coral-200)',
+          background: 'var(--brand-soft)',
+          color: 'var(--coral-700)',
+          fontFamily: 'inherit',
+          fontSize: 14,
+          fontWeight: 800,
+          cursor: 'pointer',
+          wordBreak: 'keep-all',
+          overflowWrap: 'anywhere',
+          lineHeight: 1.5,
+        }}
+      >
+        <span style={{ display: 'block', fontSize: 11, fontWeight: 700, opacity: 0.8, marginBottom: 3 }}>궁극적 목표</span>
+        {board.core.filled ? board.core.title : '아직 비어 있어요'}
+      </button>
+
+      {board.axes.map((axis) => {
+        const open = openAxis === axis.index;
+        const filled = axisFilledCount(axis);
+        const done = axisDoneCount(axis);
+        return (
+          <div key={axis.index} style={{ borderRadius: 14, border: '1px solid var(--sand-200)', background: 'var(--surface-raised)', overflow: 'hidden' }}>
+            <button
+              type="button"
+              onClick={() => onToggleAxis(open ? null : axis.index)}
+              aria-expanded={open}
+              style={{
+                width: '100%',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 8,
+                padding: '12px 14px',
+                background: 'transparent',
+                border: 'none',
+                fontFamily: 'inherit',
+                cursor: 'pointer',
+                textAlign: 'left',
+              }}
+            >
+              <span className="tnum" style={{ width: 20, height: 20, flexShrink: 0, borderRadius: 9999, background: 'var(--sand-100)', color: 'var(--text-3)', fontSize: 10, fontWeight: 700, display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}>
+                {axis.index + 1}
+              </span>
+              <span style={{ flex: 1, minWidth: 0, fontSize: 13, fontWeight: 700, color: axis.slot.filled ? 'var(--text-1)' : 'var(--text-3)', wordBreak: 'keep-all', overflowWrap: 'anywhere' }}>
+                {axis.slot.filled ? axis.slot.title : '빈 축'}
+                {axis.slot.locked && <LockSimple size={10} weight="fill" style={{ marginLeft: 4, verticalAlign: 'middle' }} />}
+              </span>
+              <span className="tnum" style={{ fontSize: 11, color: 'var(--text-3)', flexShrink: 0 }}>
+                {done}/{CELL_COUNT} 완료 · {filled}칸 착수
+              </span>
+              <CaretRight size={12} color="var(--text-3)" style={{ flexShrink: 0, transform: open ? 'rotate(90deg)' : undefined, transition: 'transform 140ms' }} />
+            </button>
+            {open && (
+              <div style={{ padding: '0 10px 10px', display: 'flex', flexDirection: 'column', gap: 5 }}>
+                <button
+                  type="button"
+                  onClick={() => onSelect(axis.slot)}
+                  style={rowButtonStyle(true)}
+                >
+                  이 축 자세히 보기 · 이번 학기 목표로 승격
+                </button>
+                {axis.cells.map((cell) => (
+                  <button
+                    key={cell.cellIndex}
+                    type="button"
+                    onClick={() => onSelect(cell)}
+                    aria-label={slotAriaLabel(board, cell)}
+                    style={{
+                      ...rowButtonStyle(false),
+                      borderStyle: cell.filled && cell.source !== 'rule' ? 'solid' : 'dashed',
+                      color: cell.filled ? 'var(--text-1)' : 'var(--text-3)',
+                      background: cell.completedAt ? 'var(--success-soft)' : 'var(--surface-ground)',
+                    }}
+                  >
+                    <span className="tnum" style={{ fontSize: 10, color: 'var(--text-3)', flexShrink: 0 }}>{cell.cellIndex + 1}</span>
+                    <span style={{ flex: 1, minWidth: 0, wordBreak: 'keep-all', overflowWrap: 'anywhere', textDecoration: cell.completedAt ? 'line-through' : undefined }}>
+                      {cell.filled ? cell.title : '빈 칸 — 여기는 아직 비워 뒀어요'}
+                    </span>
+                    {cell.completedAt && <Check size={12} weight="bold" color="var(--success)" />}
+                    {cell.filled && cell.source === 'llm' && !cell.completedAt && <Sparkle size={11} weight="fill" color="var(--text-4)" />}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function rowButtonStyle(emphasis: boolean): React.CSSProperties {
+  return {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 8,
+    width: '100%',
+    minHeight: 40,
+    padding: '9px 11px',
+    borderRadius: 10,
+    border: emphasis ? '1px solid var(--coral-200)' : '1px solid var(--sand-200)',
+    background: emphasis ? 'var(--brand-soft)' : 'var(--surface-ground)',
+    color: emphasis ? 'var(--coral-700)' : 'var(--text-1)',
+    fontFamily: 'inherit',
+    fontSize: 12,
+    fontWeight: emphasis ? 700 : 500,
+    lineHeight: 1.45,
+    textAlign: 'left',
+    cursor: 'pointer',
+  };
+}
+
+// ── 축 선택 스트립 (드릴다운 네비게이션) ─────────────────────
+
+interface AxisStripProps {
+  board: MandalaBoard;
+  active: number | null;
+  onChange: (index: number | null) => void;
+}
+
+export function MandalaAxisStrip({ board, active, onChange }: AxisStripProps) {
+  return (
+    <div
+      style={{ display: 'flex', gap: 6, overflowX: 'auto', paddingBottom: 4, WebkitOverflowScrolling: 'touch' }}
+      role="tablist"
+      aria-label="만다라트 블록 선택"
+    >
+      <StripButton label="가운데" active={active === null} onClick={() => onChange(null)} />
+      {Array.from({ length: AXIS_COUNT }, (_, k) => {
+        const axis = board.axes[k];
+        return (
+          <StripButton
+            key={k}
+            label={axis.slot.filled ? axis.slot.title : `${k + 1}번 축`}
+            muted={!axis.slot.filled}
+            locked={axis.slot.locked}
+            active={active === k}
+            onClick={() => onChange(k)}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+function StripButton({ label, active, muted, locked, onClick }: { label: string; active: boolean; muted?: boolean; locked?: boolean; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      onClick={onClick}
+      style={{
+        flexShrink: 0,
+        height: 36,
+        padding: '0 12px',
+        borderRadius: 9999,
+        border: `1px solid ${active ? 'var(--brand-surface)' : muted ? 'var(--sand-300)' : 'var(--sand-200)'}`,
+        borderStyle: muted ? 'dashed' : 'solid',
+        background: active ? 'var(--brand-surface)' : 'var(--surface-raised)',
+        color: active ? '#FFFCF6' : muted ? 'var(--text-3)' : 'var(--text-2)',
+        fontFamily: 'inherit',
+        fontSize: 12,
+        fontWeight: active ? 700 : 600,
+        cursor: 'pointer',
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 4,
+        maxWidth: 140,
+        whiteSpace: 'nowrap',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+      }}
+    >
+      {locked && <LockSimple size={10} weight="fill" />}
+      {label}
+    </button>
+  );
+}
+
+// ── 진척도(깊이/폭) ──────────────────────────────────────────
+// 분모는 항상 8 고정 — 착수한 칸만으로 나누면 1칸 하고 100% 로 보이는 착시가 생긴다.
+
+export function MandalaProgress({ progress, coverage }: { progress: number | null; coverage: number | null }) {
+  if (progress == null && coverage == null) return null;
+  return (
+    <div style={{ display: 'flex', gap: 8 }}>
+      <Meter label="깊이 · 실제 완료" value={progress} color="var(--brand)" />
+      <Meter label="폭 · 착수한 칸" value={coverage} color="var(--sand-500)" />
+    </div>
+  );
+}
+
+function Meter({ label, value, color }: { label: string; value: number | null; color: string }) {
+  const pct = value == null ? 0 : Math.round(value * 100);
+  return (
+    <div style={{ flex: 1, padding: '9px 11px', borderRadius: 12, background: 'var(--surface-raised)', border: '1px solid var(--sand-200)' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 5 }}>
+        <span style={{ fontSize: 11, color: 'var(--text-3)', fontWeight: 600 }}>{label}</span>
+        <span className="tnum" style={{ fontSize: 12, fontWeight: 800, color: 'var(--text-1)' }}>{value == null ? '—' : `${pct}%`}</span>
+      </div>
+      <div style={{ height: 4, borderRadius: 9999, background: 'var(--sand-200)', overflow: 'hidden' }}>
+        <div style={{ height: '100%', width: `${pct}%`, background: color, borderRadius: 9999, transition: 'width 400ms ease' }} />
+      </div>
+    </div>
+  );
+}
+
+export { SOURCE_LABEL };

--- a/src/contexts/NavigationContext.tsx
+++ b/src/contexts/NavigationContext.tsx
@@ -30,6 +30,10 @@ export interface NavigationContextType {
   // 이게 없으면 목표가 바뀌어 다시 인터뷰한 사용자가 온보딩 한복판에 떨어진다.
   interviewReturnTo: ScreenId | null;
   setInterviewReturnTo: (s: ScreenId | null) => void;
+  // 만다라트 화면(S30/S31)이 볼 궁극목표의 goalId(#220). null 이면 S31 이 GET /goals 에서
+  // isUltimate 목표를 직접 찾는다 — 목표 화면을 거치지 않고 들어와도 동작해야 하기 때문.
+  mandalaGoalId: string | null;
+  setMandalaGoalId: (id: string | null) => void;
 }
 
 export const NavigationContext = createContext<NavigationContextType>({
@@ -48,6 +52,8 @@ export const NavigationContext = createContext<NavigationContextType>({
   setPlannedMilestones: () => {},
   interviewReturnTo: null,
   setInterviewReturnTo: () => {},
+  mandalaGoalId: null,
+  setMandalaGoalId: () => {},
 });
 
 export const useNavigation = () => useContext(NavigationContext);

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -398,7 +398,11 @@ export const interviewApi = {
       body: {},
     }),
 
-  slotCatalog: () => request<SlotCatalogEntry[]>('/interview/slot-catalog'),
+  // kind 생략 시 계획 인터뷰 카탈로그(하위호환, U0). 'ultimate' 는 궁극목표 인터뷰 슬롯.
+  slotCatalog: (kind?: InterviewKind) =>
+    kind
+      ? request<SlotCatalogEntry[]>(`/interview/slot-catalog?kind=${encodeURIComponent(kind)}`)
+      : request<SlotCatalogEntry[]>('/interview/slot-catalog'),
 };
 
 // ── Goals (S03·S26) ───────────────────────────────────────────

--- a/src/lib/mandala.ts
+++ b/src/lib/mandala.ts
@@ -1,0 +1,324 @@
+// 만다라트(9×9) 좌표 계산과 화면 모델 — S30(초안)·S31(상시 뷰)·S32(셀 상세) 공용.
+//
+// 서버는 좌표(renderHint)를 내려주지 않는다 — "두 번째 진실"을 만들지 않으려고 일부러 뺐다.
+// 위치는 depth·orderIndex 에서 아래 상수 하나로 순수 계산한다(#220 §FE 렌더링 규칙 1).
+//
+// 렌더 81칸 = 저장 73행 + 하위목표 8칸 중복 렌더(중앙만 1회, 하위목표만 2회 등장).
+
+import type {
+  MandalaCell,
+  MandalaDraftResponse,
+  MandalaNode,
+  MandalaSource,
+  MandalaSubgoal,
+  MandalaTreeResponse,
+} from '../types/api';
+
+/** 3×3 안에서 중앙(4)을 뺀 8자리, 읽기 순서. */
+export const SLOT = [0, 1, 2, 3, 5, 6, 7, 8] as const;
+
+/** 중앙 블록 = 4. 축 k 는 블록 SLOT[k] 한가운데로 재등장한다. */
+export const CORE_BLOCK = 4;
+
+/** 축은 항상 정확히 8개, 축당 셀도 8개. 진척도 분모도 8 고정(#220 §5). */
+export const AXIS_COUNT = 8;
+export const CELL_COUNT = 8;
+
+/** (block, cell) → 0-indexed 9×9 좌표. */
+export function gridPos(block: number, cell: number): { row: number; col: number } {
+  return {
+    row: Math.floor(block / 3) * 3 + Math.floor(cell / 3),
+    col: (block % 3) * 3 + (cell % 3),
+  };
+}
+
+// ── 화면 모델 ─────────────────────────────────────────────────
+// S30(초안: subgoals/cells/gaps)과 S31(승인본: MandalaNode[])은 데이터 모양이 다르지만
+// 그리는 격자는 같다. 두 소스를 같은 MandalaBoard 로 정규화해 격자 컴포넌트를 하나만 둔다.
+
+export type MandalaSlotRole = 'core' | 'axis' | 'leaf';
+
+export interface MandalaSlot {
+  role: MandalaSlotRole;
+  /** 축 번호 0~7. core 는 -1. */
+  axisIndex: number;
+  /** 축 안의 셀 번호 0~7. core·axis 는 -1. */
+  cellIndex: number;
+  title: string;
+  /** false = AI 가 못 채운 빈 칸. 억지로 채우지 않고 점선으로 남긴다. */
+  filled: boolean;
+  source: MandalaSource;
+  /** 사용자가 인터뷰에서 직접 말한 축 — AI 재생성이 못 건드린다. */
+  locked: boolean;
+  completedAt: string | null;
+  whyText: string | null;
+  promotedGoalId: string | null;
+  progress: number | null;
+  coverage: number | null;
+  /** 승인본(S31)에서만 있음. 초안(S30)은 아직 노드가 없어 null. */
+  nodeId: string | null;
+  /** 못 채운 사유(초안 gaps) — 빈 칸에 "왜 비었는지"를 남긴다. */
+  gapReason: string | null;
+}
+
+export interface MandalaAxis {
+  index: number;
+  slot: MandalaSlot;
+  cells: MandalaSlot[]; // 항상 8개(빈 칸 포함)
+}
+
+export interface MandalaBoard {
+  statement: string;
+  core: MandalaSlot;
+  axes: MandalaAxis[]; // 항상 8개(빈 축 포함)
+  progress: number | null;
+  coverage: number | null;
+}
+
+function emptySlot(role: MandalaSlotRole, axisIndex: number, cellIndex: number): MandalaSlot {
+  return {
+    role,
+    axisIndex,
+    cellIndex,
+    title: '',
+    filled: false,
+    source: 'rule',
+    locked: false,
+    completedAt: null,
+    whyText: null,
+    promotedGoalId: null,
+    progress: null,
+    coverage: null,
+    nodeId: null,
+    gapReason: null,
+  };
+}
+
+function slotFromNode(node: MandalaNode, role: MandalaSlotRole, axisIndex: number, cellIndex: number): MandalaSlot {
+  return {
+    role,
+    axisIndex,
+    cellIndex,
+    title: node.title,
+    // 서버가 내려준 노드인데 제목이 비어 있으면 그것도 "빈 칸"이다.
+    filled: node.title.trim() !== '',
+    source: node.source,
+    locked: node.locked,
+    completedAt: node.completedAt,
+    whyText: node.whyText,
+    promotedGoalId: node.promotedGoalId,
+    progress: node.progress,
+    coverage: node.coverage,
+    nodeId: node.nodeId,
+    gapReason: null,
+  };
+}
+
+/**
+ * U8 응답(73노드) → 격자 모델.
+ *
+ * 정렬은 서버가 이미 `depth ASC, orderIndex ASC` 로 해서 내려주지만, 여기서는
+ * orderIndex 를 자리 번호로 직접 쓰기 때문에 배열 순서에 의존하지 않는다.
+ */
+export function boardFromTree(tree: MandalaTreeResponse): MandalaBoard {
+  const core = tree.nodes.find((n) => n.depth === 0) ?? null;
+  const axisNodes = tree.nodes.filter((n) => n.depth === 1);
+  const leafNodes = tree.nodes.filter((n) => n.depth >= 2);
+
+  const axes: MandalaAxis[] = Array.from({ length: AXIS_COUNT }, (_, k) => {
+    const axisNode = axisNodes.find((n) => n.orderIndex === k) ?? null;
+    const slot = axisNode
+      ? slotFromNode(axisNode, 'axis', k, -1)
+      : emptySlot('axis', k, -1);
+    const cells = Array.from({ length: CELL_COUNT }, (_, j) => {
+      const leaf = axisNode
+        ? leafNodes.find((n) => n.parentId === axisNode.nodeId && n.orderIndex === j)
+        : undefined;
+      return leaf ? slotFromNode(leaf, 'leaf', k, j) : emptySlot('leaf', k, j);
+    });
+    return { index: k, slot, cells };
+  });
+
+  const coreSlot = core
+    ? slotFromNode(core, 'core', -1, -1)
+    : { ...emptySlot('core', -1, -1), title: tree.statement, filled: tree.statement.trim() !== '' };
+
+  return {
+    statement: tree.statement,
+    core: coreSlot,
+    axes,
+    progress: tree.progress,
+    coverage: tree.coverage,
+  };
+}
+
+/**
+ * U3/U4/U5 초안 응답 → 같은 격자 모델. 승인 전이라 nodeId·완료·진척도는 없다.
+ * gaps 는 못 채운 칸의 사유로 붙여, 빈 칸이 "실패"가 아니라 "의도된 여백"임을 보인다.
+ */
+export function boardFromDraft(
+  center: { title: string; whyText?: string | null },
+  subgoals: MandalaSubgoal[],
+  cells: MandalaCell[],
+  gaps: MandalaDraftResponse['gaps'] = [],
+): MandalaBoard {
+  const axes: MandalaAxis[] = Array.from({ length: AXIS_COUNT }, (_, k) => {
+    const sg = subgoals.find((s) => s.orderIndex === k);
+    const axisSlot: MandalaSlot = sg
+      ? {
+          ...emptySlot('axis', k, -1),
+          title: sg.title,
+          filled: sg.title.trim() !== '',
+          source: sg.source ?? 'llm',
+          locked: sg.locked ?? false,
+          whyText: sg.whyText ?? null,
+        }
+      : emptySlot('axis', k, -1);
+
+    const cellSlots = Array.from({ length: CELL_COUNT }, (_, j) => {
+      const c = cells.find((x) => x.subgoalIndex === k && x.orderIndex === j);
+      const gap = gaps.find((g) => g.subgoalIndex === k && g.orderIndex === j);
+      if (!c || c.title.trim() === '') {
+        return { ...emptySlot('leaf', k, j), gapReason: gap?.reason ?? null };
+      }
+      return {
+        ...emptySlot('leaf', k, j),
+        title: c.title,
+        filled: true,
+        source: c.source ?? 'llm',
+        gapReason: gap?.reason ?? null,
+      };
+    });
+
+    return { index: k, slot: axisSlot, cells: cellSlots };
+  });
+
+  return {
+    statement: center.title,
+    core: {
+      ...emptySlot('core', -1, -1),
+      title: center.title,
+      filled: center.title.trim() !== '',
+      source: 'user',
+      whyText: center.whyText ?? null,
+    },
+    axes,
+    progress: null,
+    coverage: null,
+  };
+}
+
+// ── 뷰 도우미 ─────────────────────────────────────────────────
+
+/**
+ * 3×3 한 블록(중앙 + 링 8칸). axisIndex=null 이면 중앙 블록(궁극목표 + 8축),
+ * 아니면 그 축이 한가운데로 오는 블록(축 + 실행 셀 8개).
+ */
+export function blockOf(board: MandalaBoard, axisIndex: number | null): { center: MandalaSlot; ring: MandalaSlot[] } {
+  if (axisIndex == null) {
+    return { center: board.core, ring: board.axes.map((a) => a.slot) };
+  }
+  const axis = board.axes[axisIndex];
+  return { center: axis.slot, ring: axis.cells };
+}
+
+export interface PlacedSlot {
+  slot: MandalaSlot;
+  /** 0-indexed 9×9 좌표. */
+  row: number;
+  col: number;
+  /** 같은 축 슬롯이 두 번 등장하므로 key 를 좌표로 만든다. */
+  key: string;
+  /** 중앙 블록에 그려진 축인지(=탭하면 그 블록으로 줌인). */
+  isAxisInCore: boolean;
+}
+
+/** 9×9 전체 조망(81칸) — 축 8칸은 중앙 블록과 자기 블록 한가운데에 두 번 그린다. */
+export function fullGrid(board: MandalaBoard): PlacedSlot[] {
+  const placed: PlacedSlot[] = [];
+  const push = (slot: MandalaSlot, block: number, cell: number, isAxisInCore = false) => {
+    const { row, col } = gridPos(block, cell);
+    placed.push({ slot, row, col, key: `${row}-${col}`, isAxisInCore });
+  };
+
+  push(board.core, CORE_BLOCK, 4);
+  board.axes.forEach((axis, k) => {
+    push(axis.slot, CORE_BLOCK, SLOT[k], true); // 중앙 블록 안의 축
+    push(axis.slot, SLOT[k], 4); // 자기 블록 한가운데로 재등장
+    axis.cells.forEach((cell, j) => push(cell, SLOT[k], SLOT[j]));
+  });
+
+  return placed.sort((a, b) => (a.row - b.row) || (a.col - b.col));
+}
+
+// ── 표시용 라벨 ───────────────────────────────────────────────
+
+export const SOURCE_LABEL: Record<MandalaSource, string> = {
+  llm: 'AI가 제안',
+  rule: '규칙으로 채움',
+  user: '내가 씀',
+};
+
+/** 축 위치를 말로 — 위치가 곧 의미라 스크린리더 라벨에 반드시 넣는다(#220 §4). */
+export function slotAriaLabel(board: MandalaBoard, slot: MandalaSlot): string {
+  if (slot.role === 'core') return `가운데 칸, 궁극적 목표, ${slot.title || '아직 비어 있음'}`;
+  const axisTitle = board.axes[slot.axisIndex]?.slot.title || `${slot.axisIndex + 1}번 축`;
+  if (slot.role === 'axis') {
+    const done = slot.progress != null ? `, 진행률 ${Math.round(slot.progress * 100)}퍼센트` : '';
+    return `${slot.axisIndex + 1}번 축, ${slot.title || '아직 비어 있음'}${done}`;
+  }
+  const state = !slot.filled ? '빈 칸' : slot.completedAt ? '완료' : '미완료';
+  return `${axisTitle} 그룹, ${slot.cellIndex + 1}번째 칸, ${slot.title || '아직 비어 있음'}, ${state}`;
+}
+
+/** 축의 "몇 칸 채웠나" — 분모는 항상 8 고정(1칸 하고 100% 로 보이는 착시 방지). */
+export function axisFilledCount(axis: MandalaAxis): number {
+  return axis.cells.filter((c) => c.filled).length;
+}
+
+export function axisDoneCount(axis: MandalaAxis): number {
+  return axis.cells.filter((c) => c.completedAt != null).length;
+}
+
+// ── 승인 전 로컬 편집 보존 ────────────────────────────────────
+// 셀 편집(HITL 최하위 층)은 승인(U6)까지 서버 호출이 0회다 — 앱이 죽으면 편집이 통째로
+// 날아가므로 planId 키로 localStorage 에 즉시 저장한다(#220 §3).
+
+const DRAFT_KEY = (planId: string) => `reaction.mandalaDraft.${planId}`;
+
+export interface MandalaLocalEdit {
+  subgoals: MandalaSubgoal[];
+  cells: MandalaCell[];
+  centerWhyText: string | null;
+}
+
+export function saveLocalEdit(planId: string, edit: MandalaLocalEdit): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(DRAFT_KEY(planId), JSON.stringify(edit));
+  } catch {
+    // 저장 공간 부족 등 — 편집 자체를 막지는 않는다.
+  }
+}
+
+export function loadLocalEdit(planId: string): MandalaLocalEdit | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.localStorage.getItem(DRAFT_KEY(planId));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as MandalaLocalEdit;
+    if (!Array.isArray(parsed.subgoals) || !Array.isArray(parsed.cells)) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function clearLocalEdit(planId: string): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.removeItem(DRAFT_KEY(planId));
+  } catch {
+    /* noop */
+  }
+}

--- a/src/screens/GoalsScreen.tsx
+++ b/src/screens/GoalsScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { Plus, Trash, PencilSimple, TreeStructure, Target, ChatCircleDots } from '@phosphor-icons/react';
+import { Plus, Trash, PencilSimple, TreeStructure, Target, ChatCircleDots, SquaresFour, ArrowUpRight } from '@phosphor-icons/react';
 import { ApiError, friendlyError, goalsApi } from '../lib/api';
 import type { ApiGoal, GoalDecomposition, GoalTier } from '../types/api';
 import { GOAL_STATUS_META, GOAL_CATEGORY_OPTIONS, categoryLabel } from '../data';
@@ -27,7 +27,7 @@ interface EditDraft {
 export function GoalsScreen() {
   // 목표의 결이 바뀌면 계획의 전제(가용 시간·역량·마감·회복 톤)가 통째로 무너진다.
   // 여기서 딥 인터뷰로 되돌아갈 수 있어야 하고, 끝나면 온보딩이 아니라 이 화면으로 와야 한다(#216).
-  const { setScreen, setInterviewReturnTo } = useNavigation();
+  const { setScreen, setInterviewReturnTo, setMandalaGoalId } = useNavigation();
   const [confirmReinterview, setConfirmReinterview] = useState(false);
   // 초기값 비움 → 로딩 중 스켈레톤, 실패 시엔 빈 목록 + 에러(더미로 가리지 않는다).
   const [goals, setGoals] = useState<ApiGoal[]>([]);
@@ -77,6 +77,9 @@ export function GoalsScreen() {
   useEffect(() => fetchGoals(), [fetchGoals]);
 
   const count = (tier: GoalTier) => goals.filter((g) => g.goalTier === tier).length;
+
+  // 궁극목표는 사용자당 1개. parked 그룹에 일반 목표와 섞여 오므로 isUltimate 로만 구분한다.
+  const ultimateGoal = goals.find((g) => g.isUltimate) ?? null;
 
   // ── tier 변경 (focus/maintain → PATCH, parked → park) ──
   const changeTier = async (goal: ApiGoal, tier: GoalTier) => {
@@ -237,6 +240,38 @@ export function GoalsScreen() {
             <ChatCircleDots size={13} weight="fill" />
             목표가 바뀌었어요 · 다시 인터뷰하기
           </button>
+
+          {/* 궁극적 목표(#220) — 한 학기가 아니라 여러 학기를 관통하는 목표.
+              tier="parked" 로 아래 목록에도 섞여 나오지만, 여기서 만다라트로 바로 들어간다. */}
+          <div style={{ marginTop: 12, padding: '12px 14px', borderRadius: 16, background: ultimateGoal ? 'var(--surface-raised)' : 'var(--brand-soft)', border: `1px solid ${ultimateGoal ? 'var(--sand-200)' : 'var(--coral-200)'}` }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 4 }}>
+              <SquaresFour size={14} weight="fill" color="var(--brand)" />
+              <span style={{ fontSize: 12, fontWeight: 800, color: 'var(--text-1)' }}>궁극적 목표 만다라트</span>
+            </div>
+            <p style={{ fontSize: 12, color: 'var(--text-2)', margin: '0 0 10px', lineHeight: 1.6, wordBreak: 'keep-all' }}>
+              {ultimateGoal
+                ? `「${ultimateGoal.title}」을(를) 8개 축으로 펼쳐서 보고 있어요.`
+                : '몇 년을 관통하는 목표를 하나 세우고, 8개 축 · 64칸으로 펼쳐 봐요.'}
+            </p>
+            <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+              {ultimateGoal && (
+                <ReButton
+                  variant="primary"
+                  size="sm"
+                  onClick={() => { setMandalaGoalId(ultimateGoal.goalId); setScreen('mandala'); }}
+                >
+                  만다라트 보기
+                </ReButton>
+              )}
+              <ReButton
+                variant={ultimateGoal ? 'ghost' : 'primary'}
+                size="sm"
+                onClick={() => { setMandalaGoalId(null); setScreen('ultimate-interview'); }}
+              >
+                {ultimateGoal ? '다시 세우기' : '궁극적 목표 세우기'}
+              </ReButton>
+            </div>
+          </div>
         </div>
 
         {error && (
@@ -301,6 +336,21 @@ export function GoalsScreen() {
                     {/* 액션 패널 */}
                     {!isEditing && (
                       <>
+                        {/* 만다라트에서 온 목표는 어느 축에서 왔는지 카드에서 바로 보인다.
+                            (서버가 GET /goals 응답에 축 제목을 실어준다 — 카드마다 별도 조회하지 않는다) */}
+                        {g.promotedFromAxis && (
+                          <div style={{ display: 'inline-flex', alignItems: 'center', gap: 4, alignSelf: 'flex-start', height: 24, padding: '0 9px', borderRadius: 9999, background: 'var(--brand-soft)', border: '1px solid var(--coral-200)', color: 'var(--coral-700)', fontSize: 11, fontWeight: 700 }}>
+                            <ArrowUpRight size={10} weight="bold" /> 만다라트 축 · {g.promotedFromAxis}
+                          </div>
+                        )}
+                        {g.isUltimate && (
+                          <button
+                            onClick={() => { setMandalaGoalId(g.goalId); setScreen('mandala'); }}
+                            style={{ display: 'inline-flex', alignItems: 'center', gap: 5, alignSelf: 'flex-start', height: 34, padding: '0 12px', borderRadius: 9999, border: '1px solid var(--coral-200)', background: 'var(--brand-soft)', color: 'var(--coral-700)', fontSize: 12, fontWeight: 700, fontFamily: 'inherit', cursor: 'pointer' }}
+                          >
+                            <SquaresFour size={13} weight="fill" /> 만다라트 보기
+                          </button>
+                        )}
                         <div style={{ display: 'flex', gap: 5 }}>
                           {TIER_ORDER.map((t) => {
                             const tm = GOAL_STATUS_META[t];

--- a/src/screens/MandalaDraftScreen.tsx
+++ b/src/screens/MandalaDraftScreen.tsx
@@ -1,0 +1,436 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { ArrowClockwise, ArrowRight, LockSimple, Sparkle, Trash, WarningCircle } from '@phosphor-icons/react';
+import { friendlyError, plansApi } from '../lib/api';
+import { useToast } from '../contexts/ToastContext';
+import {
+  AXIS_COUNT,
+  boardFromDraft,
+  clearLocalEdit,
+  loadLocalEdit,
+  saveLocalEdit,
+  type MandalaSlot,
+} from '../lib/mandala';
+import { MandalaAxisStrip, MandalaBlockView } from '../components/MandalaGrid';
+import { MandalaCellSheet } from '../components/MandalaCellSheet';
+import { ErrorBanner } from '../components/ErrorBanner';
+import { SkeletonBlock } from '../components/SkeletonBlock';
+import { ReButton } from '../components/ReButton';
+import type { MandalaCell, MandalaCenterPreview, MandalaSubgoal } from '../types/api';
+
+// S30 — AI 만다라트 초안(HITL 승인).
+//
+// 승인 모델은 3층이다(#220 §3):
+//   셀 텍스트 수정 → 서버 호출 없음. 최종 승인(U6) body 에 편집본을 통째로 실어 보낸다.
+//   링(8칸) 재생성 → U5 (LLM 1콜)
+//   전체 확정 / 처음부터 → U6 / U7
+//
+// 서버 호출이 없는 층이 있으므로 편집본은 planId 키로 localStorage 에 즉시 저장한다 —
+// 앱이 죽으면 편집이 통째로 날아간다. Draft 는 72시간 후 만료(410)된다.
+
+type Stage = 'axes' | 'cells';
+
+interface MandalaDraftScreenProps {
+  goalId: string;
+  /** 승인(U6) 성공 — 상시 뷰(S31)로. */
+  onApproved: (goalId: string) => void;
+  /** 폐기하거나 접고 나갈 때. */
+  onLeave: () => void;
+}
+
+export function MandalaDraftScreen({ goalId, onApproved, onLeave }: MandalaDraftScreenProps) {
+  const toast = useToast();
+  const [stage, setStage] = useState<Stage>('axes');
+  const [center, setCenter] = useState<MandalaCenterPreview | null>(null);
+  const [subgoals, setSubgoals] = useState<MandalaSubgoal[]>([]);
+  const [cells, setCells] = useState<MandalaCell[]>([]);
+  const [gaps, setGaps] = useState<{ subgoalIndex: number; orderIndex: number; reason: string }[]>([]);
+  const [planId, setPlanId] = useState<string | null>(null);
+  const [aiSource, setAiSource] = useState<'llm' | 'rule'>('llm');
+  const [busy, setBusy] = useState<null | 'load' | 'generate' | 'regen' | 'approve' | 'discard'>('load');
+  const [error, setError] = useState<string | null>(null);
+  const [axis, setAxis] = useState<number | null>(null);
+  const [selected, setSelected] = useState<MandalaSlot | null>(null);
+  const [hint, setHint] = useState('');
+  const [confirmDiscard, setConfirmDiscard] = useState(false);
+
+  // ── Stage A (U2) — 8축 ──
+  const loadSubgoals = useCallback(async () => {
+    setBusy('load');
+    setError(null);
+    try {
+      const res = await plansApi.mandalaSubgoals({ goalId });
+      setCenter(res.center);
+      setSubgoals(normalizeSubgoals(res.subgoals));
+      setAiSource(res.aiSource ?? 'llm');
+      setPlanId(null);
+      forgetPlanId(goalId);
+      setCells([]);
+      setGaps([]);
+      setStage('axes');
+    } catch (err: unknown) {
+      setError(friendlyError(err, '하위 목표를 만들지 못했어요.'));
+    } finally {
+      setBusy(null);
+    }
+  }, [goalId]);
+
+  // 진입 시: 이 목표로 만들어 둔 초안이 있으면 U4 로 스냅샷만 다시 받아 이어서 본다
+  // (LLM 재호출 0회). 만료(410)·없음(404)이면 Stage A 부터 새로 시작한다.
+  useEffect(() => {
+    let cancelled = false;
+    const key = `reaction.mandalaPlanId.${goalId}`;
+    const saved = typeof window === 'undefined' ? null : window.localStorage.getItem(key);
+    if (!saved) {
+      void loadSubgoals();
+      return;
+    }
+    setBusy('load');
+    plansApi
+      .mandalaGet(saved)
+      .then((draft) => {
+        if (cancelled) return;
+        applyDraft(draft);
+        const edit = loadLocalEdit(draft.planId);
+        if (edit) {
+          setSubgoals(normalizeSubgoals(edit.subgoals));
+          setCells(edit.cells);
+          setCenter((c) => (c ? { ...c, whyText: edit.centerWhyText } : c));
+        }
+        setAxis(0);
+        setBusy(null);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        // 만료·삭제된 초안 — 흔적을 지우고 처음부터.
+        window.localStorage.removeItem(key);
+        clearLocalEdit(saved);
+        void loadSubgoals();
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [goalId, loadSubgoals]);
+
+  // 승인 전 편집본은 서버에 없다 — planId 가 생기는 순간부터 로컬에 계속 붙여둔다.
+  useEffect(() => {
+    if (!planId || stage !== 'cells') return;
+    saveLocalEdit(planId, { subgoals, cells, centerWhyText: center?.whyText ?? null });
+  }, [planId, stage, subgoals, cells, center]);
+
+  const board = useMemo(
+    () => boardFromDraft(center ?? { title: '', whyText: null }, subgoals, cells, gaps),
+    [center, subgoals, cells, gaps],
+  );
+
+  const applyDraft = (d: {
+    planId: string;
+    center: MandalaCenterPreview;
+    subgoals: MandalaSubgoal[];
+    cells: MandalaCell[];
+    gaps: { subgoalIndex: number; orderIndex: number; reason: string }[];
+    aiSource?: 'llm' | 'rule';
+  }) => {
+    setPlanId(d.planId);
+    // 화면을 떠났다 돌아와도 같은 초안으로 이어가기 위한 흔적(U4 로 스냅샷만 다시 받는다).
+    if (typeof window !== 'undefined') window.localStorage.setItem(`reaction.mandalaPlanId.${goalId}`, d.planId);
+    setCenter(d.center);
+    setSubgoals(normalizeSubgoals(d.subgoals));
+    setCells(d.cells);
+    setGaps(d.gaps);
+    setAiSource(d.aiSource ?? 'llm');
+    setStage('cells');
+  };
+
+  // ── Stage B (U3) — 64칸 ──
+  const generate = async () => {
+    setBusy('generate');
+    setError(null);
+    try {
+      const draft = await plansApi.mandalaGenerate({ goalId, subgoals });
+      // 같은 초안으로 돌아온 경우(재진입) 로컬 편집본이 있으면 그쪽이 권위다 —
+      // 승인 전 편집은 서버에 아예 없기 때문에 서버 스냅샷으로 덮으면 사용자 편집이 사라진다.
+      const saved = loadLocalEdit(draft.planId);
+      applyDraft(draft);
+      if (saved) {
+        setSubgoals(normalizeSubgoals(saved.subgoals));
+        setCells(saved.cells);
+        setCenter((c) => (c ? { ...c, whyText: saved.centerWhyText } : c));
+        toast.info('이 기기에 저장해 둔 편집 내용을 이어서 불러왔어요.');
+      }
+      setAxis(0);
+    } catch (err: unknown) {
+      setError(friendlyError(err, '만다라트 초안을 만들지 못했어요.'));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  // ── 링 재생성 (U5) ──
+  const regenerate = async (subgoalIndex: number) => {
+    if (!planId) return;
+    setBusy('regen');
+    setError(null);
+    try {
+      const draft = await plansApi.mandalaRegenerateBranch(planId, {
+        subgoalIndex,
+        userHint: hint.trim() || null,
+        // 재생성 대상이 아닌 칸의 현재 편집 상태를 함께 보낸다(서버는 그대로 되돌려준다).
+        editedSubgoals: subgoals,
+        editedCells: cells,
+      });
+      applyDraft(draft);
+      setHint('');
+      toast.success('이 축의 8칸을 다시 만들었어요.');
+    } catch (err: unknown) {
+      setError(friendlyError(err, '이 축을 다시 만들지 못했어요.'));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  // ── 승인 (U6) ──
+  const approve = async () => {
+    if (!planId) return;
+    setBusy('approve');
+    setError(null);
+    try {
+      const res = await plansApi.mandalaApprove(planId, {
+        subgoals,
+        cells,
+        centerWhyText: center?.whyText ?? null,
+      });
+      clearLocalEdit(planId);
+      forgetPlanId(goalId);
+      toast.success(`${res.activated}칸을 확정했어요.`);
+      onApproved(res.goalId);
+    } catch (err: unknown) {
+      setError(friendlyError(err, '만다라트를 확정하지 못했어요.'));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  // ── 폐기 (U7) ──
+  const discard = async () => {
+    setBusy('discard');
+    setError(null);
+    try {
+      if (planId) {
+        await plansApi.discard(planId);
+        clearLocalEdit(planId);
+      }
+      forgetPlanId(goalId);
+      onLeave();
+    } catch (err: unknown) {
+      setError(friendlyError(err, '초안을 버리지 못했어요.'));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  // ── 로컬 셀/축 편집 (서버 호출 없음) ──
+  const applyLocalEdit = (slot: MandalaSlot, patch: { title: string; whyText: string | null }) => {
+    if (slot.role === 'axis') {
+      setSubgoals((prev) =>
+        prev.map((s) => (s.orderIndex === slot.axisIndex ? { ...s, title: patch.title, whyText: patch.whyText, source: 'user' } : s)),
+      );
+      return;
+    }
+    if (slot.role === 'leaf') {
+      setCells((prev) => {
+        const idx = prev.findIndex((c) => c.subgoalIndex === slot.axisIndex && c.orderIndex === slot.cellIndex);
+        // 비우면 그 칸은 목록에서 뺀다 — 빈 문자열을 실어 보내면 "제목 없는 칸"이 확정된다.
+        if (patch.title.trim() === '') {
+          return idx >= 0 ? prev.filter((_, i) => i !== idx) : prev;
+        }
+        const next: MandalaCell = {
+          subgoalIndex: slot.axisIndex,
+          orderIndex: slot.cellIndex,
+          title: patch.title.trim(),
+          source: 'user',
+        };
+        if (idx >= 0) return prev.map((c, i) => (i === idx ? next : c));
+        return [...prev, next];
+      });
+    }
+  };
+
+  const filledAxes = subgoals.filter((s) => s.title.trim() !== '').length;
+  const filledCells = cells.filter((c) => c.title.trim() !== '').length;
+
+  if (busy === 'load') {
+    return (
+      <div style={{ flex: 1, overflowY: 'auto', padding: '14px 18px', display: 'flex', flexDirection: 'column', gap: 12 }}>
+        <div style={{ fontSize: 13, color: 'var(--text-2)', display: 'flex', alignItems: 'center', gap: 6 }}>
+          <Sparkle size={14} weight="fill" className="pulse" color="var(--brand)" /> 궁극적 목표를 8개 축으로 나누는 중…
+        </div>
+        <SkeletonBlock count={4} height={56} radius={14} />
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ position: 'relative', height: '100%', display: 'flex', flexDirection: 'column', background: 'var(--surface-ground)' }}>
+      <div style={{ flex: 1, overflowY: 'auto', padding: '10px 16px 24px', display: 'flex', flexDirection: 'column', gap: 12 }}>
+        {error && (
+          <ErrorBanner action={<ReButton variant="ghost" size="sm" onClick={() => (stage === 'axes' ? void loadSubgoals() : setError(null))}>다시 시도</ReButton>}>
+            {error}
+          </ErrorBanner>
+        )}
+
+        {center && (
+          <div style={{ padding: '12px 14px', borderRadius: 16, background: 'var(--brand-soft)', border: '1px solid var(--coral-200)' }}>
+            <div style={{ fontSize: 11, fontWeight: 800, color: 'var(--coral-700)', marginBottom: 4 }}>가운데 칸 · 궁극적 목표</div>
+            <div style={{ fontSize: 15, fontWeight: 800, lineHeight: 1.5, color: 'var(--text-1)', wordBreak: 'keep-all', overflowWrap: 'anywhere' }}>{center.title}</div>
+            {center.whyText && <div style={{ fontSize: 12, color: 'var(--coral-700)', marginTop: 6, lineHeight: 1.55 }}>{center.whyText}</div>}
+          </div>
+        )}
+
+        {aiSource === 'rule' && (
+          <div style={{ display: 'flex', gap: 7, padding: '10px 12px', borderRadius: 12, border: '1px dashed var(--sand-300)', background: 'var(--surface-raised)', fontSize: 12, color: 'var(--text-2)', lineHeight: 1.55 }}>
+            <WarningCircle size={14} weight="fill" color="var(--warning)" style={{ flexShrink: 0, marginTop: 1 }} />
+            AI가 아니라 규칙으로 채운 초안이에요. 직접 고쳐 쓰는 편이 훨씬 나아요.
+          </div>
+        )}
+
+        {/* ── Stage A: 8축 확인·편집 ── */}
+        {stage === 'axes' && (
+          <>
+            <div>
+              <div style={{ fontSize: 13, fontWeight: 800, color: 'var(--text-1)', marginBottom: 3 }}>① 8개 축부터 확인해요</div>
+              <p style={{ fontSize: 12, color: 'var(--text-2)', margin: 0, lineHeight: 1.6 }}>
+                축 이름은 여기까지만 고칠 수 있어요. 64칸을 만들고 나면 축의 개수와 순서는 고정돼요.
+              </p>
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 7 }}>
+              {subgoals.map((s) => (
+                <div key={s.orderIndex} style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '9px 11px', borderRadius: 12, background: 'var(--surface-raised)', border: `1px solid ${s.locked ? 'var(--coral-200)' : 'var(--sand-200)'}` }}>
+                  <span className="tnum" style={{ width: 20, height: 20, flexShrink: 0, borderRadius: 9999, background: 'var(--sand-100)', color: 'var(--text-3)', fontSize: 10, fontWeight: 700, display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}>
+                    {s.orderIndex + 1}
+                  </span>
+                  <input
+                    value={s.title}
+                    onChange={(e) =>
+                      setSubgoals((prev) => prev.map((x) => (x.orderIndex === s.orderIndex ? { ...x, title: e.target.value, source: 'user' } : x)))
+                    }
+                    placeholder="비워 두면 그 축은 만들지 않아요"
+                    aria-label={`${s.orderIndex + 1}번 축 이름`}
+                    style={{ flex: 1, minWidth: 0, height: 34, border: 'none', background: 'transparent', fontSize: 13, fontWeight: 600, fontFamily: 'inherit', color: 'var(--text-1)', outline: 'none' }}
+                  />
+                  {s.locked && (
+                    <span title="내가 직접 말한 축" style={{ display: 'inline-flex', alignItems: 'center', gap: 3, flexShrink: 0, fontSize: 10, fontWeight: 700, color: 'var(--coral-700)' }}>
+                      <LockSimple size={11} weight="fill" /> 직접 말함
+                    </span>
+                  )}
+                </div>
+              ))}
+            </div>
+            <p style={{ fontSize: 11, color: 'var(--text-3)', margin: 0, lineHeight: 1.5 }}>
+              {filledAxes}/{AXIS_COUNT}개 축이 채워졌어요. 자물쇠가 붙은 축은 인터뷰에서 직접 말한 축이라 AI 재생성이 건드리지 않아요.
+            </p>
+            <div style={{ display: 'flex', gap: 8 }}>
+              <ReButton variant="ghost" onClick={() => void loadSubgoals()} disabled={busy != null}>
+                <ArrowClockwise size={14} /> 다시 뽑기
+              </ReButton>
+              <div style={{ flex: 1 }}>
+                <ReButton variant="primary" full onClick={generate} disabled={busy != null || filledAxes === 0}>
+                  {busy === 'generate' ? '64칸을 만드는 중…' : '이 8축으로 64칸 만들기'}
+                </ReButton>
+              </div>
+            </div>
+          </>
+        )}
+
+        {/* ── Stage B: 64칸 확인·편집 ── */}
+        {stage === 'cells' && (
+          <>
+            <div>
+              <div style={{ fontSize: 13, fontWeight: 800, color: 'var(--text-1)', marginBottom: 3 }}>② 칸을 확인하고 고쳐요</div>
+              <p style={{ fontSize: 12, color: 'var(--text-2)', margin: 0, lineHeight: 1.6 }}>
+                점선 칸은 AI가 억지로 채우지 않고 비워 둔 자리예요. 지금 편집한 내용은 확정을 눌러야 서버에 남아요.
+              </p>
+            </div>
+
+            <MandalaAxisStrip board={board} active={axis} onChange={setAxis} />
+            <MandalaBlockView
+              board={board}
+              axisIndex={axis}
+              onSelect={(s) => (s.role === 'axis' && axis == null ? setAxis(s.axisIndex) : s.role === 'core' ? undefined : setSelected(s))}
+            />
+
+            {axis != null && (
+              <div style={{ padding: '12px 14px', borderRadius: 14, background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', display: 'flex', flexDirection: 'column', gap: 8 }}>
+                <div style={{ fontSize: 12, fontWeight: 800, color: 'var(--text-1)' }}>이 축이 마음에 안 들면</div>
+                <input
+                  value={hint}
+                  onChange={(e) => setHint(e.target.value)}
+                  placeholder="어떻게 바꿀지 한 줄로 (선택) — 예: 더 구체적인 행동으로"
+                  style={{ height: 40, borderRadius: 10, border: '1px solid var(--sand-200)', background: 'var(--surface-ground)', padding: '0 12px', fontSize: 12, fontFamily: 'inherit', color: 'var(--text-1)', outline: 'none' }}
+                />
+                <ReButton variant="ghost" size="sm" full onClick={() => void regenerate(axis)} disabled={busy != null}>
+                  <ArrowClockwise size={13} /> {busy === 'regen' ? '다시 만드는 중…' : '이 축의 8칸만 다시 만들기'}
+                </ReButton>
+                <p style={{ fontSize: 11, color: 'var(--text-3)', margin: 0, lineHeight: 1.5 }}>
+                  다시 만들어도 내가 직접 고친 칸은 그대로 남아요.
+                </p>
+              </div>
+            )}
+
+            <div style={{ fontSize: 11, color: 'var(--text-3)', lineHeight: 1.5 }}>
+              {filledCells}칸이 채워졌어요 (최대 64칸). 빈 칸은 그대로 둬도 괜찮아요.
+            </div>
+
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginTop: 4 }}>
+              <ReButton variant="primary" size="lg" full onClick={approve} disabled={busy != null}>
+                {busy === 'approve' ? '확정하는 중…' : '이대로 확정하기'} <ArrowRight size={16} />
+              </ReButton>
+              {confirmDiscard ? (
+                <div style={{ padding: '12px 14px', borderRadius: 12, background: '#FAE2D8', border: '1px solid var(--coral-200)', display: 'flex', flexDirection: 'column', gap: 8 }}>
+                  <span style={{ fontSize: 12, color: 'var(--coral-700)', lineHeight: 1.55 }}>
+                    이 초안과 지금까지 고친 내용이 모두 사라져요. 정말 버릴까요?
+                  </span>
+                  <div style={{ display: 'flex', gap: 8 }}>
+                    <ReButton variant="ghost" size="sm" onClick={() => setConfirmDiscard(false)}>그대로 둘래요</ReButton>
+                    <div style={{ flex: 1 }}>
+                      <ReButton variant="primary" size="sm" full onClick={discard} disabled={busy != null}>정말 버리기</ReButton>
+                    </div>
+                  </div>
+                </div>
+              ) : (
+                <button
+                  onClick={() => setConfirmDiscard(true)}
+                  style={{ alignSelf: 'center', display: 'inline-flex', alignItems: 'center', gap: 5, minHeight: 36, padding: '0 12px', borderRadius: 9999, border: 'none', background: 'transparent', color: 'var(--text-3)', fontSize: 12, fontWeight: 600, fontFamily: 'inherit', cursor: 'pointer' }}
+                >
+                  <Trash size={12} /> 이 초안 버리고 처음부터
+                </button>
+              )}
+            </div>
+          </>
+        )}
+      </div>
+
+      {selected && (
+        <MandalaCellSheet
+          board={board}
+          slot={selected}
+          mode="draft"
+          onClose={() => setSelected(null)}
+          onLocalSave={applyLocalEdit}
+        />
+      )}
+    </div>
+  );
+}
+
+function forgetPlanId(goalId: string): void {
+  if (typeof window === 'undefined') return;
+  window.localStorage.removeItem(`reaction.mandalaPlanId.${goalId}`);
+}
+
+// 서버는 항상 8개를 주지만, 화면은 자리 8개가 언제나 있다고 가정한다(빈 축 포함).
+function normalizeSubgoals(list: MandalaSubgoal[]): MandalaSubgoal[] {
+  return Array.from({ length: AXIS_COUNT }, (_, k) => {
+    const found = list.find((s) => s.orderIndex === k);
+    return found ?? { orderIndex: k, title: '', source: 'rule' as const, locked: false, whyText: null };
+  });
+}

--- a/src/screens/MandalaScreen.tsx
+++ b/src/screens/MandalaScreen.tsx
@@ -1,0 +1,268 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { GridFour, ListBullets, SquaresFour, Sparkle, ArrowClockwise } from '@phosphor-icons/react';
+import { friendlyError, goalsApi } from '../lib/api';
+import { useNavigation } from '../contexts/NavigationContext';
+import { useToast } from '../contexts/ToastContext';
+import { boardFromTree, type MandalaBoard, type MandalaSlot } from '../lib/mandala';
+import { MandalaAxisStrip, MandalaBlockView, MandalaFullView, MandalaListView, MandalaProgress } from '../components/MandalaGrid';
+import { MandalaCellSheet } from '../components/MandalaCellSheet';
+import { EmptyState } from '../components/EmptyState';
+import { ErrorBanner } from '../components/ErrorBanner';
+import { SkeletonBlock } from '../components/SkeletonBlock';
+import { ReButton } from '../components/ReButton';
+import type { MandalaNode, MandalaTreeResponse } from '../types/api';
+
+// S31 — 만다라트 상시 뷰(73칸).
+//
+// 기본은 9×9 전체가 아니라 3×3 드릴다운이다. 모바일 폭에서 81칸을 균등 배치하면
+// 셀 한 변이 ≈38pt 로 최소 터치 타겟(44pt)에 못 미치고 한글도 찌그러진다.
+// 전체 조망은 토글로 따로 두고 읽기 전용으로 둔다.
+
+type ViewMode = 'block' | 'full' | 'list';
+
+interface MandalaScreenProps {
+  /** 볼 만다라의 목표 id. 없으면 GET /goals 에서 궁극목표(isUltimate)를 찾는다. */
+  goalId?: string | null;
+  /** 궁극목표가 아직 없을 때 인터뷰(S29)로 보낸다. */
+  onStartUltimate?: () => void;
+  /** 궁극목표는 있는데 아직 승인된 만다라가 없을 때 초안(S30)으로 보낸다. */
+  onBuildMandala?: (goalId: string) => void;
+}
+
+function prefersReducedMotion(): boolean {
+  if (typeof window === 'undefined' || !window.matchMedia) return false;
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+export function MandalaScreen({ goalId, onStartUltimate, onBuildMandala }: MandalaScreenProps) {
+  const { setInterviewReturnTo } = useNavigation();
+  const toast = useToast();
+  const [tree, setTree] = useState<MandalaTreeResponse | null>(null);
+  const [resolvedGoalId, setResolvedGoalId] = useState<string | null>(goalId ?? null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  // 궁극목표 자체가 아직 없는 경우(만다라 미승인과 구분해야 안내 문구가 달라진다).
+  const [noUltimate, setNoUltimate] = useState(false);
+  // reduced-motion 사용자는 격자 대신 목록을 기본으로 — 자동 전환이지 강제는 아니다.
+  const [view, setView] = useState<ViewMode>(() => (prefersReducedMotion() ? 'list' : 'block'));
+  const [axis, setAxis] = useState<number | null>(null);
+  const [openListAxis, setOpenListAxis] = useState<number | null>(null);
+  const [selected, setSelected] = useState<MandalaSlot | null>(null);
+
+  const load = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    setNoUltimate(false);
+    try {
+      let id = goalId ?? null;
+      if (!id) {
+        const goals = await goalsApi.list();
+        const all = [...goals.focus, ...goals.maintain, ...goals.parked];
+        // 궁극목표는 tier="parked" 로 일반 목표와 섞여 온다 — isUltimate 로만 구분한다.
+        id = all.find((g) => g.isUltimate)?.goalId ?? null;
+      }
+      if (!id) {
+        setNoUltimate(true);
+        setTree(null);
+        return;
+      }
+      setResolvedGoalId(id);
+      const data = await goalsApi.mandala(id);
+      setTree(data);
+    } catch (err: unknown) {
+      setError(friendlyError(err, '만다라트를 불러오지 못했어요.'));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [goalId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const board: MandalaBoard | null = useMemo(() => (tree ? boardFromTree(tree) : null), [tree]);
+
+  // U9(셀 편집) 응답은 progress/coverage 를 다시 계산하지 않고 null 로 준다.
+  // 그래서 편집한 노드만 갈아끼우고, 진척도는 U8 을 다시 불러 최신으로 맞춘다.
+  const applyNode = (updated: MandalaNode) => {
+    setTree((prev) =>
+      prev
+        ? { ...prev, nodes: prev.nodes.map((n) => (n.nodeId === updated.nodeId ? { ...n, ...updated, progress: n.progress, coverage: n.coverage } : n)) }
+        : prev,
+    );
+    setSelected((s) => (s && s.nodeId === updated.nodeId ? { ...s, title: updated.title, whyText: updated.whyText, source: updated.source, completedAt: updated.completedAt, filled: updated.title.trim() !== '' } : s));
+    if (resolvedGoalId) {
+      goalsApi
+        .mandala(resolvedGoalId)
+        .then(setTree)
+        .catch(() => { /* 진척도만 못 갱신 — 편집 자체는 이미 저장됐다 */ });
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div style={{ flex: 1, overflowY: 'auto', padding: '14px 18px 28px', display: 'flex', flexDirection: 'column', gap: 12 }}>
+        <SkeletonBlock count={1} height={64} radius={14} />
+        <SkeletonBlock count={1} height={280} radius={18} />
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ position: 'relative', height: '100%', display: 'flex', flexDirection: 'column', background: 'var(--surface-ground)' }}>
+      <div style={{ flex: 1, overflowY: 'auto', padding: '10px 16px 32px', display: 'flex', flexDirection: 'column', gap: 12 }}>
+        {error && (
+          <ErrorBanner action={<ReButton variant="ghost" size="sm" onClick={() => void load()}>다시 시도</ReButton>}>{error}</ErrorBanner>
+        )}
+
+        {noUltimate && (
+          <EmptyState
+            tone="hero"
+            title="궁극적 목표가 아직 없어요"
+            icon={<Sparkle size={26} weight="fill" color="var(--brand)" />}
+          >
+            여러 학기를 관통하는 목표를 하나 세우면, 그걸 8개 축으로 펼친 만다라트를 여기서 볼 수 있어요.
+          </EmptyState>
+        )}
+        {noUltimate && onStartUltimate && (
+          <ReButton variant="primary" full onClick={onStartUltimate}>궁극적 목표 세우기</ReButton>
+        )}
+
+        {board && tree && tree.nodes.length === 0 && (
+          <>
+            <EmptyState tone="hero" title="아직 만다라트가 없어요" icon={<SquaresFour size={26} weight="fill" color="var(--brand)" />}>
+              「{tree.statement}」은(는) 세워 뒀지만, 8축·64칸이 아직 확정되지 않았어요.<br />
+              초안을 만들고 <b>이대로 확정</b>을 누르면 여기에 73칸이 남아요.
+            </EmptyState>
+            {resolvedGoalId && onBuildMandala && (
+              <ReButton variant="primary" full onClick={() => onBuildMandala(resolvedGoalId)}>
+                만다라트 초안 만들기
+              </ReButton>
+            )}
+          </>
+        )}
+
+        {board && tree && tree.nodes.length > 0 && (
+          <>
+            <div>
+              <div style={{ fontSize: 11, fontWeight: 700, color: 'var(--text-3)', marginBottom: 4 }}>궁극적 목표</div>
+              <h1 style={{ margin: 0, fontSize: 18, fontWeight: 800, letterSpacing: '-0.02em', lineHeight: 1.45, wordBreak: 'keep-all', overflowWrap: 'anywhere' }}>
+                {tree.statement}
+              </h1>
+            </div>
+
+            <MandalaProgress progress={tree.progress} coverage={tree.coverage} />
+
+            {/* 뷰 전환 — 편집은 ①/③ 에서만, ② 는 조망 전용. */}
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+              <ViewToggle mode={view} onChange={setView} />
+              <button
+                onClick={() => void load()}
+                aria-label="새로고침"
+                style={{ marginLeft: 'auto', width: 36, height: 36, borderRadius: 9999, border: '1px solid var(--sand-200)', background: 'var(--surface-raised)', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer' }}
+              >
+                <ArrowClockwise size={13} color="var(--text-2)" />
+              </button>
+            </div>
+
+            {view === 'block' && (
+              <>
+                <MandalaAxisStrip board={board} active={axis} onChange={setAxis} />
+                <div style={{ fontSize: 11, color: 'var(--text-3)', lineHeight: 1.5, padding: '0 2px' }}>
+                  {axis == null
+                    ? '가운데가 궁극적 목표, 둘레 8칸이 하위 목표예요. 축을 누르면 그 축의 8칸이 열려요.'
+                    : '점선 칸은 아직 비워 둔 자리예요. 억지로 채우지 않아도 괜찮아요.'}
+                </div>
+                <MandalaBlockView board={board} axisIndex={axis} onSelect={(s) => (s.role === 'axis' && axis == null ? setAxis(s.axisIndex) : setSelected(s))} />
+                {axis != null && (
+                  <p style={{ fontSize: 11, color: 'var(--text-3)', margin: '2px 2px 0', lineHeight: 1.5 }}>
+                    가운데 칸을 누르면 이 축을 이번 학기 목표로 올릴 수 있어요.
+                  </p>
+                )}
+              </>
+            )}
+
+            {view === 'full' && (
+              <MandalaFullView
+                board={board}
+                onZoom={(a) => {
+                  setAxis(a);
+                  setView('block');
+                }}
+              />
+            )}
+
+            {view === 'list' && (
+              <MandalaListView
+                board={board}
+                onSelect={setSelected}
+                openAxis={openListAxis}
+                onToggleAxis={setOpenListAxis}
+              />
+            )}
+          </>
+        )}
+      </div>
+
+      {board && selected && (
+        <MandalaCellSheet
+          board={board}
+          slot={selected}
+          mode="tree"
+          onClose={() => setSelected(null)}
+          onUpdated={applyNode}
+          onPromoted={(goal) => {
+            toast.success(`「${goal.title}」을(를) 이번 학기 목표로 올렸어요.`);
+            // 승격한 축은 계획 인터뷰(S02)로 이어져야 실제 실행 계획이 된다.
+            // 강제로 끌고 가지 않고, 사용자가 목표 화면에서 이어가도록 둔다.
+            setInterviewReturnTo('mandala');
+            if (resolvedGoalId) {
+              goalsApi.mandala(resolvedGoalId).then(setTree).catch(() => {});
+            }
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+function ViewToggle({ mode, onChange }: { mode: ViewMode; onChange: (m: ViewMode) => void }) {
+  const items: { id: ViewMode; label: string; icon: React.ReactNode }[] = [
+    { id: 'block', label: '3×3', icon: <SquaresFour size={12} weight="fill" /> },
+    { id: 'full', label: '전체', icon: <GridFour size={12} weight="fill" /> },
+    { id: 'list', label: '목록', icon: <ListBullets size={12} weight="bold" /> },
+  ];
+  return (
+    <div style={{ display: 'inline-flex', gap: 3, padding: 3, borderRadius: 9999, background: 'var(--sand-100)', border: '1px solid var(--sand-200)' }}>
+      {items.map((it) => {
+        const active = mode === it.id;
+        return (
+          <button
+            key={it.id}
+            onClick={() => onChange(it.id)}
+            aria-pressed={active}
+            style={{
+              height: 30,
+              padding: '0 12px',
+              borderRadius: 9999,
+              border: 'none',
+              background: active ? 'var(--surface-raised)' : 'transparent',
+              color: active ? 'var(--text-1)' : 'var(--text-3)',
+              fontFamily: 'inherit',
+              fontSize: 11,
+              fontWeight: 700,
+              cursor: 'pointer',
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 4,
+              boxShadow: active ? 'var(--shadow-sm)' : 'none',
+            }}
+          >
+            {it.icon}
+            {it.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/screens/UltimateGoalInterviewScreen.tsx
+++ b/src/screens/UltimateGoalInterviewScreen.tsx
@@ -1,0 +1,486 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Sparkle, ArrowUp, ArrowRight, X, Microphone, Stop, Target } from '@phosphor-icons/react';
+import { ApiError, friendlyError, goalsApi, interviewApi } from '../lib/api';
+import type { InterviewQuestion, InterviewSession, SlotCatalogEntry } from '../types/api';
+import { ErrorBanner } from '../components/ErrorBanner';
+import { DateAnswerField, TimeRangeAnswerField, isValidRange, parseRange } from '../components/TypedAnswerField';
+import { useSpeechInput } from '../lib/useSpeechInput';
+
+// S29 — 궁극적 목표 전용 인터뷰.
+//
+// 계획 인터뷰(S02)와 같은 엔진이지만 `kind="ultimate"` 로 시작한다. 종료 턴 응답에는
+// `outcome` 대신 `ultimateOutcome` 이 실려 오고, 그걸 그대로 POST /goals/ultimate(U1) 에
+// 넘겨 Goal(status=active, tier=parked) 로 확정한다 — 여기까지가 만다라트(S30)의 입력이다.
+//
+// 세션은 사용자당 1개라, 계획 인터뷰 세션이 살아 있으면 먼저 정리하고 시작한다.
+
+const STORE_KEY = 'reaction.ultimateSessionId';
+const PLAN_STORE_KEY = 'reaction.interviewSessionId';
+
+interface ChatMessage {
+  id: string;
+  who: 'ai' | 'user';
+  text: string;
+}
+
+interface UltimateGoalInterviewScreenProps {
+  /** 궁극목표 확정(U1) 성공 — 만다라트 초안(S30)으로 넘어갈 goalId. */
+  onGoalReady: (goalId: string) => void;
+  /** 인터뷰를 접고 돌아갈 때. */
+  onCancel: () => void;
+}
+
+export function UltimateGoalInterviewScreen({ onGoalReady, onCancel }: UltimateGoalInterviewScreenProps) {
+  const [session, setSession] = useState<InterviewSession | null>(null);
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [inputText, setInputText] = useState('');
+  const [isTyping, setIsTyping] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [catalog, setCatalog] = useState<SlotCatalogEntry[]>([]);
+  const [confirming, setConfirming] = useState(false);
+  const msgCounter = useRef(0);
+  const newMsgId = (prefix: string) => `${prefix}-${++msgCounter.current}`;
+  const bodyRef = useRef<HTMLDivElement>(null);
+  // 필수 슬롯 수 — 카탈로그가 오기 전 fallback. 궁극목표 인터뷰는 필수 9슬롯 기준(#220).
+  const initialAmbiguity = useRef<number>(9);
+
+  useEffect(() => {
+    if (bodyRef.current) bodyRef.current.scrollTop = bodyRef.current.scrollHeight;
+  }, [messages, isTyping]);
+
+  useEffect(() => {
+    let cancelled = false;
+    interviewApi
+      .slotCatalog('ultimate')
+      .then((c) => {
+        if (cancelled) return;
+        setCatalog(c);
+        const required = c.filter((s) => s.isRequired).length;
+        if (required > 0) initialAmbiguity.current = required;
+      })
+      .catch(() => { /* 카탈로그 없이도 흐름은 진행 */ });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // 세션 시작 — 항상 새로. 사용자당 활성 세션이 1개라 남아 있는 세션(계획/궁극 양쪽)을 먼저 닫는다.
+  useEffect(() => {
+    let cancelled = false;
+    setIsTyping(true);
+    const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+    const read = (k: string) => (typeof window !== 'undefined' && window.localStorage.getItem(k)) || null;
+
+    const closeLingering = async () => {
+      for (const key of [STORE_KEY, PLAN_STORE_KEY]) {
+        const sid = read(key);
+        if (sid) {
+          await interviewApi.finish(sid).catch(() => {});
+          window.localStorage.removeItem(key);
+        }
+      }
+    };
+
+    const beginFresh = async (attempt = 0): Promise<InterviewSession> => {
+      try {
+        return await interviewApi.start('ultimate');
+      } catch (err) {
+        if (cancelled) throw err;
+        const code = err instanceof ApiError ? err.code : '';
+        if (code === 'INTERVIEW_SESSION_EXISTS' && attempt < 5) {
+          await closeLingering();
+          await sleep(500);
+          return beginFresh(attempt + 1);
+        }
+        if (code === 'AGENT_CONCURRENT_ACCESS' && attempt < 5) {
+          await sleep(600 + attempt * 300);
+          return beginFresh(attempt + 1);
+        }
+        throw err;
+      }
+    };
+
+    (async () => {
+      await closeLingering();
+      return beginFresh();
+    })()
+      .then((s) => {
+        if (cancelled) return;
+        if (typeof window !== 'undefined') window.localStorage.setItem(STORE_KEY, s.sessionId);
+        initialAmbiguity.current = s.ambiguityScore || initialAmbiguity.current;
+        setSession(s);
+        if (s.currentQuestion) {
+          setMessages([{ id: newMsgId('ai'), who: 'ai', text: s.currentQuestion.text }]);
+        }
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(friendlyError(err, '인터뷰를 시작하지 못했어요. 잠시 후 다시 시도해 주세요.'));
+      })
+      .finally(() => {
+        if (!cancelled) setIsTyping(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const currentQuestion = session?.currentQuestion ?? null;
+  const isFinished = session?.endReason != null;
+  const ultimateOutcome = session?.ultimateOutcome ?? null;
+  const ambiguity = session?.ambiguityScore ?? initialAmbiguity.current;
+  const clarity = isFinished
+    ? 100
+    : Math.max(0, Math.min(100, Math.round((1 - ambiguity / initialAmbiguity.current) * 100)));
+
+  const currentCategory = useMemo(() => {
+    if (!currentQuestion || catalog.length === 0) return null;
+    return catalog.find((s) => s.slotKey === currentQuestion.slotKey)?.category ?? null;
+  }, [currentQuestion, catalog]);
+
+  const submit = async (value: string) => {
+    if (!session || !currentQuestion || isTyping || isFinished) return;
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    const answeredKey = currentQuestion.slotKey;
+    speech.stop();
+    setMessages((m) => [...m, { id: newMsgId('u'), who: 'user', text: trimmed }]);
+    setInputText('');
+    setIsTyping(true);
+    try {
+      const next = await interviewApi.submitAnswer(session.sessionId, {
+        slotKey: answeredKey,
+        value: trimmed,
+        clientTurn: session.totalTurns,
+      });
+      if (next.endReason != null) {
+        setSession({ ...next, endReason: next.endReason ?? 'completed', currentQuestion: null });
+        setMessages((m) => [
+          ...m,
+          { id: newMsgId('ai-end'), who: 'ai', text: '충분히 들었어요. 이 목표를 만다라트로 펼쳐볼게요.' },
+        ]);
+        return;
+      }
+      if (!next.currentQuestion) {
+        setSession(next);
+        setError('다음 질문을 받지 못했어요. 다시 시도해주세요.');
+        return;
+      }
+      setSession(next);
+      setMessages((m) => [...m, { id: newMsgId('ai'), who: 'ai', text: next.currentQuestion!.text }]);
+    } catch (err: unknown) {
+      setError(friendlyError(err, '요청 처리 중 오류가 발생했어요.'));
+    } finally {
+      setIsTyping(false);
+    }
+  };
+
+  const finishEarly = async () => {
+    if (!session) return;
+    setIsTyping(true);
+    try {
+      const s = await interviewApi.finish(session.sessionId);
+      setSession(s);
+      setMessages((m) => [...m, { id: newMsgId('ai-finish'), who: 'ai', text: '여기까지 정리해 둘게요.' }]);
+    } catch (err: unknown) {
+      setError(friendlyError(err, '종료 처리 중 오류가 발생했어요.'));
+    } finally {
+      setIsTyping(false);
+    }
+  };
+
+  // U1 — 인터뷰가 쥐고 있는 ultimateOutcome 을 그대로 실어 보낸다.
+  // 없으면 생략해도 서버가 최근 정상 종료된 궁극목표 인터뷰에서 복구한다.
+  const confirmUltimate = async () => {
+    setConfirming(true);
+    setError(null);
+    try {
+      const goal = await goalsApi.upsertUltimate(ultimateOutcome ? { outcome: ultimateOutcome } : {});
+      if (typeof window !== 'undefined') window.localStorage.removeItem(STORE_KEY);
+      onGoalReady(goal.goalId);
+    } catch (err: unknown) {
+      setError(friendlyError(err, '궁극적 목표를 저장하지 못했어요.'));
+    } finally {
+      setConfirming(false);
+    }
+  };
+
+  // 입력창을 "쉼표로 구분된 답 목록"으로 본다 — 선택지를 눌러도 바로 전송하지 않고 담기만 한다.
+  const parts = inputText.split(',').map((t) => t.trim()).filter(Boolean);
+  const togglePart = (v: string) => {
+    const t = v.trim();
+    setInputText((parts.includes(t) ? parts.filter((x) => x !== t) : [...parts, t]).join(', '));
+  };
+  const isPicked = (v: string) => parts.includes(v.trim());
+
+  const showQuickReplies =
+    currentQuestion &&
+    (currentQuestion.answerType === 'chip' || currentQuestion.answerType === 'select') &&
+    currentQuestion.options.length > 0;
+
+  const typedKind: 'date' | 'range' | null = currentQuestion
+    ? currentQuestion.answerType === 'date_picker'
+      ? 'date'
+      : currentQuestion.answerType === 'time_range'
+        ? 'range'
+        : null
+    : null;
+  const [manualEntry, setManualEntry] = useState(false);
+  const useTypedField = typedKind !== null && !manualEntry;
+
+  useEffect(() => {
+    setManualEntry(false);
+  }, [currentQuestion?.slotKey]);
+
+  useEffect(() => {
+    if (useTypedField && typedKind === 'range' && inputText.trim() === '') {
+      const { start, end } = parseRange('');
+      setInputText(`${start}-${end}`);
+    }
+  }, [useTypedField, typedKind, inputText]);
+
+  const range = typedKind === 'range' ? parseRange(inputText) : null;
+  const canSubmit =
+    inputText.trim() !== '' &&
+    !isTyping &&
+    (!useTypedField || typedKind !== 'range' || (range !== null && isValidRange(range.start, range.end)));
+
+  const appendSpoken = useCallback((text: string) => {
+    setInputText((prev) => (prev.trim() === '' ? text : `${prev.trimEnd()} ${text}`));
+  }, []);
+  const speech = useSpeechInput(appendSpoken);
+  const showMic = speech.supported && !useTypedField && !isFinished;
+
+  useEffect(() => {
+    speech.stop();
+  }, [currentQuestion?.slotKey]);
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%', background: 'var(--surface-ground)' }}>
+      {/* Header */}
+      <div style={{ padding: '10px 16px 12px', borderBottom: '1px solid var(--sand-200)', flexShrink: 0 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 8 }}>
+          <div style={{ width: 32, height: 32, borderRadius: 9999, background: 'var(--brand-surface)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+            <Target size={16} weight="fill" color="#FFFCF6" />
+          </div>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ fontWeight: 700, fontSize: 14, color: 'var(--text-1)' }}>궁극적 목표 인터뷰</div>
+            <div style={{ fontSize: 11, color: 'var(--text-3)' }}>한 학기가 아니라, 몇 년을 관통하는 목표를 세워요</div>
+          </div>
+          {currentCategory && (
+            <div style={{ height: 24, padding: '0 8px', background: 'var(--brand-soft)', border: '1px solid var(--coral-200)', borderRadius: 9999, fontSize: 11, fontWeight: 700, color: 'var(--coral-700)', display: 'flex', alignItems: 'center', flexShrink: 0 }}>
+              {currentCategory}
+            </div>
+          )}
+        </div>
+        <div style={{ background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', borderRadius: 12, padding: '10px 12px', display: 'flex', flexDirection: 'column', gap: 7 }}>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+            <span style={{ fontSize: 11, fontWeight: 700, color: 'var(--text-2)' }}>목표 선명도</span>
+            <span className="tnum" style={{ fontSize: 11, fontWeight: 800, color: 'var(--brand-ink)' }}>{clarity}% 선명</span>
+          </div>
+          <div style={{ height: 5, background: 'var(--sand-200)', borderRadius: 9999, overflow: 'hidden' }}>
+            <div style={{ height: '100%', borderRadius: 9999, background: 'var(--brand)', width: `${clarity}%`, transition: 'width 0.6s ease' }} />
+          </div>
+        </div>
+      </div>
+
+      {/* Chat */}
+      <div ref={bodyRef} style={{ flex: 1, overflowY: 'auto', padding: '14px 16px', display: 'flex', flexDirection: 'column', gap: 10 }}>
+        {error && (
+          <ErrorBanner
+            action={
+              <button onClick={onCancel} style={{ alignSelf: 'flex-start', height: 32, padding: '0 12px', borderRadius: 9999, border: '1px solid var(--coral-200)', background: 'var(--surface-raised)', color: 'var(--coral-700)', fontSize: 12, fontWeight: 700, fontFamily: 'inherit', cursor: 'pointer', display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+                목표 화면으로 돌아가기 <ArrowRight size={12} />
+              </button>
+            }
+          >
+            {error}
+          </ErrorBanner>
+        )}
+        {messages.map((m) => (
+          <div key={m.id} style={{ display: 'flex', justifyContent: m.who === 'user' ? 'flex-end' : 'flex-start' }}>
+            {m.who === 'ai' ? (
+              <div style={{ display: 'flex', gap: 8, alignItems: 'flex-end', maxWidth: '90%' }}>
+                <div style={{ width: 26, height: 26, borderRadius: 9999, background: 'var(--text-1)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+                  <Sparkle size={11} weight="fill" color="#FAF6EE" />
+                </div>
+                <div style={{ background: 'var(--sand-100)', border: '1px solid var(--sand-200)', borderRadius: '14px 14px 14px 4px', padding: '10px 13px', fontSize: 13, lineHeight: 1.55, color: 'var(--text-1)', whiteSpace: 'pre-line', wordBreak: 'keep-all', overflowWrap: 'anywhere' }}>{m.text}</div>
+              </div>
+            ) : (
+              <div style={{ maxWidth: '78%', background: 'var(--brand-surface)', color: '#FFFCF6', borderRadius: '14px 14px 4px 14px', padding: '10px 13px', fontSize: 13, lineHeight: 1.45, fontWeight: 500, wordBreak: 'keep-all', overflowWrap: 'anywhere' }}>{m.text}</div>
+            )}
+          </div>
+        ))}
+        {isTyping && (
+          <div style={{ display: 'flex', gap: 8, alignItems: 'flex-end' }}>
+            <div style={{ width: 26, height: 26, borderRadius: 9999, background: 'var(--text-1)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+              <Sparkle size={11} weight="fill" color="#FAF6EE" />
+            </div>
+            <div style={{ background: 'var(--sand-100)', border: '1px solid var(--sand-200)', borderRadius: '14px 14px 14px 4px', padding: '12px 14px', display: 'flex', gap: 4 }}>
+              {[0, 0.2, 0.4].map((d, i) => (
+                <div key={i} style={{ width: 6, height: 6, borderRadius: 9999, background: 'var(--text-3)', animation: 'bounce 1.2s infinite', animationDelay: `${d}s` }} />
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* 종료 턴 — ultimateOutcome 요약 카드. 무엇이 저장될지 보여준 뒤 확정을 받는다. */}
+        {isFinished && ultimateOutcome && (
+          <div style={{ marginTop: 4, padding: '14px 16px', borderRadius: 16, background: 'var(--brand-soft)', border: '1px solid var(--coral-200)', display: 'flex', flexDirection: 'column', gap: 8 }}>
+            <div style={{ fontSize: 11, fontWeight: 800, color: 'var(--coral-700)' }}>이렇게 정리했어요</div>
+            <div style={{ fontSize: 15, fontWeight: 800, color: 'var(--text-1)', lineHeight: 1.5, wordBreak: 'keep-all', overflowWrap: 'anywhere' }}>
+              {ultimateOutcome.statement}
+            </div>
+            <SummaryRow label="지금 위치">{ultimateOutcome.currentPosition}</SummaryRow>
+            <SummaryRow label="무엇으로 확인">{ultimateOutcome.measure}</SummaryRow>
+            <SummaryRow label="이뤘을 때의 모습">{ultimateOutcome.successImage}</SummaryRow>
+            {ultimateOutcome.horizonYears != null && <SummaryRow label="기간">{ultimateOutcome.horizonYears}년</SummaryRow>}
+            {ultimateOutcome.unresolvedSlots && ultimateOutcome.unresolvedSlots.length > 0 && (
+              <div style={{ fontSize: 11, color: 'var(--coral-700)', lineHeight: 1.5, opacity: 0.85 }}>
+                아직 못 들은 게 {ultimateOutcome.unresolvedSlots.length}가지 있어요. 그대로 진행해도 되고, 나중에 다시 인터뷰해 다듬어도 돼요.
+              </div>
+            )}
+          </div>
+        )}
+        {isFinished && !ultimateOutcome && (
+          <div style={{ marginTop: 4, padding: '12px 14px', borderRadius: 14, background: 'var(--surface-raised)', border: '1px dashed var(--sand-300)', fontSize: 12, color: 'var(--text-2)', lineHeight: 1.6 }}>
+            인터뷰는 끝났는데 정리 결과가 함께 오지 않았어요. 그대로 진행하면 서버가 방금 끝낸 인터뷰에서 목표를 복구해요.
+          </div>
+        )}
+      </div>
+
+      {/* Input / 확정 */}
+      <div style={{ padding: '10px 16px', paddingBottom: 'max(28px, env(safe-area-inset-bottom, 28px))', borderTop: '1px solid var(--sand-200)', flexShrink: 0, background: 'rgba(250,246,238,.92)', backdropFilter: 'blur(20px)' }}>
+        {!isFinished && currentQuestion ? (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+              <span style={{ fontSize: 12, color: 'var(--text-3)', fontWeight: 600 }}>편하게 답해도 돼요</span>
+              <button onClick={finishEarly} style={{ fontSize: 12, fontWeight: 700, color: 'var(--text-3)', background: 'transparent', border: 'none', cursor: 'pointer' }}>
+                충분해요
+              </button>
+            </div>
+            {showQuickReplies && (
+              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8, maxHeight: 168, overflowY: 'auto' }}>
+                {currentQuestion.options.map((reply, i) => {
+                  const picked = isPicked(reply);
+                  return (
+                    <button
+                      key={i}
+                      onClick={() => togglePart(reply)}
+                      disabled={isTyping}
+                      style={{ padding: '11px 12px', borderRadius: 12, border: `1.5px solid ${picked ? 'var(--coral-200)' : 'var(--sand-200)'}`, background: picked ? 'var(--brand-soft)' : 'var(--surface-raised)', color: picked ? 'var(--coral-700)' : 'var(--text-1)', fontWeight: picked ? 700 : 400, fontSize: 12, textAlign: 'left', cursor: isTyping ? 'wait' : 'pointer', lineHeight: 1.45, fontFamily: 'inherit', wordBreak: 'keep-all', opacity: isTyping ? 0.6 : 1 }}
+                    >
+                      {reply}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+            {!showQuickReplies && currentQuestion.suggestedAnswers && currentQuestion.suggestedAnswers.length > 0 && (
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+                {currentQuestion.suggestedAnswers.map((s, i) => (
+                  <button key={i} onClick={() => togglePart(s)} disabled={isTyping} style={{ padding: '8px 12px', borderRadius: 9999, border: '1px solid var(--coral-200)', background: 'var(--brand-soft)', color: 'var(--coral-700)', fontSize: 12, cursor: isTyping ? 'wait' : 'pointer', fontFamily: 'inherit', wordBreak: 'keep-all', opacity: isTyping ? 0.6 : 1 }}>
+                    {s}
+                  </button>
+                ))}
+              </div>
+            )}
+            {useTypedField && (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                {typedKind === 'date' ? (
+                  <DateAnswerField value={inputText} onChange={setInputText} disabled={isTyping} />
+                ) : (
+                  <TimeRangeAnswerField value={inputText} onChange={setInputText} disabled={isTyping} />
+                )}
+                <button onClick={() => { setInputText(''); setManualEntry(true); }} style={{ alignSelf: 'flex-start', fontSize: 12, fontWeight: 600, color: 'var(--text-3)', background: 'none', border: 'none', padding: '2px 0', cursor: 'pointer', fontFamily: 'inherit', textDecoration: 'underline' }}>
+                  직접 입력할게요
+                </button>
+              </div>
+            )}
+            {speech.listening && (
+              <div style={{ fontSize: 12, color: 'var(--text-3)', lineHeight: 1.5, minHeight: 18 }} aria-live="polite">
+                {speech.interim ? `“${speech.interim}”` : '듣고 있어요…'}
+              </div>
+            )}
+            <div style={{ display: 'flex', gap: 8, alignItems: 'flex-end' }}>
+              {!useTypedField && (
+                <input
+                  value={inputText}
+                  onChange={(e) => setInputText(e.target.value)}
+                  onKeyDown={(e) => { if (e.key === 'Enter' && !e.nativeEvent.isComposing) submit(inputText); }}
+                  placeholder={placeholderFor(currentQuestion)}
+                  disabled={isTyping}
+                  style={{ flex: 1, padding: '11px 14px', borderRadius: 12, border: '1.5px solid var(--sand-200)', background: 'var(--surface-raised)', color: 'var(--text-1)', fontSize: 13, fontFamily: 'inherit', outline: 'none' }}
+                />
+              )}
+              {!useTypedField && inputText.trim() !== '' && (
+                <button onClick={() => setInputText('')} disabled={isTyping} aria-label="입력 지우기" style={{ width: 44, height: 44, borderRadius: 9999, border: '1px solid var(--sand-200)', background: 'var(--surface-raised)', color: 'var(--text-2)', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer', flexShrink: 0 }}>
+                  <X size={13} weight="bold" />
+                </button>
+              )}
+              {showMic && (
+                <button
+                  onClick={() => (speech.listening ? speech.stop() : speech.start())}
+                  disabled={isTyping}
+                  aria-label={speech.listening ? '음성 입력 멈추기' : '말로 답하기'}
+                  aria-pressed={speech.listening}
+                  style={{ width: 44, height: 44, borderRadius: 9999, border: `1px solid ${speech.listening ? 'transparent' : 'var(--coral-200)'}`, background: speech.listening ? 'var(--brand-surface)' : 'var(--brand-soft)', color: speech.listening ? '#FFFCF6' : 'var(--coral-700)', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer', flexShrink: 0 }}
+                >
+                  {speech.listening ? <Stop size={14} weight="fill" /> : <Microphone size={16} weight="fill" />}
+                </button>
+              )}
+              <button
+                onClick={() => submit(inputText)}
+                disabled={!canSubmit}
+                aria-label="답변 보내기"
+                style={{ width: useTypedField ? undefined : 44, flex: useTypedField ? 1 : undefined, height: 44, borderRadius: useTypedField ? 12 : 9999, border: 'none', background: 'var(--brand-surface)', color: '#FFFCF6', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6, fontSize: 14, fontWeight: 700, fontFamily: 'inherit', cursor: canSubmit ? 'pointer' : 'not-allowed', flexShrink: 0, opacity: canSubmit ? 1 : 0.5 }}
+              >
+                {useTypedField && <span>이 답으로 보내기</span>}
+                <ArrowUp size={14} weight="fill" />
+              </button>
+            </div>
+          </div>
+        ) : isFinished ? (
+          <button
+            onClick={confirmUltimate}
+            disabled={confirming}
+            style={{ width: '100%', height: 52, borderRadius: 12, border: 'none', background: 'var(--brand-surface)', color: '#FFFCF6', fontWeight: 700, fontSize: 15, fontFamily: 'inherit', cursor: confirming ? 'wait' : 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8, opacity: confirming ? 0.6 : 1 }}
+          >
+            {confirming ? '저장하는 중…' : '이 목표로 만다라트 만들기'} <ArrowRight size={16} />
+          </button>
+        ) : (
+          <button
+            onClick={onCancel}
+            style={{ width: '100%', height: 52, borderRadius: 12, border: '1px solid var(--sand-200)', background: 'var(--surface-raised)', color: 'var(--text-2)', fontWeight: 600, fontSize: 14, fontFamily: 'inherit', cursor: 'pointer' }}
+          >
+            나중에 할게요
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SummaryRow({ label, children }: { label: string; children: React.ReactNode }) {
+  if (children == null || children === '') return null;
+  return (
+    <div style={{ display: 'flex', gap: 8, fontSize: 12, lineHeight: 1.55 }}>
+      <span style={{ flexShrink: 0, width: 82, color: 'var(--coral-700)', fontWeight: 700 }}>{label}</span>
+      <span style={{ flex: 1, minWidth: 0, color: 'var(--text-1)', wordBreak: 'keep-all', overflowWrap: 'anywhere' }}>{children}</span>
+    </div>
+  );
+}
+
+function placeholderFor(q: InterviewQuestion): string {
+  switch (q.answerType) {
+    case 'date_picker':
+      return 'YYYY-MM-DD';
+    case 'time_range':
+      return '예: 09:00-23:00';
+    case 'chip':
+    case 'select':
+      return '직접 입력해도 돼요...';
+    default:
+      return '떠오르는 대로 적어도 괜찮아요...';
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -31,6 +31,10 @@ export type ScreenId =
   | 'inbox'
   | 'review'
   | 'goals'
+  // 궁극적 목표 만다라트(#220) — S29 인터뷰 / S30 초안 승인 / S31 상시 뷰.
+  | 'ultimate-interview'
+  | 'mandala-draft'
+  | 'mandala'
   | 'settings'
   | 'my-info';
 


### PR DESCRIPTION
## 무엇을 했나

이슈 #220 의 신규 화면 4개(S29~S32)를 **실제 endpoint 에 붙여서** 만들었습니다.

> 이슈 본문의 진행상황 표는 "PR5/PR6 미착수 → S30/S31/S32 는 호출할 endpoint 가 없다"고 적혀 있지만,
> #227(OpenAPI 동기화) 이후 `openapi.json` / `src/types/openapi.d.ts` 에 U0~U10 이 전부 존재합니다.
> 이슈 본문의 잠정 타입 스니펫이 아니라 **`openapi.d.ts` 의 실제 스키마를 읽고** 그것에 맞춰 구현했습니다.

| 화면 | 파일 | 소비 endpoint |
|---|---|---|
| **S29** 궁극목표 인터뷰 | `src/screens/UltimateGoalInterviewScreen.tsx` | `GET /interview/slot-catalog?kind=ultimate`(U0), `POST /interview/sessions {kind:"ultimate"}`(U0b), `/answers` `/finish`, `POST /goals/ultimate`(U1) |
| **S30** 만다라트 초안(HITL) | `src/screens/MandalaDraftScreen.tsx` | U2 `POST /plans/mandala/subgoals` → U3 `POST /plans/mandala/generate` → U4 `GET /plans/mandala/{planId}` · U5 `regenerate-branch` → U6 `approve` / U7 `POST /plans/{planId}/discard` |
| **S31** 만다라트 상시 뷰 | `src/screens/MandalaScreen.tsx` | U8 `GET /goals/{goalId}/mandala` |
| **S32** 셀 상세 바텀시트 | `src/components/MandalaCellSheet.tsx` | U9 `PATCH /goals/mandala/nodes/{nodeId}`, U10 `POST .../promote` |

공용 모듈 2개:
- `src/lib/mandala.ts` — 9×9 좌표 계산(`SLOT` 상수 하나), 초안/승인본 두 소스를 같은 `MandalaBoard` 로 정규화, 승인 전 로컬 편집 저장
- `src/components/MandalaGrid.tsx` — 3×3 드릴다운 / 9×9 조망 / 아코디언 목록 3뷰 + 진척도 미터

## 핵심은 격자가 아니라 여백

- `source='rule'`(AI 가 제대로 못 채운 칸)과 아예 빈 칸은 **점선**으로 그리고, 실선 확정 칸과 구분합니다. 억지로 채우지 않습니다.
- 초안의 `gaps[].reason` 은 셀 상세에서 "AI가 이 칸을 비워 뒀어요 — {사유}" 로 그대로 보여줍니다.
- 사용자가 인터뷰에서 직접 말한 축(`locked`)은 자물쇠 배지 + "재생성 제외" 문구로 표시합니다.
- 승인 후에도 `source` · `whyText` · `completedAt` 을 셀 상세에서 계속 보존해 보여줍니다.

## 렌더링·계약 관련 결정

- **좌표는 서버가 안 주므로 FE 가 순수 계산**합니다. `SLOT = [0,1,2,3,5,6,7,8]` 하나로 끝나고, 렌더 81칸 = 저장 73행 + 축 8칸 중복 렌더입니다. (81칸이 전부 유일 좌표에 놓이는지 검산 완료)
- **기본 뷰는 9×9 가 아니라 3×3 드릴다운**입니다. 모바일 폭에서 81칸 균등 배치는 셀 한 변이 ≈38pt 로 최소 터치 타겟(44pt) 미달이라, 9×9 는 읽기 전용 조망 토글로 분리했습니다.
- **HITL 3층 승인 모델**을 그대로 따릅니다 — 셀 텍스트 편집은 승인 전까지 서버 호출 0회. 그래서 편집본을 `planId` 키로 `localStorage` 에 즉시 저장하고, 화면을 떠났다 돌아오면 U4 로 스냅샷만 다시 받아(LLM 재호출 0회) 로컬 편집을 얹습니다. 만료(410)/삭제 시엔 흔적을 지우고 Stage A 부터 다시 시작합니다.
- **U9 응답은 `progress`/`coverage` 를 `null` 로 준다**는 규약에 맞춰, 편집 직후 U8 을 한 번 더 불러 진척도를 최신으로 맞춥니다.
- **U10 은 축(depth=1)만** 대상이라 승격 버튼을 축 슬롯에서만 노출합니다(중앙·개별 셀에서는 아예 안 보임 → 422 를 유발하지 않음). tier 한도 초과 시 기존 `GOAL_TIER_LIMIT_EXCEEDED` 문구를 그대로 씁니다.
- 궁극목표는 `tier="parked"` 로 일반 목표와 섞여 오므로 `isUltimate` 로만 구분합니다(목표마다 만다라를 따로 조회하지 않음).

## 접근성

- 시각 격자의 9×9 조망은 `aria-hidden` + 내부 버튼 `tabIndex=-1`, 의미는 아코디언 목록 뷰가 담당합니다. `prefers-reduced-motion` 이면 목록 뷰가 기본이 됩니다.
- 셀 라벨에 위치를 넣습니다 — 예: `"체력 그룹, 3번째 칸, 몸통 강화, 완료"`.
- 색만으로 완료/미완료/빈칸/AI폴백을 구분하지 않습니다(실선·점선 + 체크·자물쇠·연필 아이콘 병행).
- 한글이 음절 단위로 찢기지 않도록 `word-break: keep-all` + `overflow-wrap: anywhere`(`break-all` 미사용), 툴팁 없음(전문은 S32 에서).

## 진입점 (S26 목표 화면)

- 헤더 아래 "궁극적 목표 만다라트" 카드 — 없으면 **[궁극적 목표 세우기]**, 있으면 **[만다라트 보기] / [다시 세우기]**
- 궁극목표 카드에 **[만다라트 보기]**, 승격된 목표 카드에 **만다라트 축 · {축 제목}** 배지(`promotedFromAxis`)

## 확인

- `npm run build` 통과
- `npm run check:api` PASS (OK 98 / WARN 0 / GONE 0) · `npm run check:fields` PASS (PHANTOM 0 / MISREF 0 / UNREAD 0)
- 9×9 좌표 검산: 81칸 전부 유일 좌표, 범위 내

## 남은 범위

- [ ] **모닝 브리프 "이번 주 굴리는 축" 1줄** — 백엔드 PR7 대기. 지금은 브리프 응답에 축 정보가 없어서, 넣으면 프론트가 지어낸 값이 됩니다.
- [ ] **승격 → 계획 인터뷰(S02) 자동 연결** — 승격 후 목표 화면에서 이어가도록만 안내합니다. 특정 goalId 로 딥 인터뷰를 시작하는 계약이 아직 없어(세션은 사용자당 1개, goalId 파라미터 없음) 억지로 연결하지 않았습니다.
- [ ] **계획 인터뷰의 `goals.heaviest` 를 만다라 8축 선택지로 확장** — 이슈에도 "아직 미정, 별도 이슈" 로 남아 있어 건드리지 않았습니다.
- [ ] **9×9 조망의 pan/zoom 제스처** — 지금은 축소 렌더 + 탭해서 줌인까지입니다. 핀치 줌은 넣지 않았습니다(모바일에서 격자 스크롤과 충돌).

Refs #220
