### PR TITLE
feat(auth): refresh token 도입 + 토큰 저장 위치 분리 (#237 §3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "re-action-web",
       "version": "0.0.1",
       "dependencies": {
+        "@aparajita/capacitor-secure-storage": "^8.0.0",
         "@capacitor/app": "^8.1.1",
         "@capacitor/core": "^8.4.2",
         "@capacitor/push-notifications": "^8.1.2",
@@ -47,6 +48,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@aparajita/capacitor-secure-storage": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@aparajita/capacitor-secure-storage/-/capacitor-secure-storage-8.0.0.tgz",
+      "integrity": "sha512-oYnwSjdIh23aRNgz8982+TmFvQH/2yZkEdw1iIg+H2ziFJoOVELPTc7u6Ez2HwOuDIW5AGqBX75GvrzQ+D70Qg==",
+      "license": "MIT",
+      "dependencies": {
+        "@capacitor/android": "^8.0.2",
+        "@capacitor/app": "^8.0.0",
+        "@capacitor/core": "^8.0.2",
+        "@capacitor/ios": "^8.0.2",
+        "@capacitor/keyboard": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
@@ -78,7 +95,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -334,7 +350,6 @@
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-8.4.2.tgz",
       "integrity": "sha512-bzf8XZ9C+ePgOQ+e+T0fnhHGH4aCNY494vvSQIF5w4AY07RwEmkFqZs1678DDSMH0hLSQpxEwXGFNUVcXO6bBA==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": "^8.4.0"
@@ -410,7 +425,6 @@
       "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-8.4.2.tgz",
       "integrity": "sha512-fQPRb3JXRaU2pnufDUvqOjhsrYxDQeFRZyaj/sHydIUxD2NxOGHKMpmKUdI+U4OOmKuGZyvRpi7TSJU+7Bjbmg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -419,10 +433,18 @@
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/@capacitor/ios/-/ios-8.4.2.tgz",
       "integrity": "sha512-ClVzIjK++yRjsRPOpdEzhsZfbHfoEc0f4M6vD0v7sWh0qcoF6NkxNAeHpWTn4OPJpJfpGGoYsq+IfEHrYyBiWA==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": "^8.4.0"
+      }
+    },
+    "node_modules/@capacitor/keyboard": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/@capacitor/keyboard/-/keyboard-8.0.5.tgz",
+      "integrity": "sha512-oFXygC4eKYA5l2MdpTR06L2M/4x6e2SLD5yS1T9+UBDKTkzyvhWKEhbYLUaTIBPpLKqlfGudJw1X73S1H9eUzQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
       }
     },
     "node_modules/@capacitor/push-notifications": {
@@ -1586,7 +1608,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1899,7 +1920,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2768,7 +2788,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -4062,7 +4081,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4266,7 +4284,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4279,7 +4296,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4972,7 +4988,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5236,7 +5251,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "android": "npm run build && cap sync android && cap open android"
   },
   "dependencies": {
+    "@aparajita/capacitor-secure-storage": "^8.0.0",
     "@capacitor/app": "^8.1.1",
     "@capacitor/core": "^8.4.2",
     "@capacitor/push-notifications": "^8.1.2",

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -5,7 +5,7 @@ import { LoginScreen } from '../screens/LoginScreen';
 import { NavigationContext, STATE_TO_SCREEN } from '../contexts/NavigationContext';
 import { ToastProvider } from '../contexts/ToastContext';
 import { IosInstallCard } from '../components/IosInstallCard';
-import { ApiError, authApi, friendlyError, getAuthKind, onAuthExpired, onboardingApi, setAccessToken, stubLoginAllowed } from '../lib/api';
+import { ApiError, authApi, clearSession, friendlyError, getAccessToken, getAuthKind, initTokenStore, onAuthExpired, onboardingApi, setSession, stubLoginAllowed } from '../lib/api';
 import type { ScreenId, TabId } from '../types';
 import type { MilestoneDraft, OnboardingState, UserProfile } from '../types/api';
 
@@ -143,7 +143,8 @@ export function AppShell() {
     setAuthError(null);
     try {
       const session = await authApi.loginWithGoogle(idToken);
-      setAccessToken(session.accessToken, 'real');
+      // refreshToken 까지 함께 보관한다 — 이게 있어야 access 가 만료돼도 세션이 이어진다.
+      setSession(session, 'real');
       setNeedsLogin(false);
       setBootError(null);
       loadSessionAfterLogin(session.user);
@@ -162,7 +163,7 @@ export function AppShell() {
     setAuthError(null);
     try {
       const session = await authApi.loginWithGoogle(stubIdToken());
-      setAccessToken(session.accessToken, 'stub');
+      setSession(session, 'stub');
       setNeedsLogin(false);
       setBootError(null);
       loadSessionAfterLogin(session.user);
@@ -194,6 +195,11 @@ export function AppShell() {
     async function bootstrap() {
       const force = new URLSearchParams(window.location.search).get('force') as ScreenId | null;
 
+      // 네이티브는 토큰이 보안 저장소에 있어 읽기가 비동기다. 첫 API 호출 전에 메모리로
+      // 올려 두지 않으면 인증 헤더 없이 나가 401 을 맞는다. 웹에서는 즉시 반환한다.
+      await initTokenStore();
+      if (cancelled) return;
+
       // force 쿼리가 있으면 최우선. 없으면 진입 화면은 applyProfile 이 계정
       // onboarding_state 로 결정한다(#120). 부팅 중엔 초기값 'intro'(로딩 자리표시).
       if (force) setScreen(force);
@@ -207,11 +213,11 @@ export function AppShell() {
       // 새로고침 한 번이면 로그인 화면으로 돌아가는 증상. 로그인 종류를 직접 보고 판단한다.
       if (
         typeof window !== 'undefined' &&
-        window.localStorage.getItem('reaction.accessToken') &&
+        getAccessToken() &&
         getAuthKind() !== 'real' &&
         !window.localStorage.getItem('reaction.deviceId')
       ) {
-        setAccessToken(null);
+        clearSession();
       }
 
       try {
@@ -229,7 +235,7 @@ export function AppShell() {
             // api 레이어 자가치유와 같은 판단을 쓴다(stubLoginAllowed).
             if (stubLoginAllowed()) {
               const session = await authApi.loginWithGoogle(stubIdToken());
-              setAccessToken(session.accessToken, 'stub');
+              setSession(session, 'stub');
               profile = session.user;
             } else {
               // 실제 로그인 필요 — 로그인 화면으로 전환하고 부팅을 종료한다(아래 finally).

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -2,6 +2,13 @@
 // 응답·에러·인증·Idempotency 규약은 docs/api-contract.md v0.7 의 §1 을 따른다.
 
 import { Capacitor } from '@capacitor/core';
+import {
+  clearSession,
+  getAccessToken,
+  getAuthKind,
+  getRefreshToken,
+  setSession,
+} from './tokenStore';
 import type {
   ActionItem,
   AnonymizeRequest,
@@ -108,7 +115,7 @@ const isNative =
 const BASE_URL = (
   isNative ? NATIVE_API_BASE : (import.meta.env.VITE_API_BASE_URL ?? '/api')
 ).replace(/\/$/, '');
-const TOKEN_KEY = 'reaction.accessToken';
+
 
 export class ApiError extends Error {
   constructor(
@@ -172,32 +179,10 @@ export function friendlyError(err: unknown, fallback: string = DEFAULT_ERROR_MSG
   return fallback;
 }
 
-function getToken(): string | null {
-  if (typeof window === 'undefined') return null;
-  return window.localStorage.getItem(TOKEN_KEY);
-}
-
-// 세션을 어떻게 얻었는지. 'real' = 실제 Google 로그인, 'stub' = 데모/개발용.
-// 401 자가치유가 실제 사용자를 데모 계정으로 갈아타게 만들면 안 되므로 구분해 둔다.
-const AUTH_KIND_KEY = 'reaction.authKind';
-export type AuthKind = 'real' | 'stub';
-
-export function setAccessToken(token: string | null, kind?: AuthKind): void {
-  if (typeof window === 'undefined') return;
-  if (token) {
-    window.localStorage.setItem(TOKEN_KEY, token);
-    if (kind) window.localStorage.setItem(AUTH_KIND_KEY, kind);
-  } else {
-    window.localStorage.removeItem(TOKEN_KEY);
-    window.localStorage.removeItem(AUTH_KIND_KEY);
-  }
-}
-
-export function getAuthKind(): AuthKind | null {
-  if (typeof window === 'undefined') return null;
-  const v = window.localStorage.getItem(AUTH_KIND_KEY);
-  return v === 'real' || v === 'stub' ? v : null;
-}
+// 토큰이 어디에 어떻게 보관되는지는 tokenStore 한 곳에만 있다(플랫폼별로 다르다).
+// 여기서는 "지금 쓸 토큰" 만 꺼내 쓴다.
+export type { AuthKind } from './tokenStore';
+export { clearSession, getAccessToken, getAuthKind, getRefreshToken, initTokenStore, setSession } from './tokenStore';
 
 // 세션이 끝났음(되살릴 수 없는 401)을 앱 껍데기에 알린다.
 // 예전엔 401 이 각 화면의 개별 에러로만 끝나서, 세션이 만료되면 "데이터가 안 불러와지는"
@@ -262,6 +247,28 @@ interface RequestOptions {
   _retry?: boolean;
 }
 
+// refresh token 으로 access 를 다시 받는다. 성공하면 true.
+//
+// 동시에 날아간 여러 요청이 한꺼번에 401 을 받으면 재발급도 그만큼 시도된다. 백엔드가
+// refresh 를 회전시키지 않는 MVP 라 데이터가 깨지지는 않지만, 같은 일을 n번 하고 서버에
+// 불필요한 부하를 준다. 진행 중인 시도가 있으면 거기에 올라탄다.
+let renewInFlight: Promise<boolean> | null = null;
+function renewAccessToken(): Promise<boolean> {
+  if (renewInFlight) return renewInFlight;
+  const token = getRefreshToken();
+  if (!token) return Promise.resolve(false);
+  const kind = getAuthKind() ?? 'real';
+  renewInFlight = authApi.refresh(token)
+    .then((res) => {
+      // 회전하지 않으므로 refresh 는 그대로 두고 access 만 갈아 끼운다.
+      setSession({ accessToken: res.accessToken }, kind);
+      return true;
+    })
+    .catch(() => false)
+    .finally(() => { renewInFlight = null; });
+  return renewInFlight;
+}
+
 async function request<T>(path: string, opts: RequestOptions = {}): Promise<T> {
   const { method = 'GET', body, idempotencyKey, anonymous = false, _retry = false } = opts;
   const headers: Record<string, string> = { Accept: 'application/json' };
@@ -270,7 +277,7 @@ async function request<T>(path: string, opts: RequestOptions = {}): Promise<T> {
   // 구분하는 데 쓴다. 구분하지 않으면 첫 방문자에게도 "로그인이 만료됐어요" 가 뜬다.
   let sentToken = false;
   if (!anonymous) {
-    const token = getToken();
+    const token = getAccessToken();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
       sentToken = true;
@@ -288,36 +295,38 @@ async function request<T>(path: string, opts: RequestOptions = {}): Promise<T> {
   if (res.status === 204) return undefined as T;
 
   if (!res.ok) {
-    // 401 자가치유: 인증 필요 호출인데 토큰이 없/만료면 stub 재로그인 후 1회 재시도.
-    // (부트스트랩 타이밍/토큰 유실로 "인증 헤더 없음" 401 이 나던 문제 방지)
-    // stub 자가치유는 데모/개발 세션에만 적용한다. 실제 Google 로그인 사용자에게
-    // 적용하면 만료된 순간 조용히 '데모 계정' 으로 갈아타서, 로그인은 되어 있는데
-    // 남의(또는 빈) 데이터가 보이는 상태가 된다.
-    if (
-      res.status === 401 &&
-      !anonymous &&
-      !_retry &&
-      typeof window !== 'undefined' &&
-      getAuthKind() !== 'real' &&
-      stubLoginAllowed()
-    ) {
-      try {
-        const session = await request<AuthSession>('/auth/google', {
-          method: 'POST',
-          body: { idToken: stubIdToken() },
-          anonymous: true,
-        });
-        setAccessToken(session.accessToken, 'stub');
-        return await request<T>(path, { ...opts, _retry: true });
-      } catch {
-        /* 재로그인 실패 — 아래에서 원래 401 을 그대로 던진다 */
+    // 401 자가치유 — 두 갈래를 순서대로 시도하고, 둘 다 안 되면 재로그인으로 보낸다.
+    // (부트스트랩 타이밍이나 토큰 유실로 "인증 헤더 없음" 401 이 나던 문제도 여기서 걸린다)
+    if (res.status === 401 && !anonymous && !_retry && typeof window !== 'undefined') {
+      // ① 실제 로그인 사용자: refresh token 으로 새 access 를 받아 1회 재시도한다.
+      //    access TTL 이 60분이라, 이게 없으면 로그인 한 시간 뒤에 무조건 튕긴다.
+      if (getRefreshToken()) {
+        const renewed = await renewAccessToken();
+        if (renewed) return await request<T>(path, { ...opts, _retry: true });
+      }
+
+      // ② 데모/개발 세션: stub 재로그인 후 1회 재시도.
+      //    실제 Google 로그인 사용자에게 적용하면 만료된 순간 조용히 '데모 계정' 으로
+      //    갈아타서, 로그인은 되어 있는데 남의(또는 빈) 데이터가 보이는 상태가 된다.
+      if (getAuthKind() !== 'real' && stubLoginAllowed()) {
+        try {
+          const session = await request<AuthSession>('/auth/google', {
+            method: 'POST',
+            body: { idToken: stubIdToken() },
+            anonymous: true,
+          });
+          setSession(session, 'stub');
+          return await request<T>(path, { ...opts, _retry: true });
+        } catch {
+          /* 재로그인 실패 — 아래에서 원래 401 을 그대로 던진다 */
+        }
       }
     }
 
     // 여기까지 온 401 은 되살릴 수 없다 — 토큰을 버리고 재로그인으로 보낸다.
     // 토큰을 보내지 않았던 요청(= 애초에 로그인 상태가 아님)은 만료가 아니므로 알리지 않는다.
     if (res.status === 401 && !anonymous && sentToken) {
-      setAccessToken(null);
+      clearSession();
       authExpiredHandler?.();
     }
 

--- a/src/lib/tokenStore.ts
+++ b/src/lib/tokenStore.ts
@@ -1,0 +1,146 @@
+// 세션 토큰 보관소.
+//
+// 예전에는 access token 을 localStorage 에 그대로 넣고 refresh token 은 받자마자 버렸다.
+// localStorage 는 같은 오리진의 모든 스크립트가 읽으므로, XSS 가 한 번 터지면 거기 있는
+// 토큰이 통째로 새어 나간다. 그 자리에 14일짜리 refresh token 까지 얹으면 한 번의 사고가
+// 2주짜리 세션을 넘겨주는 셈이라, 저장 위치를 토큰별·플랫폼별로 나눈다.
+//
+//                    access token (60분)          refresh token (14일)
+//   네이티브 앱      보안 저장소                   보안 저장소
+//                    (iOS Keychain / Android Keystore)
+//   웹 브라우저      localStorage (기존 유지)      메모리에만 — 디스크에 남기지 않는다
+//
+// 웹에서 refresh 를 메모리에만 두면 새로고침 시 사라진다. 그래도 access token 이 남아 있어
+// 60분 안에는 그대로 쓰고, 그 뒤에는 다시 로그인해야 한다. 웹에서 14일 세션을 온전히
+// 살리려면 백엔드가 refresh 를 httpOnly 쿠키로 내려 주는 수밖에 없다 — 클라이언트가
+// 읽을 수 있는 저장소는 어디든 XSS 에 노출된다.
+import { isNativeApp } from './platform';
+
+const ACCESS_KEY = 'reaction.accessToken';
+const REFRESH_KEY = 'reaction.refreshToken';
+const KIND_KEY = 'reaction.authKind';
+
+/** 세션을 어떻게 얻었는지. 'real' = 실제 Google 로그인, 'stub' = 데모/개발용. */
+export type AuthKind = 'real' | 'stub';
+
+// 진실의 원본은 메모리다. request() 가 매 호출마다 동기로 읽어야 하는데 네이티브 보안
+// 저장소는 비동기라서, 부팅 때 한 번 읽어 여기 채워 두고 이후로는 메모리만 본다.
+let accessToken: string | null = null;
+let refreshToken: string | null = null;
+let authKind: AuthKind | null = null;
+
+const hasWindow = typeof window !== 'undefined';
+
+// 웹 값은 동기로 바로 채운다 — init 을 기다리지 않아도 첫 요청에 토큰이 실린다.
+if (hasWindow && !isNativeApp()) {
+  accessToken = window.localStorage.getItem(ACCESS_KEY);
+  const k = window.localStorage.getItem(KIND_KEY);
+  authKind = k === 'real' || k === 'stub' ? k : null;
+}
+
+// 플러그인은 동적으로 부른다. 웹 초기 번들에 네이티브 전용 코드를 싣지 않기 위함이고,
+// 아직 `cap sync` 를 안 돌린 셸에서도 앱이 죽지 않게 하기 위함이다.
+type SecureStorageApi = {
+  get: (key: string) => Promise<unknown>;
+  set: (key: string, value: string) => Promise<void>;
+  remove: (key: string) => Promise<boolean>;
+};
+let securePromise: Promise<SecureStorageApi | null> | null = null;
+function secure(): Promise<SecureStorageApi | null> {
+  if (!isNativeApp()) return Promise.resolve(null);
+  if (!securePromise) {
+    securePromise = import('@aparajita/capacitor-secure-storage')
+      .then((m) => m.SecureStorage as unknown as SecureStorageApi)
+      // 플러그인이 없거나(동기화 전) 기기가 거부하면 메모리 보관으로 떨어진다.
+      // 세션이 앱 재시작을 못 넘길 뿐, 앱이 멈추지는 않는다.
+      .catch(() => null);
+  }
+  return securePromise;
+}
+
+/**
+ * 네이티브 보안 저장소에서 토큰을 읽어 메모리에 채운다.
+ * 첫 API 호출 전에 반드시 await 해야 한다(웹에서는 즉시 반환).
+ */
+export async function initTokenStore(): Promise<void> {
+  if (!isNativeApp()) return;
+  const api = await secure();
+  if (!api) return;
+  try {
+    const [a, r, k] = await Promise.all([api.get(ACCESS_KEY), api.get(REFRESH_KEY), api.get(KIND_KEY)]);
+    accessToken = typeof a === 'string' ? a : null;
+    refreshToken = typeof r === 'string' ? r : null;
+    authKind = k === 'real' || k === 'stub' ? k : null;
+  } catch {
+    /* 읽기 실패 — 로그인 화면으로 보내는 편이 낫다. 빈 상태 유지. */
+  }
+}
+
+export function getAccessToken(): string | null {
+  return accessToken;
+}
+
+export function getRefreshToken(): string | null {
+  return refreshToken;
+}
+
+export function getAuthKind(): AuthKind | null {
+  return authKind;
+}
+
+/**
+ * 로그인/재발급 결과를 보관한다.
+ * refresh 는 재발급 응답에 없을 수 있어(회전하지 않는 MVP) 생략하면 기존 값을 유지한다.
+ */
+export function setSession(
+  session: { accessToken: string; refreshToken?: string | null },
+  kind: AuthKind,
+): void {
+  accessToken = session.accessToken;
+  if (session.refreshToken !== undefined && session.refreshToken !== null) {
+    refreshToken = session.refreshToken;
+  }
+  authKind = kind;
+  if (!hasWindow) return;
+
+  if (isNativeApp()) {
+    // 실패해도 메모리 세션은 살아 있다 — 이번 실행 동안은 정상 동작하고,
+    // 앱을 껐다 켜면 다시 로그인하게 된다.
+    void secure().then((api) => {
+      if (!api) return;
+      const writes = [api.set(ACCESS_KEY, accessToken as string), api.set(KIND_KEY, kind)];
+      if (refreshToken) writes.push(api.set(REFRESH_KEY, refreshToken));
+      return Promise.all(writes).then(() => undefined);
+    }).catch(() => { /* 저장 실패는 치명적이지 않다 */ });
+    return;
+  }
+
+  // 웹: refresh 는 일부러 쓰지 않는다. 디스크에 남는 순간 XSS 의 탈취 대상이 된다.
+  window.localStorage.setItem(ACCESS_KEY, session.accessToken);
+  window.localStorage.setItem(KIND_KEY, kind);
+}
+
+/** 로그아웃·만료. 메모리와 저장소 양쪽을 비운다. */
+export function clearSession(): void {
+  accessToken = null;
+  refreshToken = null;
+  authKind = null;
+  if (!hasWindow) return;
+
+  if (isNativeApp()) {
+    void secure().then((api) => {
+      if (!api) return;
+      return Promise.all([
+        api.remove(ACCESS_KEY),
+        api.remove(REFRESH_KEY),
+        api.remove(KIND_KEY),
+      ]).then(() => undefined);
+    }).catch(() => { /* 지우기 실패 — 메모리는 이미 비었다 */ });
+    return;
+  }
+
+  window.localStorage.removeItem(ACCESS_KEY);
+  window.localStorage.removeItem(KIND_KEY);
+  // 예전 버전이 남겨 둔 값이 있을 수 있어 함께 지운다.
+  window.localStorage.removeItem(REFRESH_KEY);
+}


### PR DESCRIPTION
관련: #237 §3 (체크리스트 일부. 이슈는 닫지 않았습니다)

## 문제 — 세션 수명이 정확히 60분이었습니다

백엔드는 이미 준비가 되어 있었습니다.

- access token TTL **60분**, refresh token TTL **14일** (`config.py:150-151`)
- `POST /auth/refresh` 구현 완료 (`api/routes/auth.py:81`, 회전 없는 MVP)

그런데 프론트가 `AuthSession.refreshToken` 을 **받자마자 버리고 있었습니다.** `setAccessToken(session.accessToken, 'real')` 이 access 만 저장했고, `refreshToken` 이라는 식별자는 `src/` 전체에서 타입 정의에만 나오고 호출부가 한 곳도 없었습니다. `authApi.refresh` 와 `authApi.logout` 은 래퍼만 있는 죽은 코드였습니다.

그 결과 access 가 만료되면 `request()` 가 곧바로 토큰을 지우고 로그인 화면으로 보냈습니다. 14일짜리 refresh 는 발급받은 그 순간 버려졌습니다.

## 저장 위치를 나눴습니다 (`src/lib/tokenStore.ts` 신설)

| | access token (60분) | refresh token (14일) |
|---|---|---|
| **네이티브 앱** | 보안 저장소 | 보안 저장소 |
| **웹 브라우저** | localStorage (기존 유지) | **메모리에만** — 디스크에 남기지 않음 |

네이티브는 `@aparajita/capacitor-secure-storage`(Capacitor 8+)로 iOS Keychain / Android Keystore 에 넣습니다. #237 §3 의 "민감 토큰의 네이티브 보안 저장소 적용" 항목입니다.

웹은 refresh 를 디스크에 남기지 않습니다. localStorage 는 같은 오리진의 모든 스크립트가 읽으므로, 14일짜리 refresh 를 거기 두면 **한 번의 XSS 가 2주짜리 세션을 넘겨주는 셈**이 됩니다. 지금처럼 refresh 를 안 쓰는 상태보다 오히려 나빠집니다.

절충의 대가는 분명합니다. 웹에서 새로고침하면 메모리의 refresh 가 사라집니다. access 는 localStorage 에 남아 60분 안에는 그대로 쓰지만, 그 뒤에는 다시 로그인해야 합니다. **웹에서 14일 세션을 온전히 살리려면 백엔드가 refresh 를 httpOnly 쿠키로 내려 주는 수밖에 없습니다** — 클라이언트가 읽을 수 있는 저장소는 어디든 XSS 에 노출됩니다.

## 401 처리

두 갈래를 순서대로 시도합니다.

1. **refresh 재발급** — refresh token 이 있으면 새 access 를 받아 원래 요청을 1회 재시도
2. **stub 자가치유** — 데모/개발 세션에만 (실제 로그인 사용자에게 적용하면 조용히 데모 계정으로 갈아타 남의 데이터가 보입니다)
3. 둘 다 안 되면 세션을 비우고 재로그인으로 보냅니다

동시에 날아간 요청들이 한꺼번에 401 을 받아도 재발급은 한 번만 나갑니다(single flight). `/auth/refresh` 자체는 `anonymous: true` 라 401 자가치유 대상이 아니어서 재귀하지 않습니다.

## 부팅 순서

네이티브는 보안 저장소 읽기가 비동기라, 부팅에서 `await initTokenStore()` 를 한 뒤 첫 API 호출을 냅니다. 이걸 빠뜨리면 인증 헤더 없이 나가 401 을 맞습니다. 웹은 모듈 로드 시점에 localStorage 를 동기로 읽으므로 즉시 반환합니다.

## 실패에 견디게

플러그인은 **동적 import + 실패 fallback** 입니다. `cap sync` 를 아직 안 돌린 셸이나 플러그인을 거부하는 기기에서도 앱이 죽지 않고 메모리 보관으로 떨어집니다. 세션이 앱 재시작을 못 넘길 뿐, 지금과 같은 동작입니다.

## 검증

- `npm run build`(CI 와 동일한 `tsc && vite build`) 통과
- `npm run check:api` PASS
- **네이티브 빌드는 검증하지 못했습니다.** 이 환경에 Java 와 Android SDK 가 없습니다(`java: command not found`). `cap sync` 후 실기기에서 아래 두 가지를 확인해 주십시오.
  - 앱을 껐다 켰을 때 로그인이 유지되는지 (Keystore 읽기)
  - 60분 이상 지난 뒤 화면 조작 시 자동으로 세션이 갱신되는지 (#237 §7 항목)

## 남는 것

`authApi.logout` 은 여전히 호출부가 없습니다. 설정 화면에 로그아웃 UI 자체가 없어서입니다. UI 가 생기면 `authApi.logout(refreshToken)` 으로 서버 쪽 jti 를 revoke 해야 합니다 — 지금은 로그아웃해도 서버에서는 refresh 가 14일 내내 살아 있습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
