### PR TITLE
chore(android): 네이티브 API 주소 환경변수화 + 릴리스 절차 문서 (#237)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,10 @@ VITE_GOOGLE_CLIENT_ID=
 # 프로덕션에서 데모 진입을 열려면 여기 true + 백엔드 AUTH_STUB_MODE=true 가 함께 필요하다.
 # 둘이 어긋나면 로그인이 깨진다.
 VITE_ALLOW_STUB_LOGIN=
+
+# 네이티브(Capacitor) 앱이 호출할 절대 HTTPS 주소. 앱은 capacitor://localhost 로 로드돼
+# same-origin `/api` 프록시가 없어서 절대 주소가 필요하다.
+#   미설정 = https://reaction-frontend.vercel.app/api (Vercel rewrite 로 백엔드에 우회)
+# 백엔드에 HTTPS 도메인이 붙으면 여기에 그 주소를 넣어 프록시를 건너뛴다.
+# Play 프로덕션 출시(#237)의 "API 전 구간 HTTPS" 완료 조건이 이 값에 걸려 있다.
+VITE_NATIVE_API_BASE_URL=

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -8,7 +8,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
-        versionName "1.0"
+        versionName "1.0.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/docs/android-release.md
+++ b/docs/android-release.md
@@ -1,0 +1,74 @@
+# Android 릴리스 절차 (#237)
+
+Google Play 프로덕션 출시를 위한 프론트엔드 저장소 쪽 절차와 현재 상태를 적어 둔다.
+Play Console 계정 생성처럼 사람이 직접 해야 하는 항목과 백엔드가 열어 줘야 하는 항목은
+이 문서 맨 아래 "이 저장소 밖의 선행조건" 에 따로 모았다.
+
+## 이미 맞춰져 있는 설정
+
+`npm run android` 로 빌드하기 전에 아래 값이 바뀌지 않았는지만 확인하면 된다.
+
+| 항목 | 값 | 위치 |
+|---|---|---|
+| 패키지명 | `com.hanium.reaction` | `capacitor.config.ts`, `android/app/build.gradle` |
+| `minSdkVersion` | 24 | `android/variables.gradle` |
+| `compileSdkVersion` | 36 | `android/variables.gradle` |
+| `targetSdkVersion` | 36 | `android/variables.gradle` |
+| 클리어텍스트 | 차단 | `capacitor.config.ts` (`allowMixedContent: false`), `AndroidManifest.xml` 에 `usesCleartextTraffic` 없음 |
+| 하드웨어 뒤로가기 | 처리됨 | `src/lib/native.ts` — 히스토리가 있으면 뒤로, 없으면 앱 최소화 |
+| 네이티브 푸시 | 첫 버전에서 숨김 | `src/lib/platform.ts` `nativePushReady()` 가 항상 false |
+
+## API 주소
+
+앱은 `capacitor://localhost` 로 로드되므로 same-origin `/api` 프록시가 없다. 그래서
+네이티브 빌드는 절대 HTTPS 주소를 쓴다.
+
+- 기본값: `https://reaction-frontend.vercel.app/api` — 앱→Vercel 구간만 HTTPS 이고,
+  Vercel rewrite 가 http 백엔드로 우회한다.
+- 백엔드에 HTTPS 도메인이 붙으면 `VITE_NATIVE_API_BASE_URL` 에 그 주소를 넣는다.
+  코드를 고칠 필요 없이 빌드 환경변수만 바꾸면 된다.
+
+#237 의 완료 조건인 "API 전 구간 HTTPS" 는 이 값을 실제 HTTPS 백엔드로 바꿔야 충족된다.
+지금 기본값 그대로 출시하면 Vercel 뒤편 구간이 http 로 남는다.
+
+## 릴리스마다 하는 일
+
+1. `android/app/build.gradle` 의 `versionCode` 를 **1 올린다**. Play 는 같은
+   `versionCode` 를 두 번 받지 않는다. 이미 올린 릴리스를 지워도 그 번호는 재사용할 수 없다.
+2. `versionName` 은 사용자에게 보이는 문자열이다. 기능이 늘면 minor, 버그 수정만이면
+   patch 를 올린다. 현재 `1.0.0`.
+3. 웹과 Android 를 **같은 release 태그**에서 빌드한다. 두 빌드가 다른 커밋에서 나오면
+   같은 날 공개해도 서로 다른 앱이 된다.
+4. `npm run android` (= `npm run build && cap sync android && cap open android`) 로
+   Android Studio 를 연 뒤 AAB 를 만든다.
+5. `app-release.aab` 를 내부 테스트 트랙에 먼저 올린다. 로컬 APK 설치만으로 검증을
+   끝내지 않는다 — Play 설치본에서만 드러나는 서명·권한 문제가 있다.
+
+## 이 저장소 밖의 선행조건
+
+아래는 코드로 처리할 수 없다. 사람이 직접 하거나 백엔드가 열어 줘야 한다.
+
+### 사람이 직접
+
+- Play Console 개발자 계정 생성, 본인 인증, 등록비 결제
+- 신규 개인 계정이면 테스터 12명 이상으로 14일 연속 비공개 테스트 후 프로덕션 접근 신청
+- Managed publishing 활성화
+- upload keystore 생성과 백업 (저장소에 넣지 않는다 — 비밀번호 관리자와 오프라인 두 곳)
+- Play App Signing 구성
+- Google Cloud 에 웹/Android OAuth Client 분리 생성, 패키지명과 SHA-1 등록
+  (개발 키, 업로드 키, Play App Signing 키 셋 다)
+- 스토어 등록정보: 아이콘 512×512, Feature Graphic 1024×500, 스크린샷 2장 이상,
+  콘텐츠 등급, Data Safety 응답
+- 개인정보처리방침과 계정 삭제 안내 페이지의 **본문 작성**. 법적 문서라 실제 데이터 처리와
+  어긋나면 심사에서 문제가 된다. 문구가 정해지면 이 저장소에 정적 페이지로 올린다.
+- 실기기 테스트 (API 24·33·36, 네트워크 단절·복원, 강제 종료 후 복원, ANR)
+
+### 백엔드가 열어 줘야
+
+- API 전 구간 HTTPS (고정 도메인 + 인증서)
+- Android ID token 검증
+- refresh token 자동 갱신
+- **계정 삭제 엔드포인트** — 현재 `openapi.json` 에 계정 삭제용 `DELETE` 경로가 없다.
+  이것 없이는 "앱 설정에서 계정 삭제" 를 프론트에서 만들 수 없다.
+- 초대코드 가입 게이트와 30명 제한, `SIGNUPS_ENABLED` / `SCHEDULER_ENABLED` 차단 수단
+- 사용자별 API 호출 한도, Gemini 일 비용 상한과 룰 폴백

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -98,9 +98,15 @@ import type {
 // http 백엔드를 HTTPS 페이지에서 직접 부르면 Mixed Content 로 차단되므로 프록시를 기본으로 한다.
 //
 // 네이티브(Capacitor) 앱은 capacitor://localhost 로 로드돼 same-origin `/api` 프록시가 없다.
-// 그래서 네이티브에선 절대 HTTPS 오리진(Vercel)으로 보내 rewrite(/api→http 백엔드)를 타게 한다.
-// 이렇게 하면 앱이 http 백엔드를 직접 부르지 않아 iOS ATS 클리어텍스트 차단도 피한다.
-const NATIVE_API_BASE = 'https://reaction-frontend.vercel.app/api';
+// 그래서 네이티브에선 절대 HTTPS 오리진으로 보낸다. 앱이 http 백엔드를 직접 부르지 않으므로
+// iOS ATS 와 Android 클리어텍스트 차단을 둘 다 피한다.
+//
+// Play 프로덕션 출시(#237)는 "API 전 구간 HTTPS" 를 완료 조건으로 둔다. 기본값인 Vercel
+// 오리진은 앱→Vercel 구간만 HTTPS 이고 Vercel→백엔드 구간은 rewrite 로 http 를 탄다.
+// 백엔드에 HTTPS 도메인이 붙으면 VITE_NATIVE_API_BASE_URL 에 그 주소를 넣어 프록시를
+// 건너뛴다 — 코드를 고치지 않고 빌드 환경변수만 바꾸면 되게 해 둔다.
+const NATIVE_API_BASE =
+  import.meta.env.VITE_NATIVE_API_BASE_URL || 'https://reaction-frontend.vercel.app/api';
 const isNative =
   typeof Capacitor !== 'undefined' && typeof Capacitor.isNativePlatform === 'function'
     ? Capacitor.isNativePlatform()

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -2,6 +2,8 @@
 
 interface ImportMetaEnv {
   readonly VITE_API_BASE_URL?: string;
+  // 네이티브 셸이 호출할 절대 HTTPS 주소. 미설정이면 Vercel 오리진(rewrite 경유)으로 떨어진다.
+  readonly VITE_NATIVE_API_BASE_URL?: string;
   readonly VITE_VAPID_PUBLIC_KEY?: string;
   readonly VITE_ALLOW_STUB_LOGIN?: string;
   // Google OAuth Client ID (공개값) — 백엔드 GOOGLE_OAUTH_CLIENT_ID 와 동일해야 id_token.aud 검증 통과.


### PR DESCRIPTION
관련: #237 (일부만 처리 — 아래 "남은 것" 참고. 이슈는 닫지 않았습니다)

#237 은 대부분 Play Console 조작·keystore 생성·실기기 테스트처럼 사람이 직접 해야 하거나, 백엔드가 열어 줘야 하는 항목입니다. 이 PR 은 **이 저장소에서 코드로 처리할 수 있는 범위만** 다룹니다.

## 확인해 보니 이미 되어 있던 것

이슈 §2 체크리스트 상당수가 이미 요구대로 되어 있었습니다. 손대지 않고 `docs/android-release.md` 에 표로 남겼습니다.

| 항목 | 현재 값 |
|---|---|
| 패키지명 | `com.hanium.reaction` |
| `minSdkVersion` | 24 |
| `compileSdkVersion` / `targetSdkVersion` | 36 / 36 |
| `versionCode` | 1 |
| 클리어텍스트 | 차단 (`allowMixedContent: false`, 매니페스트에 `usesCleartextTraffic` 없음) |
| 하드웨어 뒤로가기 | 처리됨 (`src/lib/native.ts` — 히스토리 있으면 뒤로, 없으면 최소화) |
| 네이티브 푸시 | 첫 버전에서 숨김 (`nativePushReady()` 가 항상 false) |

## 바꾼 것

### 1. 네이티브 API 주소를 환경변수로

`NATIVE_API_BASE` 가 `https://reaction-frontend.vercel.app/api` 로 하드코딩돼 있었습니다. 이 주소는 **앱→Vercel 구간만 HTTPS** 이고, Vercel rewrite 뒤편 백엔드 구간은 http 로 남습니다. 즉 지금 그대로 출시하면 이슈의 완료 조건인 "API 통신이 전 구간 HTTPS이고 cleartext 요청이 없다" 를 충족하지 못합니다.

`VITE_NATIVE_API_BASE_URL` 로 빼서, 백엔드에 HTTPS 도메인이 붙으면 코드를 고치지 않고 빌드 환경변수만 바꿔 프록시를 건너뛸 수 있게 했습니다. 기본값은 기존 동작 그대로라 지금 빌드에는 아무 변화가 없습니다.

`.env.example` 과 `src/vite-env.d.ts` 에도 함께 넣었습니다.

### 2. `versionName` 을 `1.0.0` 으로

이슈 §2 에 명시된 값입니다. 기존 `"1.0"`.

### 3. `docs/android-release.md`

- 현재 설정 상태 표
- 릴리스마다 하는 일 — 특히 **`versionCode` 는 릴리스마다 1씩 올리고, 지운 릴리스의 번호도 재사용할 수 없다** 는 점 (이슈 §5 "새 릴리스마다 versionCode 증가 절차 문서화")
- 이 저장소 밖의 선행조건을 "사람이 직접" / "백엔드가 열어 줘야" 로 나눠 정리

## 일부러 손대지 않은 것

**Gradle 서명 설정(`signingConfigs`)** — 이 환경에 Java 와 Android SDK 가 없어(`java: command not found`, `ANDROID_HOME` 비어 있음) Gradle 빌드로 검증할 수 없습니다. 검증하지 못한 빌드 파일 변경은 P0 릴리스에서 위험하다고 판단했습니다. keystore 를 만드신 뒤 알려 주시면 그때 배선하겠습니다.

**개인정보처리방침·계정 삭제 안내 페이지** — 본문이 법적 문서라 제가 지어내면 실제 데이터 처리와 어긋날 수 있습니다. 문구가 정해지면 정적 페이지로 올리겠습니다.

**앱 내 계정 삭제** — `openapi.json` 에 계정 삭제용 `DELETE` 경로가 없습니다(`/goals/{id}`, `/habits/{id}` 등만 있음). 백엔드 엔드포인트 없이는 만들 수 없습니다.

## 검증

`npm run build`(CI 와 동일한 `tsc && vite build`) 통과. Android 빌드는 위 이유로 돌리지 못했습니다 — `build.gradle` 변경은 문자열 리터럴 하나뿐입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
