### PR TITLE
fix(reflection): 저녁 일괄 회고에 실패 사유 입력 단계 추가 (#238)

### DIFF
--- a/src/components/FailureTagPicker.tsx
+++ b/src/components/FailureTagPicker.tsx
@@ -1,0 +1,116 @@
+// 실패 사유 태그 입력 폼 (S18, 백엔드 #17 카탈로그).
+//
+// 원래 오늘 화면(TodayScreen)의 실패 시트 안에만 인라인으로 박혀 있던 UI다. 저녁 일괄
+// 회고(EveningCheckInScreen)에서도 같은 입력을 받아야 해서(#238) 폼 본체만 떼어냈다.
+// 시트 껍데기(오버레이·바텀시트)는 화면마다 다르므로 여기 넣지 않는다 — 오늘 화면은
+// 바텀시트로, 저녁 체크인은 마법사 단계로 각각 감싼다.
+import { useEffect, useState } from 'react';
+import { FAIL_REASONS } from '../data';
+import { reflectionApi } from '../lib/api';
+import { Segmented } from './Segmented';
+
+export interface FailureTagOption {
+  code: string;
+  labelKo: string;
+}
+
+// 실패 태그 마스터 카탈로그(GET /reflection/failure-tags, #17).
+// 백엔드가 응답하지 않으면 더미 라벨로 버틴다 — 사유 입력 자체가 막히면 안 되기 때문이다.
+// tagCode 를 함께 들고 있어야 reflectionApi.tagExecution 에 실제 코드를 실어 보낼 수 있다(#80).
+export function useFailureTagCatalog(): FailureTagOption[] {
+  const [reasons, setReasons] = useState<FailureTagOption[]>(
+    FAIL_REASONS.map((label) => ({ code: label, labelKo: label })),
+  );
+  useEffect(() => {
+    let cancelled = false;
+    reflectionApi.failureTags().then(
+      (tags) => {
+        if (!cancelled && tags.length) setReasons(tags.map((t) => ({ code: t.tagCode, labelKo: t.labelKo })));
+      },
+      () => { /* 미구현이거나 오류가 발생한 상황 — 더미 라벨을 그대로 유지한다 */ },
+    );
+    return () => { cancelled = true; };
+  }, []);
+  return reasons;
+}
+
+interface FailureTagPickerProps {
+  reasons: FailureTagOption[];
+  selected: FailureTagOption[];
+  onChange: (next: FailureTagOption[]) => void;
+  memo: string;
+  onMemoChange: (memo: string) => void;
+  memoPlaceholder?: string;
+  // task_aversiveness(#222) 1~5 문항. 값을 보낼 곳이 있는 화면에서만 켠다.
+  // 백엔드에 저장 필드가 아직 없으므로(#299), 답을 받아도 버려지는 화면에서는 묻지 않는다.
+  aversiveness?: number | null;
+  onAversivenessChange?: (v: number | null) => void;
+}
+
+// 태그는 최대 2개까지 고를 수 있다. 3번째를 누르면 가장 오래된 것을 밀어낸다(swap).
+// 이 규칙을 여기 한 곳에만 두어야 화면마다 상한이 어긋나는 일이 생기지 않는다.
+function toggle(selected: FailureTagOption[], r: FailureTagOption): FailureTagOption[] {
+  if (selected.some((t) => t.code === r.code)) return selected.filter((t) => t.code !== r.code);
+  if (selected.length >= 2) return [selected[1], r];
+  return [...selected, r];
+}
+
+export function FailureTagPicker({
+  reasons,
+  selected,
+  onChange,
+  memo,
+  onMemoChange,
+  memoPlaceholder = '메모 (선택) — 어떤 상황이었는지 적어두면 다음 제안이 더 잘 맞아요',
+  aversiveness,
+  onAversivenessChange,
+}: FailureTagPickerProps) {
+  return (
+    <>
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginBottom: 6 }}>
+        {reasons.map((r) => {
+          const sel = selected.some((t) => t.code === r.code);
+          return (
+            <button
+              key={r.code}
+              aria-pressed={sel}
+              onClick={() => onChange(toggle(selected, r))}
+              style={{ padding: '9px 12px', borderRadius: 9999, background: sel ? 'var(--text-1)' : 'var(--surface-raised)', color: sel ? '#FAF6EE' : 'var(--text-1)', border: `1px solid ${sel ? 'var(--text-1)' : 'var(--sand-200)'}`, fontSize: 13, fontWeight: 500, cursor: 'pointer', fontFamily: 'inherit', transition: 'all 160ms' }}
+            >
+              {r.labelKo}
+            </button>
+          );
+        })}
+      </div>
+      <div style={{ fontSize: 11, color: 'var(--text-3)', marginBottom: 16 }}>
+        최대 2개까지 고를 수 있어요{selected.length > 0 ? ` · ${selected.length}/2` : ''}
+      </div>
+
+      {onAversivenessChange && (
+        <>
+          <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--text-1)', marginBottom: 8 }}>이 일이 얼마나 하기 싫었나요?</div>
+          <Segmented
+            fluid
+            ariaLabel="하기 싫은 정도 1~5"
+            value={aversiveness ?? 0}
+            onChange={(v) => onAversivenessChange(aversiveness === v ? null : v)}
+            options={[1, 2, 3, 4, 5].map((n) => ({ value: n, label: String(n) }))}
+          />
+          <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 10, color: 'var(--text-3)', margin: '4px 0 14px' }}>
+            <span>전혀 아니었어요</span>
+            <span>정말 하기 싫었어요</span>
+          </div>
+        </>
+      )}
+
+      <textarea
+        value={memo}
+        onChange={(e) => onMemoChange(e.target.value)}
+        placeholder={memoPlaceholder}
+        rows={2}
+        maxLength={300}
+        style={{ width: '100%', boxSizing: 'border-box', borderRadius: 12, border: '1px solid var(--sand-200)', background: 'var(--surface-ground)', padding: '10px 12px', fontSize: 13, fontFamily: 'inherit', color: 'var(--text-1)', outline: 'none', resize: 'none', marginBottom: 14 }}
+      />
+    </>
+  );
+}

