### PR TITLE
fix(weekly): 모바일 캘린더 세로 뷰포트 확대 (#248)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -273,6 +273,21 @@ body {
   }
 }
 
+/* 주간 캘린더: 모바일에서는 상태 칩 전용 행을 접어 시간표에 세로 공간을 돌려준다.
+   7일 보기와 시간축 배율은 유지한다 — 문제는 열 수가 아니라 짧은 캘린더 뷰포트다. */
+@media (max-width: 639px) {
+  .weekly-calendar-header {
+    padding: 6px 10px 4px !important;
+  }
+
+  .weekly-week-nav {
+    margin-bottom: 0 !important;
+  }
+
+  .weekly-status-chips {
+    display: none !important;
+  }
+}
 /* ── 데스크탑 전용 레이어 (≥ 1024px) ─────────── */
 .app-desktop {
   display: none;

--- a/src/screens/WeeklyCalendarScreen.tsx
+++ b/src/screens/WeeklyCalendarScreen.tsx
@@ -504,10 +504,10 @@ export function WeeklyCalendarScreenV2() {
   return (
     <div ref={rootRef} style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column', background: 'var(--surface-ground)' }}>
       {/* Header */}
-      <div style={{ flexShrink: 0, padding: '10px 14px 8px', borderBottom: '1px solid var(--sand-200)' }}>
+      <div className="weekly-calendar-header" style={{ flexShrink: 0, padding: '10px 14px 8px', borderBottom: '1px solid var(--sand-200)' }}>
         {/* 주 단위 이동(#119) — 마감까지 여러 주에 걸친 계획을 이전/다음 주로 열람.
             주간 리뷰의 "다음 주 계획 확인" 은 weekOffset=1 로 진입한다. */}
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+        <div className="weekly-week-nav" style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
           <button
             onClick={goPrev}
             style={{ width: 28, height: 28, borderRadius: 8, border: '1px solid var(--sand-200)', background: 'var(--surface-raised)', color: 'var(--text-1)', cursor: 'pointer', fontFamily: 'inherit', fontSize: 14 }}
@@ -553,7 +553,7 @@ export function WeeklyCalendarScreenV2() {
           </div>
         )}
         {/* 칩은 완료·대기만. 이월은 0 일 때가 대부분이라 자리만 차지했다. */}
-        <div style={{ display: 'flex', gap: 6, alignItems: 'center', flexWrap: 'wrap' }}>
+        <div className="weekly-status-chips" style={{ display: 'flex', gap: 6, alignItems: 'center', flexWrap: 'wrap' }}>
           {[
             { label: '완료', n: blocks.filter((b) => b.status === 'done').length, bg: '#E5EFE3', bd: '#b4dfc8', fg: 'var(--success-ink)' },
             { label: '대기', n: blocks.filter((b) => b.status === 'pending').length, bg: 'var(--sand-100)', bd: 'var(--sand-200)', fg: 'var(--text-2)' },


### PR DESCRIPTION
## 정정된 문제

모바일 주간 캘린더 피드백의 핵심은 7일 열 너비가 아니라 **캘린더 본문의 세로 뷰포트가 짧은 것**입니다. 3일 보기 제안은 철회하고 7일 보기를 유지합니다.

## 변경

- 모바일에서 완료/대기 상태 칩 전용 행을 접음
- 모바일 캘린더 헤더 상하 패딩 축소
- 주 이동 행 아래 불필요한 간격 제거
- 7일 보기, 시간당 72px 배율, 주 이동·오늘 복귀 기능은 유지
- 태블릿·데스크톱 레이아웃은 변경 없음

결과적으로 모바일에서 캘린더 시간표가 사용할 수 있는 세로 공간을 약 28~32px 늘립니다.

## 검증

- `npm run build` 통과
- `npm run check:api` 통과
- `npm run check:fields` 통과

Closes #248