### PR TITLE
fix(api): 백엔드 주소를 HTTPS 고정 도메인으로 — 배포 웹 /api 복구 (#263)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,4 +22,6 @@ VITE_ALLOW_STUB_LOGIN=
 #   미설정 = https://reaction-frontend.vercel.app/api (Vercel rewrite 로 백엔드에 우회)
 # 백엔드에 HTTPS 도메인이 붙으면 여기에 그 주소를 넣어 프록시를 건너뛴다.
 # Play 프로덕션 출시(#237)의 "API 전 구간 HTTPS" 완료 조건이 이 값에 걸려 있다.
+#   현재 주소(BE #320, FE #263): https://54-184-8-149.sslip.io
+#   주의 — 탄력적 IP 가 아니라서 EC2 가 stop/start 되면 이 도메인이 바뀐다.
 VITE_NATIVE_API_BASE_URL=

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
   "rewrites": [
-    { "source": "/api/:path*", "destination": "http://54.184.8.149:8000/:path*" }
+    { "source": "/api/:path*", "destination": "https://54-184-8-149.sslip.io/:path*" }
   ]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,11 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
-// 백엔드는 http://54.184.8.149:8000 (staging). 브라우저가 HTTPS 페이지에서 http 백엔드를
-// 직접 부르면 Mixed Content 로 차단되므로, 프론트는 항상 same-origin `/api/*` 를 부르고
-// dev 는 아래 프록시가, prod 는 vercel.json rewrite 가 http 백엔드로 중계한다.
-const API_TARGET = 'http://54.184.8.149:8000';
+// 백엔드는 https://54-184-8-149.sslip.io (staging, Caddy + Let's Encrypt).
+// 평문 8000 포트는 외부 인바운드가 차단됐다(BE #320) — 예전 주소로 두면 프록시가 통째로 죽는다.
+// 프론트는 여전히 same-origin `/api/*` 를 부르고, dev 는 아래 프록시가, prod 는
+// vercel.json rewrite 가 이 주소로 중계한다.
+const API_TARGET = 'https://54-184-8-149.sslip.io';
 
 export default defineConfig({
   plugins: [react()],


### PR DESCRIPTION
## 이슈

Closes #263 (BE: hanium-reaction/reaction-backend#320)

## 급합니다 — 지금 배포된 웹이 죽어 있습니다

BE #320 이 HTTPS 도메인을 붙이면서 **평문 8000 포트 외부 인바운드를 차단**했는데,
웹 경로의 백엔드 주소는 `vercel.json` 과 `vite.config.ts` 에 하드코딩돼 있어 함께 바뀌지
않았습니다. 이슈 본문은 "코드 수정 없이 환경변수만"이라고 했지만, 그건 네이티브 앱
경로(`VITE_NATIVE_API_BASE_URL`) 이야기이고 웹 프록시는 별개입니다.

실측:

| 대상 | 결과 |
| --- | --- |
| `https://reaction-frontend.vercel.app/api/health` | **000 (25초 타임아웃)** |
| `http://54.184.8.149:8000/health` | **000 (응답 없음)** |
| `https://54-184-8-149.sslip.io/health` | 200, `db.ok=true` |

머지 후 프로덕션 배포가 돌아야 복구됩니다.

## 변경

- `vercel.json` rewrite 대상을 새 도메인으로 (프로덕션 웹 복구)
- `vite.config.ts` dev 프록시 대상도 같이 (로컬 개발 복구)
- `.env.example` 에 현재 도메인과 "탄력적 IP 가 아니라서 EC2 stop/start 시 바뀐다"는 주의 기재

## 남은 일 — 코드로는 못 하는 부분

`VITE_NATIVE_API_BASE_URL` 은 빌드 환경변수라 대시보드/시크릿에 넣어야 합니다.

- Vercel 프로젝트 환경변수
- GitHub Actions 시크릿 `VITE_NATIVE_API_BASE_URL` (`android-release.yml` 이 이미 참조 중)

값: `https://54-184-8-149.sslip.io`

## 어떻게 테스트했는지

- 새 도메인 `/health` 200 확인 (위 표)
- `npm run build` 통과
- 프록시 실제 동작은 프리뷰 배포에서 `/api/health` 가 200 인지로 확인 부탁드립니다

## 리뷰어 체크 포인트

- 웹도 새 도메인을 직접 부르게 할지(프록시 제거), 지금처럼 same-origin `/api` 를 유지할지.
  이 PR 은 유지 쪽입니다 — 쿠키·CORS 설정을 건드리지 않는 최소 변경이라서요
