### PR TITLE
chore(android): 서명 AAB 릴리스 워크플로 준비 (#237)

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -1,0 +1,84 @@
+name: Android Release AAB
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_code:
+        description: Play Console에서 아직 사용하지 않은 정수 versionCode
+        required: true
+        type: number
+      version_name:
+        description: 사용자에게 표시할 버전(예: 1.0.0)
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: android-release-aab
+  cancel-in-progress: false
+
+jobs:
+  bundle:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      VITE_NATIVE_API_BASE_URL: ${{ secrets.VITE_NATIVE_API_BASE_URL }}
+      REACTION_VERSION_CODE: ${{ inputs.version_code }}
+      REACTION_VERSION_NAME: ${{ inputs.version_name }}
+      REACTION_ANDROID_KEYSTORE_PATH: ${{ runner.temp }}/reaction-upload.jks
+      REACTION_ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+      REACTION_ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+      REACTION_ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: gradle
+      - name: Validate release inputs and secrets
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          test -n "$ANDROID_KEYSTORE_BASE64" || { echo 'ANDROID_KEYSTORE_BASE64 is missing'; exit 1; }
+          test -n "$REACTION_ANDROID_KEYSTORE_PASSWORD" || { echo 'ANDROID_KEYSTORE_PASSWORD is missing'; exit 1; }
+          test -n "$REACTION_ANDROID_KEY_ALIAS" || { echo 'ANDROID_KEY_ALIAS is missing'; exit 1; }
+          test -n "$REACTION_ANDROID_KEY_PASSWORD" || { echo 'ANDROID_KEY_PASSWORD is missing'; exit 1; }
+          case "$VITE_NATIVE_API_BASE_URL" in
+            https://*) ;;
+            *) echo 'VITE_NATIVE_API_BASE_URL must be an absolute HTTPS URL'; exit 1 ;;
+          esac
+          test "$REACTION_VERSION_CODE" -gt 0 || { echo 'version_code must be positive'; exit 1; }
+      - run: npm ci
+      - name: Build web bundle for native shell
+        run: npm run build
+      - name: Sync Capacitor Android project
+        run: npx cap sync android
+      - name: Restore upload keystore
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          printf '%s' "$ANDROID_KEYSTORE_BASE64" | base64 --decode > "$REACTION_ANDROID_KEYSTORE_PATH"
+          chmod 600 "$REACTION_ANDROID_KEYSTORE_PATH"
+      - name: Build signed release AAB
+        working-directory: android
+        run: |
+          chmod +x gradlew
+          ./gradlew --no-daemon bundleRelease
+      - name: Upload AAB artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: reaction-android-${{ inputs.version_name }}-${{ inputs.version_code }}
+          path: android/app/build/outputs/bundle/release/app-release.aab
+          if-no-files-found: error
+          retention-days: 14
+      - name: Remove temporary keystore
+        if: always()
+        run: rm -f "$REACTION_ANDROID_KEYSTORE_PATH"

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,10 @@ ds-bundle/
 .design-sync/.cache/
 .design-sync/learnings/
 .design-sync/node_modules
+
+# Android signing material — never commit upload keys or local properties
+*.jks
+*.keystore
+keystore.properties
+android/upload-keystore.*
+android/app/google-services.json

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,5 +1,17 @@
 apply plugin: 'com.android.application'
 
