### PR TITLE
feat(settings): 로그아웃 버튼 추가 (#237 §3)

### DIFF
--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -5,7 +5,7 @@ import { LoginScreen } from '../screens/LoginScreen';
 import { NavigationContext, STATE_TO_SCREEN } from '../contexts/NavigationContext';
 import { ToastProvider } from '../contexts/ToastContext';
 import { IosInstallCard } from '../components/IosInstallCard';
-import { ApiError, authApi, clearSession, friendlyError, getAccessToken, getAuthKind, initTokenStore, onAuthExpired, onboardingApi, setSession, stubLoginAllowed } from '../lib/api';
+import { ApiError, authApi, clearSession, friendlyError, getAccessToken, getAuthKind, getRefreshToken, initTokenStore, onAuthExpired, onboardingApi, setSession, stubLoginAllowed } from '../lib/api';
 import type { ScreenId, TabId } from '../types';
 import type { MilestoneDraft, OnboardingState, UserProfile } from '../types/api';
 
@@ -157,6 +157,40 @@ export function AppShell() {
     }
   }, [loadSessionAfterLogin]);
 
+  // 로그아웃 — 서버 revoke 를 먼저 시도하고, 성공 여부와 무관하게 로컬 세션은 반드시 비운다.
+  //
+  // revoke 를 건너뛰면 발급된 refresh token 이 서버에서 14일 동안 살아 있다. 기기를
+  // 잃어버렸거나 공용 브라우저에서 로그아웃한 경우가 정확히 그 위험이다.
+  // 반대로 revoke 가 실패했다고 로컬 세션을 남겨 두면, 사용자는 로그아웃을 눌렀는데
+  // 로그인된 채로 남는다 — 그쪽이 더 나쁘다. 그래서 revoke 실패는 삼킨다.
+  //
+  // 웹에서 새로고침한 뒤라면 refresh 가 메모리에서 사라졌을 수 있다. 그때는 보낼 토큰이
+  // 없으니 로컬만 비운다(서버 토큰은 만료까지 남는다).
+  const handleLogout = useCallback(async () => {
+    const refreshToken = getRefreshToken();
+    if (refreshToken) {
+      try {
+        await authApi.logout(refreshToken);
+      } catch {
+        /* 네트워크 오류나 이미 만료된 토큰 — 아래에서 로컬은 그대로 비운다 */
+      }
+    }
+    clearSession();
+    // 다음 로그인이 이전 사용자의 화면 상태를 물려받지 않게 되돌린다.
+    setUser(null);
+    setOnboardingState(null);
+    setScreen('intro');
+    setTab('today');
+    setInterviewSessionId(null);
+    setPlannedMilestones(null);
+    setInterviewReturnTo(null);
+    setMandalaGoalId(null);
+    setWeekOffset(0);
+    setAuthError(null);
+    setBootError(null);
+    setNeedsLogin(true);
+  }, []);
+
   // 데모 계정 명시적 진입 — 로그인 화면에서 사용자가 직접 눌렀을 때만(자동 아님).
   const handleDemoLogin = useCallback(async () => {
     setAuthBusy(true);
@@ -294,7 +328,7 @@ export function AppShell() {
 
   return (
     <NavigationContext.Provider
-      value={{ screen, tab, setScreen, setTab, user, onboardingState, isBootstrapping, weekOffset, setWeekOffset, interviewSessionId, setInterviewSessionId, plannedMilestones, setPlannedMilestones, interviewReturnTo, setInterviewReturnTo, mandalaGoalId, setMandalaGoalId }}
+      value={{ screen, tab, setScreen, setTab, user, onboardingState, isBootstrapping, weekOffset, setWeekOffset, interviewSessionId, setInterviewSessionId, plannedMilestones, setPlannedMilestones, interviewReturnTo, setInterviewReturnTo, mandalaGoalId, setMandalaGoalId, logout: handleLogout }}
     >
       <ToastProvider>
         {/* 뷰포트에 맞는 트리 하나만 마운트(둘 다 마운트 후 CSS 로만 숨기면 데이터 페칭이 2배로 나감). */}

--- a/src/contexts/NavigationContext.tsx
+++ b/src/contexts/NavigationContext.tsx
@@ -34,6 +34,9 @@ export interface NavigationContextType {
   // isUltimate 목표를 직접 찾는다 — 목표 화면을 거치지 않고 들어와도 동작해야 하기 때문.
   mandalaGoalId: string | null;
   setMandalaGoalId: (id: string | null) => void;
+  // 로그아웃 — 서버의 refresh token 을 revoke 하고 세션을 비운 뒤 로그인 화면으로 보낸다.
+  // 설정 화면이 부르지만 화면 전환은 AppShell 이 쥐고 있어서 여기로 내려 준다.
+  logout: () => Promise<void>;
 }
 
 export const NavigationContext = createContext<NavigationContextType>({
@@ -54,6 +57,7 @@ export const NavigationContext = createContext<NavigationContextType>({
   setInterviewReturnTo: () => {},
   mandalaGoalId: null,
   setMandalaGoalId: () => {},
+  logout: async () => {},
 });
 
 export const useNavigation = () => useContext(NavigationContext);

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { CaretLeft, CaretRight, Sparkle, BellRinging, BellSlash, Shield, Warning, Check, ArrowClockwise, IdentificationCard } from '@phosphor-icons/react';
+import { CaretLeft, CaretRight, Sparkle, BellRinging, BellSlash, Shield, Warning, Check, ArrowClockwise, IdentificationCard, SignOut } from '@phosphor-icons/react';
 import { ApiError, notificationsApi, privacyApi, settingsApi } from '../lib/api';
 import { isNativeApp, nativePushReady } from '../lib/platform';
 import { subscribePush, unsubscribePush, getPushPermission } from '../lib/push';
@@ -23,13 +23,15 @@ const CONSENT_TYPES: { type: ConsentType; label: string; desc: string }[] = [
 ];
 
 export function SettingsScreen() {
-  const { user, setScreen } = useNavigation();
+  const { user, setScreen, logout } = useNavigation();
   const [settings, setSettings] = useState<UserSettings | null>(null);
   const [consents, setConsents] = useState<ConsentRecord[]>([]);
   const [pushEnabled, setPushEnabled] = useState(false);
   const [pushBusy, setPushBusy] = useState(false);
   const [confirmAnonymize, setConfirmAnonymize] = useState(false);
   const [confirmRestartInterview, setConfirmRestartInterview] = useState(false);
+  const [confirmLogout, setConfirmLogout] = useState(false);
+  const [loggingOut, setLoggingOut] = useState(false);
   const [toast, setToast] = useState<string | null>(null);
 
   useEffect(() => {
@@ -256,6 +258,48 @@ export function SettingsScreen() {
               <div style={{ display: 'flex', gap: 8 }}>
                 <button onClick={() => setConfirmRestartInterview(false)} style={{ flex: 1, height: 36, borderRadius: 10, border: '1px solid var(--sand-200)', background: 'var(--surface-raised)', color: 'var(--text-2)', fontWeight: 600, fontSize: 12, cursor: 'pointer', fontFamily: 'inherit' }}>취소</button>
                 <button onClick={() => setScreen('goal-intake')} style={{ flex: 1, height: 36, borderRadius: 10, border: 'none', background: 'var(--brand-surface)', color: '#FFFCF6', fontWeight: 700, fontSize: 12, cursor: 'pointer', fontFamily: 'inherit' }}>다시 시작</button>
+              </div>
+            </div>
+          )}
+        </section>
+
+        {/* Account — 로그아웃은 데이터를 지우지 않으므로 아래 위험 구역에 넣지 않는다.
+            같은 붉은 테두리로 묶어 두면 "계정이 없어지나?" 하고 누르기를 망설이게 된다. */}
+        <section>
+          <SectionHeader icon={<SignOut size={11} weight="fill" />}>계정</SectionHeader>
+          <button
+            onClick={() => setConfirmLogout(true)}
+            style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '12px 14px', width: '100%', background: 'var(--surface-raised)', border: '1.5px solid var(--sand-200)', borderRadius: 12, cursor: 'pointer', fontFamily: 'inherit', textAlign: 'left' }}
+          >
+            <div style={{ flex: 1 }}>
+              <div style={{ fontWeight: 600, fontSize: 13, color: 'var(--text-1)' }}>로그아웃</div>
+              <div style={{ fontSize: 11, color: 'var(--text-3)', marginTop: 2 }}>
+                {user?.email ? `${user.email} 에서 로그아웃해요. ` : ''}기록한 목표와 실행은 그대로 남아요.
+              </div>
+            </div>
+          </button>
+          {confirmLogout && (
+            <div style={{ marginTop: 8, padding: 12, background: 'var(--sand-100)', border: '1px solid var(--sand-200)', borderRadius: 12 }}>
+              <div style={{ fontSize: 12, fontWeight: 700, color: 'var(--text-1)', marginBottom: 6 }}>로그아웃할까요?</div>
+              <div style={{ fontSize: 11, color: 'var(--text-2)', marginBottom: 10, lineHeight: 1.5 }}>
+                다시 쓰려면 Google 계정으로 로그인하면 돼요. 목표·계획·실행 기록은 계정에 그대로 남아 있어요.
+              </div>
+              <div style={{ display: 'flex', gap: 8 }}>
+                <button
+                  onClick={() => setConfirmLogout(false)}
+                  disabled={loggingOut}
+                  style={{ flex: 1, height: 36, borderRadius: 10, border: '1px solid var(--sand-200)', background: 'var(--surface-raised)', color: 'var(--text-2)', fontWeight: 600, fontSize: 12, cursor: loggingOut ? 'default' : 'pointer', fontFamily: 'inherit' }}
+                >취소</button>
+                <button
+                  onClick={() => {
+                    // 이 화면은 로그아웃이 끝나면 통째로 언마운트된다. 그래서 완료 후에
+                    // 상태를 되돌리지 않는다 — 없는 컴포넌트에 setState 하는 셈이 된다.
+                    setLoggingOut(true);
+                    void logout();
+                  }}
+                  disabled={loggingOut}
+                  style={{ flex: 1, height: 36, borderRadius: 10, border: 'none', background: 'var(--text-1)', color: '#FAF6EE', fontWeight: 700, fontSize: 12, cursor: loggingOut ? 'default' : 'pointer', fontFamily: 'inherit', opacity: loggingOut ? 0.6 : 1 }}
+                >{loggingOut ? '로그아웃 중…' : '로그아웃'}</button>
               </div>
             </div>
           )}


### PR DESCRIPTION
관련: #237 §3 "로그아웃 시 저장 토큰 제거" (이슈는 닫지 않았습니다)

#246 에서 refresh token 을 도입하면서 남겨 뒀던 항목입니다. 로그아웃할 방법이 아예 없어서 `authApi.logout` 이 죽은 코드로 남아 있었습니다.

## 왜 필요한가

`POST /auth/logout` 은 refresh token 의 `jti` 를 revoke set 에 등록합니다. 이걸 부르지 않으면 **발급된 refresh token 이 서버에서 14일 동안 그대로 살아 있습니다.** 기기를 잃어버렸거나 공용 브라우저를 쓴 경우가 정확히 그 위험입니다.

## UI

설정 화면에 **'계정'** 섹션을 새로 만들고 로그아웃 버튼을 넣었습니다. 확인 패널은 같은 화면의 '인터뷰 다시하기' · '계정 익명화' 와 같은 인라인 형태를 씁니다.

**위험 구역('데이터 관리')에는 넣지 않았습니다.** 로그아웃은 데이터를 지우지 않는데 '계정 익명화' 와 같은 붉은 테두리로 묶어 두면, 계정이 없어지는 줄 알고 누르기를 망설이게 됩니다. 그래서 온보딩 섹션과 위험 구역 사이에 평범한 섹션으로 두고, 설명에도 "기록한 목표와 실행은 그대로 남아요" 를 적었습니다.

로그인한 계정을 알 수 있도록 버튼 설명에 `user.email` 을 함께 보여 줍니다.

## 동작

`AppShell.handleLogout` 이 순서대로 처리합니다.

1. refresh token 이 있으면 `authApi.logout(refreshToken)` 으로 서버 `jti` 를 revoke
2. `clearSession()` 으로 로컬 세션을 비움
3. 화면 상태를 초기화하고 로그인 화면으로 전환

**revoke 실패는 삼킵니다.** 네트워크 오류나 이미 만료된 토큰 때문에 로컬 세션을 남겨 두면, 사용자는 로그아웃을 눌렀는데 로그인된 채로 남습니다. 그쪽이 더 나쁩니다.

**웹에서 새로고침한 뒤라면** refresh 가 메모리에서 사라졌을 수 있습니다(#246 의 저장 정책). 그때는 보낼 토큰이 없으니 로컬만 비웁니다 — 서버 토큰은 만료까지 남습니다. 이건 httpOnly 쿠키로 가지 않는 한 피할 수 없는 한계입니다.

## 다음 로그인이 이전 상태를 물려받지 않게

`user` · `onboardingState` · `screen` · `tab` · `interviewSessionId` · `plannedMilestones` · `interviewReturnTo` · `mandalaGoalId` · `weekOffset` 을 모두 되돌립니다. 이걸 빠뜨리면 다른 계정으로 로그인했을 때 앞사람이 보던 화면이나 인터뷰 세션 id 가 그대로 남습니다.

`needsLogin` 이 켜지면 `AppShell` 이 `LoginScreen` 을 반환하고 설정 화면은 통째로 언마운트됩니다. 그래서 완료 후 `loggingOut` 상태를 되돌리지 않습니다 — 없는 컴포넌트에 setState 하는 셈이 되기 때문입니다.

## 검증

`npm run build`(CI 와 동일한 `tsc && vite build`) 통과. 실제 로그아웃 왕복은 백엔드가 붙은 환경에서 확인해 주십시오.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
