### PR TITLE
fix(ci): android-release 워크플로가 파싱 실패로 등록조차 안 되던 문제 (#257)

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: number
       version_name:
-        description: 사용자에게 표시할 버전(예: 1.0.0)
+        description: '사용자에게 표시할 버전(예: 1.0.0)'
         required: true
         type: string
 
@@ -27,13 +27,16 @@ jobs:
       VITE_NATIVE_API_BASE_URL: ${{ secrets.VITE_NATIVE_API_BASE_URL }}
       REACTION_VERSION_CODE: ${{ inputs.version_code }}
       REACTION_VERSION_NAME: ${{ inputs.version_name }}
-      REACTION_ANDROID_KEYSTORE_PATH: ${{ runner.temp }}/reaction-upload.jks
       REACTION_ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
       REACTION_ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
       REACTION_ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
 
     steps:
       - uses: actions/checkout@v4
+      # runner 컨텍스트는 job 레벨 env 에서 못 쓴다(러너 배정 전이라 값이 없다).
+      # 여기서 한 번 내보내면 이후 step 들이 job 레벨 env 처럼 그대로 쓴다 (#257).
+      - name: Resolve keystore path
+        run: echo "REACTION_ANDROID_KEYSTORE_PATH=${{ runner.temp }}/reaction-upload.jks" >> "$GITHUB_ENV"
       - uses: actions/setup-node@v4
         with:
           node-version: '22'


### PR DESCRIPTION
## 이슈

Closes #257

## 원인이 둘이었습니다

### 1. YAML 이 애초에 깨져 있었습니다 (이슈에 없던 부분)

`workflow_dispatch` 입력 설명이 따옴표 없이 콜론을 품고 있었습니다.

```yaml
description: 사용자에게 표시할 버전(예: 1.0.0)
```

`(예: 1.0.0)` 의 콜론+공백을 YAML 이 매핑 구분자로 읽어 **11행에서 스캐너 오류**가 납니다.
컨텍스트 검증보다 먼저 걸리는 단계라, 이것만으로도 워크플로가 등록되지 않습니다.
이슈에서 관찰한 "이름이 `Android Release AAB` 가 아니라 파일 경로로 표시된다"는 증상과
정확히 맞습니다.

### 2. job 레벨 env 의 `runner` 컨텍스트 (이슈에 적힌 원인)

`runner` 는 러너가 배정된 뒤에야 값이 정해져 job 레벨 `env:` 에서 쓸 수 없습니다.
`REACTION_ANDROID_KEYSTORE_PATH` 를 빼고, 이슈가 제안한 대로 checkout 직후 step 에서
`$GITHUB_ENV` 로 내보내 이후 step 들이 그대로 쓰게 했습니다.

## 어떻게 테스트했는지

PyYAML 로 파싱해 확인했습니다.

```
워크플로 이름: Android Release AAB          ← 이제 읽힙니다
job env 내 runner 컨텍스트: 없음
앞 3개 step: checkout / Resolve keystore path / setup-node
```

저장소의 다른 워크플로(`ci.yml`, `sync-api.yml`)도 함께 파싱해 같은 따옴표 문제가
없는지 확인했습니다 — 둘 다 정상입니다.

## 남은 일

이 PR 이 머지돼야 워크플로가 비로소 목록에 뜹니다. 실제 AAB 산출까지 가려면 시크릿이
필요합니다.

- `ANDROID_KEYSTORE_BASE64`, `ANDROID_KEYSTORE_PASSWORD`, `ANDROID_KEY_ALIAS`, `ANDROID_KEY_PASSWORD`
- `VITE_NATIVE_API_BASE_URL` = `https://54-184-8-149.sslip.io` (#263 과 같은 값)

## 리뷰어 체크 포인트

- 머지 후 Actions 탭에 `Android Release AAB` 가 뜨는지 (이게 1차 판정)
- `workflow_dispatch` 로 한 번 돌려 키스토어 경로가 step 들에 제대로 전달되는지
