### PR TITLE
fix(mandala): 칸 상태 뱃지를 하나만 노출 + 잠금 상태를 라벨에 담기 (#240)

### DIFF
--- a/src/components/MandalaGrid.tsx
+++ b/src/components/MandalaGrid.tsx
@@ -69,9 +69,19 @@ function cellVisual(slot: MandalaSlot, center: boolean) {
   };
 }
 
+// 칸 우상단에 띄울 상태 아이콘 하나 — 굵은 사실부터 고른다(#240).
+function cellBadge(slot: MandalaSlot) {
+  if (slot.completedAt) return { Icon: Check, size: 10, weight: 'bold' as const, color: 'var(--success)' };
+  // 잠금 색은 초안 화면 Stage A 의 '직접 말함' 뱃지와 맞춘다 — 같은 사실은 같은 색으로.
+  if (slot.locked) return { Icon: LockSimple, size: 9, weight: 'fill' as const, color: 'var(--coral-700)' };
+  if (slot.filled && slot.source === 'user') return { Icon: PencilSimple, size: 9, weight: 'fill' as const, color: 'var(--text-3)' };
+  return null;
+}
+
 export function MandalaCellButton({ board, slot, center = false, compact = false, onClick, disabled }: CellProps) {
   const v = cellVisual(slot, center);
   const label = slotAriaLabel(board, slot);
+  const badge = cellBadge(slot);
   return (
     <button
       type="button"
@@ -105,23 +115,33 @@ export function MandalaCellButton({ board, slot, center = false, compact = false
         ...v,
       }}
     >
-      {/* 상태 아이콘 — 색만으로 구분하지 않기 위한 병행 표시. */}
-      {!compact && (slot.completedAt || slot.locked || (slot.filled && slot.source === 'user')) && (
+      {/* 상태 아이콘 — 색만으로 구분하지 않기 위한 병행 표시.
+          한 번에 하나만 띄운다(#240). 예전에는 잠금·연필·체크를 조건별로 나란히 그려서,
+          인터뷰에서 직접 말해 locked 가 된 축을 초안 화면에서 손보면(그때 source 만
+          'user' 로 바뀐다) 9px 아이콘 둘이 2px 간격으로 붙어 뭉개졌다. 특히 축을 센터로
+          드릴다운했을 때의 coral 배경 위에서 심했다.
+          완료가 가장 굵은 사실이고, 잠금은 "인터뷰에서 직접 말한 축"이라 손댔다는 사실을
+          이미 함축한다. 나머지 상태는 칸을 열면 MandalaCellSheet 가 글로 다 보여 준다.
+          배경 칩을 깔아 셀 배경과 아이콘을 분리한다. */}
+      {!compact && badge && (
         <span
           aria-hidden
           style={{
             position: 'absolute',
             top: 4,
             right: 4,
+            width: 15,
+            height: 15,
+            borderRadius: 9999,
             display: 'inline-flex',
             alignItems: 'center',
-            gap: 2,
-            color: slot.completedAt ? 'var(--success)' : 'var(--text-3)',
+            justifyContent: 'center',
+            background: 'var(--surface-raised)',
+            border: '1px solid var(--sand-200)',
+            color: badge.color,
           }}
         >
-          {slot.locked && <LockSimple size={9} weight="fill" />}
-          {slot.filled && slot.source === 'user' && !slot.completedAt && <PencilSimple size={9} weight="fill" />}
-          {slot.completedAt && <Check size={10} weight="bold" />}
+          <badge.Icon size={badge.size} weight={badge.weight} />
         </span>
       )}
       <span

--- a/src/lib/mandala.ts
+++ b/src/lib/mandala.ts
@@ -259,16 +259,25 @@ export const SOURCE_LABEL: Record<MandalaSource, string> = {
   user: '내가 씀',
 };
 
+// 칸 우상단 아이콘은 aria-hidden 이라, 그 아이콘이 나타내는 사실을 라벨이 대신 말해야
+// 한다(#240). 예전에는 잠금·직접 씀이 어디에도 없어서 스크린리더로는 알 수 없었다.
+function slotStateWords(slot: MandalaSlot): string {
+  const words: string[] = [];
+  if (slot.locked) words.push('내가 직접 말한 축이라 잠김');
+  if (slot.filled && slot.source === 'user' && !slot.locked) words.push('내가 직접 씀');
+  return words.length ? `, ${words.join(', ')}` : '';
+}
+
 /** 축 위치를 말로 — 위치가 곧 의미라 스크린리더 라벨에 반드시 넣는다(#220 §4). */
 export function slotAriaLabel(board: MandalaBoard, slot: MandalaSlot): string {
   if (slot.role === 'core') return `가운데 칸, 궁극적 목표, ${slot.title || '아직 비어 있음'}`;
   const axisTitle = board.axes[slot.axisIndex]?.slot.title || `${slot.axisIndex + 1}번 축`;
   if (slot.role === 'axis') {
     const done = slot.progress != null ? `, 진행률 ${Math.round(slot.progress * 100)}퍼센트` : '';
-    return `${slot.axisIndex + 1}번 축, ${slot.title || '아직 비어 있음'}${done}`;
+    return `${slot.axisIndex + 1}번 축, ${slot.title || '아직 비어 있음'}${done}${slotStateWords(slot)}`;
   }
   const state = !slot.filled ? '빈 칸' : slot.completedAt ? '완료' : '미완료';
-  return `${axisTitle} 그룹, ${slot.cellIndex + 1}번째 칸, ${slot.title || '아직 비어 있음'}, ${state}`;
+  return `${axisTitle} 그룹, ${slot.cellIndex + 1}번째 칸, ${slot.title || '아직 비어 있음'}, ${state}${slotStateWords(slot)}`;
 }
 
 /** 축의 "몇 칸 채웠나" — 분모는 항상 8 고정(1칸 하고 100% 로 보이는 착시 방지). */


### PR DESCRIPTION
관련: #240 (머지 여부와 이슈 종료는 리뷰어가 판단)

## 문제

`MandalaCellButton` 이 잠금·연필·체크를 조건별로 **나란히** 그려서, 9px 아이콘 둘이 2px 간격으로 붙으면 무슨 상태인지 읽히지 않았습니다. 축을 센터로 드릴다운한 coral 배경 위에서 특히 심했습니다.

이 조합은 드물지 않습니다. 인터뷰에서 직접 말해 `locked: true` 가 된 축을 초안 화면에서 다시 손보면 `applyLocalEdit`(`MandalaDraftScreen.tsx:232-238`)이 `locked` 는 그대로 둔 채 `source: 'user'` 만 바꾸므로, `locked && source === 'user'` 가 일상적으로 발생합니다.

## 고친 것

### 1. 우선순위로 하나만 노출

`완료 > 잠금 > 직접 씀` 순서로 아이콘 하나만 띄웁니다.

- 완료가 가장 굵은 사실입니다.
- 잠금은 "인터뷰에서 직접 말한 축" 이라, 사용자가 손댔다는 사실을 이미 함축합니다. 그 위에 연필을 겹쳐 봐야 새로 알려주는 것이 없습니다.
- 나머지 상태는 칸을 열면 `MandalaCellSheet` 가 `SOURCE_LABEL` 과 `내가 직접 말한 축 · 재생성 제외` 로 글로 다 보여 줍니다(`MandalaCellSheet.tsx:145-148`). 격자에서 잃는 정보가 없습니다.

이슈에서 주신 두 제안 중 "우선순위를 정해 하나만" 쪽을 골랐습니다. 아이콘을 둘 유지한 채 여백만 늘리면 9px 짜리 두 개가 여전히 나란히 서 있어, 셀이 좁아질수록 같은 문제가 돌아옵니다.

### 2. 배경 칩

아이콘에 원형 배경 칩(`--surface-raised` + `--sand-200` 보더, 15×15)을 깔아 셀 배경과 분리했습니다. 잠금 색은 초안 화면 Stage A 의 '직접 말함' 뱃지와 같은 `--coral-700` 으로 맞췄습니다. 같은 사실은 같은 색으로 보이는 편이 낫습니다.

### 3. `slotAriaLabel` 에 상태 문구 추가

뱃지 `<span>` 이 `aria-hidden` 이라 스크린리더로는 잠금 여부를 알 방법이 아예 없었습니다. 축 라벨과 리프 라벨 양쪽에 넣었습니다.

- 잠김: `..., 내가 직접 말한 축이라 잠김`
- 직접 씀(잠기지 않은 경우): `..., 내가 직접 씀`

`role === 'core'` 는 잠금·source 개념이 없어 그대로 뒀습니다.

## 검증

`npm run build`(CI 와 동일한 `tsc && vite build`) 통과. 레포에 테스트 러너가 없고 로컬 백엔드를 띄우지 않아서 실제 화면 확인은 하지 못했습니다 — Vercel 프리뷰에서 봐 주시면 좋겠습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
