### PR TITLE
fix(weekly): 자정을 넘는 블록을 두 칸으로 나눠 그린다 (#262)

### DIFF
--- a/src/components/WeekGrid.tsx
+++ b/src/components/WeekGrid.tsx
@@ -67,6 +67,34 @@ const LOADING_SLOTS = [
 
 const NEUTRAL = { bg: 'var(--sand-100)', bd: 'var(--sand-300)', fg: 'var(--text-3)' };
 
+const DAY_MIN = 24 * 60;
+
+/** 화면에 실제로 그려지는 한 조각. 자정을 넘는 블록은 두 조각이 된다. */
+interface Segment {
+  col: number;
+  startMin: number;
+  durMin: number;
+  /** 자정 이후로 넘어간 뒷조각인가. 앞조각과 모서리·라벨 처리가 다르다. */
+  tail: boolean;
+}
+
+/**
+ * 자정을 넘는 블록을 요일 칸에 맞게 나눈다(#262).
+ *
+ * 백엔드가 활동창을 자정에서 이어 붙이면서 `22:00 → 다음날 01:00` 같은 블록이 실제로 온다.
+ * 나누지 않으면 시작 요일 칸의 바닥을 뚫고 나가 아래 그리드 위에 겹쳐 그려진다.
+ * 캘린더 앱들이 하는 방식대로 앞뒤 두 조각으로 나눠, 새벽 부분이 제 요일 칸 맨 위에 놓이게 한다.
+ */
+function segmentsOf(b: WeekGridBlock): Segment[] {
+  const end = b.startMin + b.durMin;
+  if (end <= DAY_MIN) return [{ col: b.col, startMin: b.startMin, durMin: b.durMin, tail: false }];
+  return [
+    { col: b.col, startMin: b.startMin, durMin: DAY_MIN - b.startMin, tail: false },
+    // 일요일에서 넘어간 조각은 다음 주라 이번 화면엔 칸이 없다 — slotOf 가 걸러낸다.
+    { col: b.col + 1, startMin: 0, durMin: end - DAY_MIN, tail: true },
+  ];
+}
+
 /**
  * 한 주 7칸이 폰 폭에 다 안 들어가므로, 봐야 할 요일(오늘·첫 블록)을 가로 가운데로
  * 보내준다. 이게 없으면 일요일이 오늘일 때 화면엔 월~목만 보이고, 사용자는 자기
@@ -128,14 +156,17 @@ export function WeekGrid({
   const toY = (m: number) => ((m - startHour * 60) * hourPx) / 60;
   const bodyWidth = colWidth * cols.length;
 
-  const renderBlock = (b: WeekGridBlock, interactive: boolean) => {
-    const slot = slotOf(b.col);
+  const renderSegment = (b: WeekGridBlock, seg: Segment, interactive: boolean) => {
+    const slot = slotOf(seg.col);
     if (slot < 0) return null; // 지금 안 보이는 요일
-    const y = toY(b.startMin);
+    const y = toY(seg.startMin);
     if (y < 0) return null;
-    const h = Math.max((b.durMin * hourPx) / 60 - 2, 20);
+    const h = Math.max((seg.durMin * hourPx) / 60 - 2, 20);
     const c = b.colors ?? NEUTRAL;
     const dashed = b.muted || b.dragging;
+    // 잘린 면은 모서리를 세워 둔다 — 두 조각이 자정에서 이어진다는 걸 모양으로 알린다.
+    const split = b.startMin + b.durMin > DAY_MIN;
+    const radius = !split ? 6 : seg.tail ? '0 0 6px 6px' : '6px 6px 0 0';
     const common: React.CSSProperties = {
       position: 'absolute',
       left: slot * colWidth + 2,
@@ -144,7 +175,7 @@ export function WeekGrid({
       height: h,
       background: c.bg,
       border: `1.5px ${dashed ? 'dashed' : 'solid'} ${c.bd}`,
-      borderRadius: 6,
+      borderRadius: radius,
       padding: '3px 4px',
       overflow: 'hidden',
     };
@@ -170,7 +201,7 @@ export function WeekGrid({
             wordBreak: 'break-word',
           }}
         >
-          {b.glyph ?? ''}
+          {seg.tail ? '↳ ' : (b.glyph ?? '')}
           {b.title}
         </div>
         {(wide || h > 52) && b.subLabel && (
@@ -186,7 +217,7 @@ export function WeekGrid({
 
     if (!interactive) {
       return (
-        <div key={b.id} aria-hidden style={{ ...common, opacity: 0.38, pointerEvents: 'none' }}>
+        <div key={b.id + (seg.tail ? '-tail' : '')} aria-hidden style={{ ...common, opacity: 0.38, pointerEvents: 'none' }}>
           {label}
         </div>
       );
@@ -194,7 +225,7 @@ export function WeekGrid({
 
     return (
       <button
-        key={b.id}
+        key={b.id + (seg.tail ? '-tail' : '')}
         onPointerDown={(e) => onBlockPointerDown?.(e, b)}
         style={{
           ...common,
@@ -213,6 +244,10 @@ export function WeekGrid({
       </button>
     );
   };
+
+  /** 블록 하나가 한 조각 또는 (자정을 넘으면) 두 조각으로 그려진다. */
+  const renderBlock = (b: WeekGridBlock, interactive: boolean) =>
+    segmentsOf(b).map((seg) => renderSegment(b, seg, interactive));
 
   return (
     <div ref={scrollRef} style={{ flex: 1, minHeight: 0, overflow: 'auto' }}>

--- a/src/screens/WeeklyCalendarScreen.tsx
+++ b/src/screens/WeeklyCalendarScreen.tsx
@@ -54,6 +54,15 @@ function weeklyToBlocks(res: WeeklyPlanResponse): (Block & { status: 'pending' |
 
 // 15분 snap 단위 — Issue #9 S15 Direct Edit DoD.
 const SNAP_MIN = 15;
+
+// 하루의 분 길이. 자정을 넘는 블록(예: 22:00~다음날 01:00)이 실제로 오므로 필요하다.
+const DAY_MIN = 24 * 60;
+
+// 드래그로 옮길 수 있는 시작 시각의 범위(#262).
+// 예전엔 `24*60 - dur` 로 잘라서, 서버가 만들어 준 180분짜리 22:00 블록을 한 번만
+// 건드려도 21:00 으로 끌려 내려가고 되돌릴 방법이 없었다. 블록은 자정을 넘을 수 있으므로
+// 끝이 아니라 **시작**만 하루 안에 있으면 된다. 실제 야간 차단은 localValidate 가 맡는다.
+const clampStart = (minute: number) => Math.max(0, Math.min(DAY_MIN - SNAP_MIN, minute));
 // 정책 위반 시뮬 (백엔드 404 mock-and-replace): 23시 이후 시작 차단.
 const POLICY_NIGHT_START = 23 * 60;
 // 정책 위반 시뮬: 6시 이전 시작 차단.
@@ -399,7 +408,7 @@ export function WeeklyCalendarScreenV2() {
       // 픽셀 → 분 변환. 15분 snap.
       const minDelta = Math.round((dy / HOUR_PX) * 60 / SNAP_MIN) * SNAP_MIN;
       const newDay = dayFromDx(startDay, dx);
-      const newMinute = Math.max(0, Math.min(24 * 60 - block.dur, startMinute + minDelta));
+      const newMinute = clampStart(startMinute + minDelta);
       setDragGhost({ id: block.id, day: newDay, minute: newMinute });
     };
 
@@ -418,7 +427,7 @@ export function WeeklyCalendarScreenV2() {
       const dy = ev.clientY - startY;
       const minDelta = Math.round((dy / HOUR_PX) * 60 / SNAP_MIN) * SNAP_MIN;
       const newDay = dayFromDx(startDay, dx);
-      const newMinute = Math.max(0, Math.min(24 * 60 - block.dur, startMinute + minDelta));
+      const newMinute = clampStart(startMinute + minDelta);
       setDragGhost(null);
       if (newDay === startDay && newMinute === startMinute) return; // no-op.
       commitMove(block, newDay, newMinute);


### PR DESCRIPTION
## 이슈

Closes #262 (BE: hanium-reaction/reaction-backend#359)

## 변경

### 1. 표시 — 이슈의 A안(두 조각으로 쪼개 그리기)

`WeekGrid` 에 `segmentsOf` 를 두어 블록 하나를 앞뒤 조각으로 나눈다.

| 입력 | 결과 |
| --- | --- |
| 월 22:00 +180분 | 월 22:00 +120분, 화 00:00 +60분(이어짐) |
| 월 23:00 +60분 (정확히 자정) | 나누지 않음 |
| 일 23:00 +120분 | 일 23:00 +60분, 나머지는 다음 주라 렌더 안 함 |

- 잘린 면은 모서리를 세워(`6px 6px 0 0` / `0 0 6px 6px`) 자정에서 이어진다는 걸 모양으로 알린다
- 뒷조각 제목 앞에 `↳`
- 블록 식별자는 그대로라 뒷조각을 눌러도 같은 블록이 열리고 드래그도 동작한다

B안(칸을 늘려 넘치게 두기)은 "화요일 새벽인데 월요일 칸에 있는" 어색함이 남고,
C안(야행성 사용자 그리드 원점 이동)은 범위가 커서 택하지 않았다. **표시 방식은
제품 판단이라고 이슈에 적혀 있으니, 다른 안을 원하시면 이 PR 에서 바꾸겠습니다.**

### 2. 드래그 클램프 — 어느 안을 택하든 필요한 수정

`Math.min(24*60 - dur, ...)` → `clampStart()`. 시작 시각만 하루 안에 두고 끝은 넘어갈 수 있게 했다.
예전엔 서버가 만든 180분짜리 22:00 블록을 한 번만 건드려도 21:00 으로 끌려 내려갔고
되돌릴 방법이 없었다. 야간 차단(23시 이후 시작)은 `localValidate` 가 그대로 맡는다.

## 어떻게 테스트했는지

- `npx tsc --noEmit` 통과, `npm run build` 통과
- `segmentsOf` 경계값을 직접 돌려 확인 (위 표가 실행 결과)
- 실제 데이터로 보이는 모습은 프리뷰에서 확인 부탁드립니다. 심야 활동창(22:00~02:00)
  사용자 계정이 있어야 재현됩니다

## 리뷰어 체크 포인트

- A안이 맞는지 (다른 안을 원하면 말씀해 주세요)
- 1분처럼 아주 짧은 뒷조각은 최소 높이 20px 로 그려집니다. 그대로 둘지, 임계값 아래는
  접을지
- 계획 초안 화면(`WeeklyPlanGenerationScreen`)도 같은 `WeekGrid` 를 쓰므로 함께 바뀝니다