--- a/src/screens/EveningCheckInScreen.tsx
+++ b/src/screens/EveningCheckInScreen.tsx
@@ -1,6 +1,11 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { CheckCircle } from '@phosphor-icons/react';
 import { DemoNotice } from '../components/DemoNotice';
+import {
+  FailureTagPicker,
+  useFailureTagCatalog,
+  type FailureTagOption,
+} from '../components/FailureTagPicker';
 import { plansApi, reflectionApi } from '../lib/api';
 import { localDateStr, weekStartStr } from '../lib/dates';
 import type {
@@ -12,6 +17,18 @@ import type {
 
 interface EveningCheckInScreenProps {
   onDone: () => void;
+}
+
+// 화면 단계. 'tags' 는 batch 응답의 needsFailureTags 가 비어 있지 않을 때만 거친다(#238).
+type Step = 'checkin' | 'tags' | 'tomorrow' | 'done';
+
+// 사유를 받아야 하는 실행 1건 — batch 를 보내고 나면 pending 목록에서 빠지기 때문에,
+// 제목과 날짜를 미리 떠 두었다가 사유 단계에서 그대로 보여 준다.
+interface TagTarget {
+  executionId: string;
+  title: string | null;
+  scheduledDate: string | null;
+  status: CompletionStatus | undefined;
 }
 
 // YYYY-MM-DD → 오늘/어제/그제 상대 라벨 (최근 3일 회고 대상이라 그 범위만 다룬다).
@@ -61,7 +78,7 @@ function idempotencyKeyFor(items: ReflectionBatchItem[]): string {
 }
 
 export function EveningCheckInScreen({ onDone }: EveningCheckInScreenProps) {
-  const [step, setStep] = useState(0);
+  const [step, setStep] = useState<Step>('checkin');
   const [energy, setEnergy] = useState<number | null>(null);
 
   // GET /reflection/pending (#83) — 최근 3일 미체크(in_progress) 실행. 실패 시 더미로 가리지
@@ -74,8 +91,23 @@ export function EveningCheckInScreen({ onDone }: EveningCheckInScreenProps) {
   const [picked, setPicked] = useState<Record<string, CompletionStatus>>({});
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
-  // 실패/부분완료인데 사유를 안 남긴 항목 — 서버가 알려준다(S18 유도 대상).
-  const [needsTags, setNeedsTags] = useState<string[]>([]);
+
+  // 실패/부분완료인데 사유를 안 남긴 항목 — 서버가 needsFailureTags 로 알려준다(S18 유도 대상).
+  // 예전에는 이 목록을 받아 두고도 입력 화면으로 이어주지 않아서, 완료 화면이 "오늘 화면에서
+  // 카드를 열면 이어서 할 수 있어요" 라고 안내하지만 실제로는 도달할 수 없는 경로였다(#238).
+  // 그 결과 태그가 0개인 채로 회복 룰 엔진이 돌아 카드가 늘 같은 조합으로만 뽑혔다.
+  // 이제 batch 직후 'tags' 단계에서 한 건씩 사유를 받아 POST /reflection/failure-tags 로 보낸다.
+  const [tagTargets, setTagTargets] = useState<TagTarget[]>([]);
+  const [tagIndex, setTagIndex] = useState(0);
+  const [tagSelected, setTagSelected] = useState<FailureTagOption[]>([]);
+  const [tagMemo, setTagMemo] = useState('');
+  const [tagSaving, setTagSaving] = useState(false);
+  const [tagError, setTagError] = useState<string | null>(null);
+  // 완료 화면 안내용 집계. tagTargets 는 batch 를 새로 보낼 때마다 갈리므로, 이번 체크인에서
+  // 실제로 남긴 건수와 넘긴 건수는 따로 누적한다(뒤로 갔다가 다시 제출해도 숫자가 지워지지 않는다).
+  const [taggedCount, setTaggedCount] = useState(0);
+  const [skippedCount, setSkippedCount] = useState(0);
+  const failReasons = useFailureTagCatalog();
 
   useEffect(() => {
     let cancelled = false;
@@ -103,15 +135,30 @@ export function EveningCheckInScreen({ onDone }: EveningCheckInScreenProps) {
 
   const goNext = () => {
     setSubmitError(null);
-    if (items.length === 0) { setStep(1); return; }
+    if (items.length === 0) { setStep('tomorrow'); return; }
     setSubmitting(true);
     reflectionApi.batch({ items }, idempotencyKeyFor(items)).then(
       (res) => {
-        setNeedsTags(res.needsFailureTags);
+        // pending 에서 빼기 전에 제목·날짜를 떠 둔다 — 사유 단계에서 어떤 실행인지 보여줘야 한다.
+        // 서버가 목록에 없는 executionId 를 돌려주더라도 건너뛰지 않고 제목만 비운 채 받는다.
+        const byId = new Map(pending.map((p) => [p.executionId, p]));
+        setTagTargets(res.needsFailureTags.map((id) => {
+          const p = byId.get(id);
+          return {
+            executionId: id,
+            title: p?.title ?? null,
+            scheduledDate: p?.scheduledDate ?? null,
+            status: picked[id],
+          };
+        }));
+        setTagIndex(0);
+        setTagSelected([]);
+        setTagMemo('');
+        setTagError(null);
         // 종결된 실행은 더 이상 미체크가 아니다 — 목록에서 뺀다.
         const done = new Set(items.map((i) => i.executionId));
         setPending((ps) => ps.filter((p) => !done.has(p.executionId)));
-        setStep(1);
+        setStep(res.needsFailureTags.length > 0 ? 'tags' : 'tomorrow');
       },
       () => {
         // 저장 실패를 삼키지 않는다 — 삼키면 사용자는 기록된 줄 알고 넘어간다.
@@ -120,7 +167,51 @@ export function EveningCheckInScreen({ onDone }: EveningCheckInScreenProps) {
     ).finally(() => setSubmitting(false));
   };
 
-  if (step === 2) {
+  // 사유 단계에서 한 건을 끝냈을 때 — 다음 건으로 넘기거나, 마지막이면 내일 미리보기로.
+  const advanceTagStep = () => {
+    setTagSelected([]);
+    setTagMemo('');
+    setTagError(null);
+    const next = tagIndex + 1;
+    if (next >= tagTargets.length) setStep('tomorrow');
+    else setTagIndex(next);
+  };
+
+  // 이 건은 사유를 남기지 않고 넘긴다. 태그 입력은 끝까지 선택 사항이다 — 필수로 만들면
+  // 저녁 체크인 자체를 회피하게 되고, 그러면 실행 데이터마저 못 받는다.
+  const skipTag = () => {
+    setSkippedCount((c) => c + 1);
+    advanceTagStep();
+  };
+
+  // 남은 건을 통째로 넘긴다.
+  const skipRemainingTags = () => {
+    setSkippedCount((c) => c + (tagTargets.length - tagIndex));
+    setStep('tomorrow');
+  };
+
+  // 0개 태그로는 저장하지 않는다 — 빈 요청은 회복 룰 엔진에 아무 정보도 주지 못한다.
+  // 남기고 싶지 않으면 [건너뛰기] 로 넘어가면 된다.
+  const submitTag = () => {
+    const target = tagTargets[tagIndex];
+    if (!target || tagSelected.length === 0) return;
+    setTagSaving(true);
+    setTagError(null);
+    reflectionApi.tagExecution(target.executionId, {
+      tagCodes: tagSelected.map((t) => t.code),
+      memo: tagMemo.trim() || null,
+    }).then(
+      () => {
+        setTaggedCount((c) => c + 1);
+        advanceTagStep();
+      },
+      () => {
+        setTagError('사유를 저장하지 못했어요. 다시 시도하거나 건너뛸 수 있어요.');
+      },
+    ).finally(() => setTagSaving(false));
+  };
+
+  if (step === 'done') {
     const selectedEnergy = energyOptions.find((e) => e.v === energy);
     return (
       <div style={{ height: '100%', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '40px 20px', background: 'var(--surface-ground)', gap: 18 }}>
@@ -134,9 +225,17 @@ export function EveningCheckInScreen({ onDone }: EveningCheckInScreenProps) {
             <b>내일 반영 사항:</b><br />에너지 "{selectedEnergy.label}" 기록 → 내일 블록 강도 자동 조정
           </div>
         )}
-        {needsTags.length > 0 && (
+        {/* 사유를 실제로 남겼는지 그대로 알려 준다. 예전에는 "오늘 화면에서 이어서 할 수
+            있어요" 라고 안내했지만, 그 executionId 들은 대개 어제·그제 건이라 오늘 화면의
+            날짜 스코프에 뜨지 않았고 'failed' 를 다시 여는 경로 자체도 없었다(#238). */}
+        {taggedCount > 0 && (
+          <div style={{ padding: '10px 14px', background: 'var(--brand-soft)', borderRadius: 12, border: '1px solid var(--coral-200)', fontSize: 12, color: 'var(--coral-700)', textAlign: 'left', width: '100%', lineHeight: 1.55 }}>
+            <b>회복 제안에 반영:</b><br />{taggedCount}건의 사유를 남겼어요. 다음 회복안이 그 상황에 맞춰 달라져요.
+          </div>
+        )}
+        {skippedCount > 0 && (
           <div style={{ padding: '10px 14px', background: 'var(--surface-raised)', borderRadius: 12, border: '1px solid var(--sand-200)', fontSize: 12, color: 'var(--text-2)', textAlign: 'left', width: '100%', lineHeight: 1.55 }}>
-            {needsTags.length}건은 무엇이 막았는지 남기면 그에 맞는 회복안을 제안해드려요. 오늘 화면에서 카드를 열면 이어서 할 수 있어요.
+            {skippedCount}건은 사유를 남기지 않았어요. 사유가 없으면 회복안이 늘 비슷하게 나오니, 다음 저녁 체크인에서 남겨 주세요.
           </div>
         )}
         <div style={{ width: '100%' }}>
@@ -149,8 +248,84 @@ export function EveningCheckInScreen({ onDone }: EveningCheckInScreenProps) {
     );
   }
 
-  if (step === 1) {
-    return <TomorrowPreview onBack={() => setStep(0)} onConfirm={() => setStep(2)} />;
+  if (step === 'tomorrow') {
+    return <TomorrowPreview onBack={() => setStep('checkin')} onConfirm={() => setStep('done')} />;
+  }
+
+  // 실패 사유 입력 단계(#238) — needsFailureTags 를 한 건씩 훑는다. 여러 건을 한 화면에
+  // 늘어놓으면 태그 13종 + 메모가 겹쳐 길어지므로, 한 번에 한 건만 묻는다.
+  if (step === 'tags') {
+    const target = tagTargets[tagIndex];
+    // 방어적 처리 — 대상이 비면 흐름을 막지 않고 다음 단계로 흘려보낸다.
+    if (!target) {
+      return <TomorrowPreview onBack={() => setStep('checkin')} onConfirm={() => setStep('done')} />;
+    }
+    const isLast = tagIndex === tagTargets.length - 1;
+    const statusLabel = statusOptions.find((s) => s.v === target.status)?.label;
+    return (
+      <div style={{ height: '100%', overflowY: 'auto', padding: '16px 18px 32px', background: 'var(--surface-ground)', display: 'flex', flexDirection: 'column', gap: 14 }}>
+        <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between' }}>
+          <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: '-0.01em', color: 'var(--text-3)' }}>저녁 체크인 · 사유 남기기</div>
+          <span className="tnum" style={{ fontSize: 11, color: 'var(--text-3)' }}>{tagIndex + 1} / {tagTargets.length}</span>
+        </div>
+        <h2 style={{ fontSize: 22, fontWeight: 700, letterSpacing: '-0.02em', margin: '0 0 4px' }}>무엇이 막았나요?</h2>
+        <p style={{ fontSize: 13, color: 'var(--text-2)', lineHeight: 1.55 }}>
+          사유를 남기면 그 상황에 맞는 회복안을 제안해드려요. 남기지 않으면 늘 같은 제안이 반복돼요.
+        </p>
+
+        <div style={{ background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', borderRadius: 14, padding: 14, display: 'flex', flexDirection: 'column', gap: 10 }}>
+          <div style={{ display: 'flex', gap: 10, alignItems: 'center' }}>
+            {target.scheduledDate && (
+              <span style={{ height: 'var(--ctrl-xs)', minWidth: 34, padding: '0 7px', background: 'var(--sand-100)', border: '1px solid var(--sand-200)', borderRadius: 9999, fontSize: 10, color: 'var(--text-2)', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>{relDayLabel(target.scheduledDate)}</span>
+            )}
+            <div style={{ flex: 1, fontSize: 13, fontWeight: 500, color: 'var(--text-1)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{target.title ?? '체크인한 실행'}</div>
+            {statusLabel && (
+              <span style={{ fontSize: 11, color: 'var(--text-3)', flexShrink: 0 }}>{statusLabel}</span>
+            )}
+          </div>
+          {/* 정서 1문항(#222)은 여기서 묻지 않는다 — POST /reflection/failure-tags 에 담을
+              필드가 아직 없어(BE #299) 답을 받아도 버려지기 때문이다. 필드가 생기면
+              onAversivenessChange 를 넘겨 주기만 하면 된다. */}
+          <FailureTagPicker
+            reasons={failReasons}
+            selected={tagSelected}
+            onChange={setTagSelected}
+            memo={tagMemo}
+            onMemoChange={setTagMemo}
+          />
+        </div>
+
+        {tagError && (
+          <div role="alert" style={{ padding: '10px 12px', background: '#FBE9E7', border: '1px solid var(--danger)', borderRadius: 10, fontSize: 12, color: 'var(--danger-ink)', lineHeight: 1.5 }}>
+            {tagError}
+          </div>
+        )}
+
+        <div style={{ display: 'flex', gap: 8 }}>
+          <button
+            onClick={skipTag}
+            disabled={tagSaving}
+            style={{ flex: 1, height: 44, borderRadius: 12, border: '1px solid var(--sand-200)', background: 'transparent', color: 'var(--text-2)', fontWeight: 600, fontSize: 13, fontFamily: 'inherit', cursor: tagSaving ? 'default' : 'pointer' }}
+          >
+            건너뛰기
+          </button>
+          <button
+            onClick={submitTag}
+            disabled={tagSelected.length === 0 || tagSaving}
+            style={{ flex: 2, height: 44, borderRadius: 12, border: 'none', background: 'var(--text-1)', color: '#FAF6EE', fontWeight: 700, fontSize: 14, fontFamily: 'inherit', cursor: tagSelected.length && !tagSaving ? 'pointer' : 'default', opacity: tagSelected.length && !tagSaving ? 1 : 0.35 }}
+          >
+            {tagSaving ? '저장하는 중…' : isLast ? '저장하고 완료 →' : '저장하고 다음 →'}
+          </button>
+        </div>
+        <button
+          onClick={skipRemainingTags}
+          disabled={tagSaving}
+          style={{ alignSelf: 'center', background: 'none', border: 'none', color: 'var(--text-3)', fontSize: 12, fontFamily: 'inherit', textDecoration: 'underline', cursor: tagSaving ? 'default' : 'pointer', padding: 4 }}
+        >
+          나중에 할게요
+        </button>
+      </div>
+    );
   }
 
   return (

--- a/src/screens/TodayScreen.tsx
+++ b/src/screens/TodayScreen.tsx
@@ -10,14 +10,14 @@ import {
 } from '@phosphor-icons/react';
 import type { Task, TaskStatus } from '../types';
 import type { AgendaCard, AgendaFixedSchedule, ApiGoal, WeeklyPlanResponse } from '../types/api';
-import { FAIL_REASONS, GOAL_CATEGORY_OPTIONS } from '../data';
+import { GOAL_CATEGORY_OPTIONS } from '../data';
 import { useNavigation } from '../contexts/NavigationContext';
-import { friendlyError, goalsApi, habitsApi, plansApi, reflectionApi, todayApi } from '../lib/api';
+import { friendlyError, goalsApi, habitsApi, plansApi, todayApi } from '../lib/api';
 import { localDateStr } from '../lib/dates';
 import { dismissUncheckedBlocks, filterDismissedBlocks, findUncheckedBlocks } from '../lib/uncheckedBlocks';
 import { categoryLabel, goalColor } from '../data';
 import { DemoNotice } from '../components/DemoNotice';
-import { Segmented } from '../components/Segmented';
+import { FailureTagPicker, useFailureTagCatalog, type FailureTagOption } from '../components/FailureTagPicker';
 import { HeroTaskCard } from '../components/HeroTaskCard';
 import { TodayTimeline } from '../components/TodayTimeline';
 import { ProgressSheet } from '../components/ProgressSheet';
@@ -337,26 +337,16 @@ export function MergedTodayScreen({ tasks: allTasks, onOpen, onMarkDone, onParti
     if (uncheckedBlocks[0]) setSelectedTaskId(uncheckedBlocks[0].actionId);
   };
   // 실패 사유 태그 — 최대 2개 선택(S18). memo 는 선택 자유 텍스트.
-  const [failTags, setFailTags] = useState<{ code: string; labelKo: string }[]>([]);
+  const [failTags, setFailTags] = useState<FailureTagOption[]>([]);
   const [failMemo, setFailMemo] = useState('');
   // task_aversiveness — 실패 회고에 얹는 정서 1문항(#222), 1~5. 선택 안 해도 제출 가능
   // (마찰 최소화 — 강제하지 않는다). 백엔드 필드가 아직 없어 로컬 상태로만 갖고 있다가
   // markFailed 로 전달만 하고, 실제 전송은 백엔드 스펙이 생기면 그때 연결한다.
   const [taskAversiveness, setTaskAversiveness] = useState<number | null>(null);
   const [toast, setToast] = useState<{ msg: string; tone: 'ok' | 'error' } | null>(null);
-  // 실패 사유 목록 — 백엔드 실패 태그 카탈로그(#17)가 오면 그 tagCode/labelKo 로, 없으면 더미.
-  // tagCode 를 같이 들고 있어야 reflectionApi.tagExecution 저장 호출에 실 코드를 실어보낸다(#80).
-  const [failReasons, setFailReasons] = useState<{ code: string; labelKo: string }[]>(
-    FAIL_REASONS.map((label) => ({ code: label, labelKo: label })),
-  );
-  useEffect(() => {
-    let cancelled = false;
-    reflectionApi.failureTags().then(
-      (tags) => { if (!cancelled && tags.length) setFailReasons(tags.map((t) => ({ code: t.tagCode, labelKo: t.labelKo }))); },
-      () => { /* 미구현/오류 — 더미 그대로 */ },
-    );
-    return () => { cancelled = true; };
-  }, []);
+  // 실패 사유 목록 — 백엔드 실패 태그 카탈로그(#17). 저녁 일괄 회고도 같은 목록을 쓰므로
+  // 조회와 더미 fallback 을 훅 하나로 모았다(#238).
+  const failReasons = useFailureTagCatalog();
   // 초기값 비움 → 로딩 중 스켈레톤. 백엔드 미동작 시에만 더미 fallback (flash 방지).
   const [habits, setHabits] = useState<Habit[]>([]);
   const [addingHabit, setAddingHabit] = useState(false);
@@ -453,14 +443,6 @@ export function MergedTodayScreen({ tasks: allTasks, onOpen, onMarkDone, onParti
   // 일정이 0개면 "모두 완료"가 아니다(0===0 이라도) — 없는 걸 다 했다고 하지 않는다.
   const allDone = tasks.length > 0 && doneTasks.length === tasks.length;
 
-  // 태그 토글 — 최대 2개. 3번째 클릭 시 가장 오래된 것을 밀어낸다(swap).
-  const toggleFailTag = (r: { code: string; labelKo: string }) => {
-    setFailTags((cur) => {
-      if (cur.some((t) => t.code === r.code)) return cur.filter((t) => t.code !== r.code);
-      if (cur.length >= 2) return [cur[1], r];
-      return [...cur, r];
-    });
-  };
   const submitFail = () => {
     if (failTags.length === 0 || !failSheet) return;
     onFail(
@@ -799,32 +781,17 @@ export function MergedTodayScreen({ tasks: allTasks, onOpen, onMarkDone, onParti
             <div style={{ width: 36, height: 4, borderRadius: 9999, background: 'var(--sand-300)', margin: '0 auto 14px' }} />
             <div style={{ fontSize: 17, fontWeight: 600, marginBottom: 4, color: 'var(--text-1)' }}>지금 어떤 상태예요?</div>
             <p style={{ fontSize: 12, color: 'var(--text-3)', marginBottom: 14 }}>이유를 기록하면 더 잘 맞는 복구안을 제안해드려요.</p>
-            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginBottom: 6 }}>
-              {failReasons.map((r) => {
-                const sel = failTags.some((t) => t.code === r.code);
-                return (
-                  <button key={r.code} onClick={() => toggleFailTag(r)} style={{ padding: '9px 12px', borderRadius: 9999, background: sel ? 'var(--text-1)' : 'var(--surface-raised)', color: sel ? '#FAF6EE' : 'var(--text-1)', border: `1px solid ${sel ? 'var(--text-1)' : 'var(--sand-200)'}`, fontSize: 13, fontWeight: 500, cursor: 'pointer', fontFamily: 'inherit', transition: 'all 160ms' }}>{r.labelKo}</button>
-                );
-              })}
-            </div>
-            <div style={{ fontSize: 11, color: 'var(--text-3)', marginBottom: 16 }}>최대 2개까지 고를 수 있어요{failTags.length > 0 ? ` · ${failTags.length}/2` : ''}</div>
-
-            {/* 정서 1문항(#222) — 실패로 기록될 때만 노출. 별도 단계 없이 이 시트 안에 얹는다.
-                선택은 선택 사항(강제하지 않음) — 문항 하나라도 필수화하면 그만큼 마찰이 는다. */}
-            <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--text-1)', marginBottom: 8 }}>이 일이 얼마나 하기 싫었나요?</div>
-            <Segmented
-              fluid
-              ariaLabel="하기 싫은 정도 1~5"
-              value={taskAversiveness ?? 0}
-              onChange={(v) => setTaskAversiveness((cur) => (cur === v ? null : v))}
-              options={[1, 2, 3, 4, 5].map((n) => ({ value: n, label: String(n) }))}
+            {/* 정서 1문항(#222)은 이 시트에서만 노출한다 — 실패로 기록되는 경로라서
+                markFailed 가 답을 이어받을 수 있기 때문이다. */}
+            <FailureTagPicker
+              reasons={failReasons}
+              selected={failTags}
+              onChange={setFailTags}
+              memo={failMemo}
+              onMemoChange={setFailMemo}
+              aversiveness={taskAversiveness}
+              onAversivenessChange={setTaskAversiveness}
             />
-            <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 10, color: 'var(--text-3)', margin: '4px 0 14px' }}>
-              <span>전혀 아니었어요</span>
-              <span>정말 하기 싫었어요</span>
-            </div>
-
-            <textarea value={failMemo} onChange={(e) => setFailMemo(e.target.value)} placeholder="메모 (선택) — 어떤 상황이었는지 적어두면 다음 제안이 더 잘 맞아요" rows={2} style={{ width: '100%', boxSizing: 'border-box', borderRadius: 12, border: '1px solid var(--sand-200)', background: 'var(--surface-ground)', padding: '10px 12px', fontSize: 13, fontFamily: 'inherit', color: 'var(--text-1)', outline: 'none', resize: 'none', marginBottom: 14 }} />
             <button onClick={submitFail} disabled={failTags.length === 0} style={{ width: '100%', height: 44, borderRadius: 12, border: 'none', background: 'var(--text-1)', color: '#FAF6EE', fontWeight: 700, fontSize: 14, fontFamily: 'inherit', cursor: failTags.length ? 'pointer' : 'not-allowed', opacity: failTags.length ? 1 : 0.35 }}>기록하고 복구안 보기</button>
           </div>
         </div>


### PR DESCRIPTION
관련: #238 (머지 여부와 이슈 종료는 리뷰어가 판단)

## 무엇이 문제였나

`POST /reflection/batch` 응답의 `needsFailureTags` 를 `needsTags` state 에 담아만 두고 실제 입력 화면으로 이어주지 않았습니다. 완료 화면은 이렇게 안내했습니다.

> N건은 무엇이 막았는지 남기면 그에 맞는 회복안을 제안해드려요. **오늘 화면에서 카드를 열면 이어서 할 수 있어요.**

그런데 그 경로가 실제로는 없었습니다.

1. 해당 `executionId` 들은 대개 어제·그제 미체크분이라 `TodayScreen` 의 날짜 스코프 agenda 에 애초에 뜨지 않습니다.
2. `TodayScreen` 의 `failSheet` 는 hero task 의 당일 즉시 체크인(`POST /today/check-ins`, `onFail`)에만 연결돼 있어서, `'failed'` 를 다시 열어 태그를 받는 경로가 없습니다.

그 결과 실패 태그가 0건으로 남고, `select_strategies` 의 `primary_trigger_tags` 교집합 점수가 전부 0 이 되어 회복 카드가 늘 `RESCHEDULE_DEFAULT` + `NANO_STEP` 조합으로만 뽑혔습니다(백엔드 도그푸딩 hanium-reaction/reaction-backend#258 실측 4건, 태그 전부 없음).

## 무엇을 바꿨나

### 1. `FailureTagPicker` 신설 (`src/components/FailureTagPicker.tsx`)

`TodayScreen` 실패 시트 안에 인라인으로 박혀 있던 입력 폼을 컴포넌트로 분리했습니다.

- 태그 칩 목록과 **최대 2개 swap 규칙**을 한 곳에 모았습니다. 예전에는 이 규칙이 `toggleFailTag` 안에만 있어서, 다른 화면이 같은 UI 를 쓰려면 규칙을 복사해야 했습니다.
- 카탈로그 조회(`GET /reflection/failure-tags`)와 더미 fallback 은 `useFailureTagCatalog` 훅으로 모았습니다. 두 화면이 같은 목록을 씁니다.
- 시트 껍데기(오버레이·바텀시트)는 넣지 않았습니다. 오늘 화면은 바텀시트, 저녁 체크인은 마법사 단계로 각각 감싸기 때문입니다.
- `memo` 에 `maxLength={300}` 을 붙였습니다. `ReflectionBatchItem` 주석에 명시된 상한인데 입력 쪽에서는 막고 있지 않았습니다.

### 2. `EveningCheckInScreen` 에 `'tags'` 단계 추가

`batch` 직후 `needsFailureTags` 를 **한 건씩** 훑으며 `POST /reflection/failure-tags/{executionId}` 로 태그 0~2개와 메모를 보냅니다.

- 여러 건을 한 화면에 늘어놓으면 태그 13종과 메모가 겹쳐 길어지므로 한 번에 한 건만 묻고, 우상단에 `1 / 3` 진행 표시를 둡니다.
- `batch` 를 보내고 나면 해당 항목이 `pending` 목록에서 빠지므로, 제목과 날짜를 미리 떠 두었다가 그대로 보여 줍니다.
- **[건너뛰기]** 와 **[나중에 할게요]** 로 언제든 넘어갈 수 있습니다. 태그 입력을 필수로 만들면 저녁 체크인 자체를 회피하게 되고, 그러면 실행 데이터마저 못 받기 때문입니다.
- 저장에 실패하면 삼키지 않고 인라인 오류를 띄운 뒤 재시도나 건너뛰기를 고를 수 있게 했습니다.

### 3. 완료 화면 안내를 실제 결과로 교체

도달할 수 없는 경로를 약속하는 대신, 남긴 건수와 넘긴 건수를 그대로 알려 줍니다.

### 4. `step` 을 문자열 유니온으로

`0 | 1 | 2` 사이에 단계를 끼워 넣으면 읽기 어려워지므로 `'checkin' | 'tags' | 'tomorrow' | 'done'` 으로 바꿨습니다.

## 범위 밖으로 둔 것

`task_aversiveness`(#222) 문항은 이 단계에서 묻지 않습니다. `FailureTagRequest` 에 담을 필드가 아직 없어서(BE hanium-reaction/reaction-backend#299) 답을 받아도 버려지기 때문입니다. 필드가 생기면 `onAversivenessChange` 를 넘겨 주기만 하면 됩니다. 오늘 화면 시트에서는 `markFailed` 가 답을 이어받으므로 기존대로 유지했습니다.

## 검증

- `npm run build`(CI 와 동일한 `tsc && vite build`) 통과
- `npm run check:api` PASS, `npm run check:fields` PASS (남은 경고는 기존 항목)
- 레포에 테스트 러너가 없고 이번 작업은 백엔드를 띄우지 않았으므로, 실제 기기에서의 동작 확인은 하지 못했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

