### PR TITLE
fix(mandala): 축 선택 스트립이 세로로 눌려 잘리던 문제 (#254)

### DIFF
--- a/src/components/MandalaGrid.tsx
+++ b/src/components/MandalaGrid.tsx
@@ -416,7 +416,19 @@ interface AxisStripProps {
 export function MandalaAxisStrip({ board, active, onChange }: AxisStripProps) {
   return (
     <div
-      style={{ display: 'flex', gap: 6, overflowX: 'auto', paddingBottom: 4, WebkitOverflowScrolling: 'touch' }}
+      style={{
+        display: 'flex',
+        gap: 6,
+        overflowX: 'auto',
+        paddingBottom: 4,
+        WebkitOverflowScrolling: 'touch',
+        // 세로로 눌리지 않게 못을 박는다(#254). overflow-x:auto 를 주면 계산된
+        // overflow-y 도 auto 가 되어 이 div 가 스크롤 컨테이너가 되고, 그 순간
+        // flexbox 의 자동 최소 크기(min-height:auto)가 0 으로 풀린다. 형제들은
+        // 전부 overflow:visible 이라 min-content 밑으로 줄지 못하므로, 부모 열의
+        // 세로 넘침을 이 스트립 혼자 흡수해 40px 칩이 4~15px 띠로 잘려 보였다.
+        flexShrink: 0,
+      }}
       role="tablist"
       aria-label="만다라트 블록 선택"
     >


### PR DESCRIPTION
## 이슈

Closes #254

## 변경

`MandalaAxisStrip` 루트 div 에 `flexShrink: 0` 한 줄. 이슈에 적힌 원인 분석 그대로다.

`overflow-x:auto` → 계산된 `overflow-y` 도 `auto` → 이 div 가 스크롤 컨테이너가 되고,
flexbox 의 자동 최소 크기(`min-height:auto`)가 0 으로 풀린다. 형제들은 전부
`overflow:visible` 이라 min-content 밑으로 못 줄어드니, 컬럼의 세로 넘침을 이 스트립
혼자 흡수했다. 자기 자신이 클리핑 컨테이너라 40px 칩의 윗부분만 남았다.

왜 이렇게 되는지 다음 사람이 다시 추적하지 않도록 주석으로 남겼다.

## 어떻게 테스트했는지

- `npx tsc --noEmit` 통과, `npm run build` 통과
- 실제 높이 회복은 프리뷰에서 확인 부탁드립니다. 이슈에 적힌 재현 조건(데스크탑 560px 열,
  375x667, 목표문 2줄)에서 40px 로 돌아오는지가 판정 기준입니다

## 리뷰어 체크 포인트

- 스트립이 고정 높이를 갖게 되면서 부모(`MandalaScreen`)가 정상적으로 세로 스크롤하는지
- 가로 스크롤(칩이 화면 밖으로 넘어가는 동작)은 그대로인지