+// 릴리스 서명 정보는 저장소 파일이 아니라 CI/로컬 환경변수로만 받는다(#237).
+def releaseKeystorePath = System.getenv('REACTION_ANDROID_KEYSTORE_PATH')
+def releaseKeystorePassword = System.getenv('REACTION_ANDROID_KEYSTORE_PASSWORD')
+def releaseKeyAlias = System.getenv('REACTION_ANDROID_KEY_ALIAS')
+def releaseKeyPassword = System.getenv('REACTION_ANDROID_KEY_PASSWORD')
+def releaseSigningConfigured = [
+    releaseKeystorePath,
+    releaseKeystorePassword,
+    releaseKeyAlias,
+    releaseKeyPassword,
+].every { it != null && !it.trim().isEmpty() }
+
 android {
     namespace = "com.hanium.reaction"
     compileSdk = rootProject.ext.compileSdkVersion
@@ -7,8 +19,8 @@ android {
         applicationId "com.hanium.reaction"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1
-        versionName "1.0.0"
+        versionCode Integer.parseInt(System.getenv('REACTION_VERSION_CODE') ?: '1')
+        versionName System.getenv('REACTION_VERSION_NAME') ?: '1.0.0'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.
@@ -16,8 +28,23 @@ android {
             ignoreAssetsPattern = '!.svn:!.git:!.ds_store:!*.scc:.*:!CVS:!thumbs.db:!picasa.ini:!*~'
         }
     }
+    signingConfigs {
+        if (releaseSigningConfigured) {
+            release {
+                storeFile file(releaseKeystorePath)
+                storePassword releaseKeystorePassword
+                keyAlias releaseKeyAlias
+                keyPassword releaseKeyPassword
+            }
+        }
+    }
     buildTypes {
         release {
+            if (releaseSigningConfigured) {
+                signingConfig signingConfigs.release
+            } else {
+                logger.warn('Release signing is not configured; bundleRelease will be unsigned.')
+            }
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }

--- a/docs/android-release.md
+++ b/docs/android-release.md
@@ -72,3 +72,41 @@ Play Console 계정 생성처럼 사람이 직접 해야 하는 항목과 백엔
   이것 없이는 "앱 설정에서 계정 삭제" 를 프론트에서 만들 수 없다.
 - 초대코드 가입 게이트와 30명 제한, `SIGNUPS_ENABLED` / `SCHEDULER_ENABLED` 차단 수단
 - 사용자별 API 호출 한도, Gemini 일 비용 상한과 룰 폴백
+
+## GitHub Actions로 서명 AAB 만들기
+
+`.github/workflows/android-release.yml`의 **Android Release AAB** 워크플로를 수동 실행한다.
+저장소에는 키 파일이나 비밀번호를 넣지 않는다.
+
+### 최초 1회 GitHub Secrets
+
+| Secret | 내용 |
+|---|---|
+| `ANDROID_KEYSTORE_BASE64` | upload keystore 파일을 base64 한 문자열 |
+| `ANDROID_KEYSTORE_PASSWORD` | keystore 비밀번호 |
+| `ANDROID_KEY_ALIAS` | upload key alias |
+| `ANDROID_KEY_PASSWORD` | upload key 비밀번호 |
+| `VITE_NATIVE_API_BASE_URL` | 고정 HTTPS 백엔드 API 주소(BE #320 완료 후 설정) |
+
+워크플로 실행 시 Play에서 아직 사용하지 않은 양의 `version_code`와 사용자 표시용
+`version_name`을 입력한다. 워크플로는 같은 체크아웃에서 웹 번들을 만든 뒤 Capacitor를
+동기화하고 서명된 `app-release.aab`를 14일 보관 artifact로 올린다.
+
+`VITE_NATIVE_API_BASE_URL`이 HTTPS가 아니거나 서명 Secret이 하나라도 비면 빌드를 즉시
+중단한다. keystore는 runner 임시 디렉터리에만 복원하고 성공·실패와 관계없이 삭제한다.
+
+### 로컬 서명 빌드
+
+아래 환경변수를 설정한 셸에서 `npm run build`, `npx cap sync android`,
+`android/gradlew bundleRelease` 순서로 실행한다.
+
+- `REACTION_ANDROID_KEYSTORE_PATH`
+- `REACTION_ANDROID_KEYSTORE_PASSWORD`
+- `REACTION_ANDROID_KEY_ALIAS`
+- `REACTION_ANDROID_KEY_PASSWORD`
+- `REACTION_VERSION_CODE`
+- `REACTION_VERSION_NAME`
+- `VITE_NATIVE_API_BASE_URL`
+
+키 경로는 저장소 밖을 사용한다. `.jks`, `.keystore`, `keystore.properties`,
+`android/upload-keystore.*`는 Git에서 무시된다.


### PR DESCRIPTION
## 준비한 것

Google Play용 서명 AAB를 팀원이 같은 절차로 반복 생성할 수 있도록 릴리스 파이프라인을 준비합니다.

- Gradle release signing을 환경변수 기반으로 배선
- `versionCode`/`versionName`을 워크플로 입력으로 주입
- 수동 `Android Release AAB` GitHub Actions 추가
- HTTPS API 주소와 필수 Secret 누락 시 fail-fast
- 동일 체크아웃에서 웹 빌드 → Capacitor sync → 서명 AAB 생성
- AAB를 14일 artifact로 보관
- 임시 keystore를 항상 삭제
- `.jks`/`.keystore`/Google services 파일 Git 제외
- 최초 Secret 설정과 로컬 빌드 절차 문서화

## GitHub Secrets 필요

- `ANDROID_KEYSTORE_BASE64`
- `ANDROID_KEYSTORE_PASSWORD`
- `ANDROID_KEY_ALIAS`
- `ANDROID_KEY_PASSWORD`
- `VITE_NATIVE_API_BASE_URL` — BE #320의 고정 HTTPS 주소

## 검증

- `npm run build` 통과
- `npm run check:api` 통과
- `npm run check:fields` 통과
- 로컬 Gradle 검증 불가: 현재 환경에 Java/Android SDK 없음
- 실제 서명 AAB는 keystore Secret 설정 후 `workflow_dispatch` 최초 실행으로 검증 필요

Refs #237