### PR TITLE
fix(progress): 진척 바 터치 드래그·키보드 입력 연결 (#249)

### DIFF
--- a/src/components/ProgressSheet.tsx
+++ b/src/components/ProgressSheet.tsx
@@ -79,26 +79,40 @@ export function ProgressSheet({
           </span>
         </div>
 
-        <div style={{ position: 'relative', height: 8, background: 'var(--sand-200)', borderRadius: 9999, marginBottom: 8 }}>
-          <div
-            style={{ position: 'absolute', left: 0, top: 0, bottom: 0, width: `${pct}%`, background: 'var(--brand)', borderRadius: 9999 }}
+        <div style={{ position: 'relative', height: 44, margin: '-18px 0 -10px' }}>
+          {/* 네이티브 range 가 터치 드래그·트랙 탭·키보드 조작을 맡는다. 시각 요소는
+              아래에 따로 두어 브라우저별 thumb 스타일 차이 없이 기존 디자인을 유지한다. */}
+          <input
+            className="progress-range-input"
+            type="range"
+            min={0}
+            max={100}
+            step={1}
+            value={pct}
+            aria-label="오늘의 진척률"
+            aria-valuetext={`${pct}%`}
+            onChange={(e) => setPct(Number(e.currentTarget.value))}
           />
-          <div
-            style={{
-              position: 'absolute',
-              left: `${pct}%`,
-              top: '50%',
-              transform: 'translate(-50%,-50%)',
-              width: 24,
-              height: 24,
-              borderRadius: 9999,
-              background: '#FFFCF6',
-              border: '2px solid var(--brand)',
-              boxShadow: 'var(--shadow-md)',
-            }}
-          />
+          <div className="progress-range-visual" aria-hidden>
+            <div
+              style={{ position: 'absolute', left: 0, top: 0, bottom: 0, width: `${pct}%`, background: 'var(--brand)', borderRadius: 9999 }}
+            />
+            <div
+              style={{
+                position: 'absolute',
+                left: `${pct}%`,
+                top: '50%',
+                transform: 'translate(-50%,-50%)',
+                width: 24,
+                height: 24,
+                borderRadius: 9999,
+                background: '#FFFCF6',
+                border: '2px solid var(--brand)',
+                boxShadow: 'var(--shadow-md)',
+              }}
+            />
+          </div>
         </div>
-
         <div style={{ display: 'flex', justifyContent: 'space-between', padding: '0 2px', marginBottom: 18 }}>
           {PRESETS.map((t) => (
             <button

--- a/src/index.css
+++ b/src/index.css
@@ -4,6 +4,37 @@
 @tailwind components;
 @tailwind utilities;
 
+/* ProgressSheet: 네이티브 range 는 입력 동작만 담당하고 기존 디자인은 아래 visual 이 그린다.
+   44px hit area 로 모바일 터치 최소 크기를 확보한다. */
+.progress-range-input {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  width: 100%;
+  height: 44px;
+  margin: 0;
+  opacity: 0;
+  cursor: ew-resize;
+  touch-action: none;
+}
+
+.progress-range-visual {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 50%;
+  height: 8px;
+  transform: translateY(-50%);
+  border-radius: 9999px;
+  background: var(--sand-200);
+  pointer-events: none;
+}
+
+.progress-range-input:focus-visible + .progress-range-visual {
+  outline: 3px solid var(--brand-focus-ring);
+  outline-offset: 5px;
+}
+
 :root {
   /* COLOR — Sand */
   --sand-50:  #FAF6EE;


### PR DESCRIPTION
## 문제

`ProgressSheet`의 진척 바가 시각적 `div`로만 구성돼 모바일 터치 드래그와 키보드 입력에 반응하지 않았습니다.

## 변경

- 네이티브 `input[type=range]`를 0~100, step 1로 연결
- 44px 터치 영역에서 드래그와 트랙 탭 지원
- 기존 채움 트랙·핸들 디자인과 0/25/50/75/100 프리셋 유지
- `aria-label`, `aria-valuetext`, 키보드 포커스 링 추가
- 프리셋과 range가 동일한 `pct` 상태를 사용해 즉시 동기화

## 검증

- `npm run build` 통과
- `npm run check:api` 통과
- `npm run check:fields` 통과
- 실제 브라우저 터치 자동화는 현재 Windows 샌드박스 브라우저 연결 ACL 오류로 실행하지 못함

Closes #249