### PR TITLE
feat(notification): 알림 열람을 서버에 기록한다 (#258)

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -26,22 +26,37 @@ self.addEventListener('push', (event) => {
     body,
     icon: '/icon.svg',
     badge: '/icon.svg',
-    data: data.url || '/',
+    // 예전엔 url 문자열만 담아서 알림 id 가 여기서 버려졌고, 그래서 "열었다"를
+    // 서버에 기록할 방법이 없었다(#258). 객체로 담아 id 를 클릭까지 끌고 간다.
+    data: { id: data.id || null, url: data.url || '/' },
   };
   event.waitUntil(self.registration.showNotification(title, options));
 });
 
 self.addEventListener('notificationclick', (event) => {
   event.notification.close();
-  const url = (event.notification.data && typeof event.notification.data === 'string')
-    ? event.notification.data
-    : '/';
+  const raw = event.notification.data;
+  // 구버전 알림(문자열 url)도 아직 트레이에 남아 있을 수 있다.
+  const url = (typeof raw === 'string' ? raw : raw && raw.url) || '/';
+  const id = (raw && typeof raw === 'object' && raw.id) || null;
+
+  // 열람 기록은 SW 가 직접 못 보낸다 — 액세스 토큰이 localStorage 에 있고
+  // service worker 는 거기에 접근할 수 없다. 그래서 앱 쪽에 id 를 넘기고
+  // 앱이 POST /notifications/{id}/opened 를 부른다(#258).
+  //   · 창이 이미 있으면 postMessage
+  //   · 없으면 열 주소에 ?notif= 를 붙여 앱이 부팅하며 집어가게 한다
   event.waitUntil(
-    self.clients.matchAll({ type: 'window' }).then((cs) => {
+    self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then((cs) => {
       for (const c of cs) {
-        if ('focus' in c) return c.focus();
+        if ('focus' in c) {
+          if (id) c.postMessage({ type: 'notification-opened', id });
+          return c.focus();
+        }
       }
-      return self.clients.openWindow(url);
+      const target = id
+        ? url + (url.includes('?') ? '&' : '?') + 'notif=' + encodeURIComponent(id)
+        : url;
+      return self.clients.openWindow(target);
     }),
   );
 });

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -6,6 +6,7 @@ import { NavigationContext, STATE_TO_SCREEN } from '../contexts/NavigationContex
 import { ToastProvider } from '../contexts/ToastContext';
 import { IosInstallCard } from '../components/IosInstallCard';
 import { ApiError, authApi, clearSession, friendlyError, getAccessToken, getAuthKind, getRefreshToken, initTokenStore, onAuthExpired, onboardingApi, setSession, stubLoginAllowed } from '../lib/api';
+import { startNotificationOpenReporting } from '../lib/push';
 import type { ScreenId, TabId } from '../types';
 import type { MilestoneDraft, OnboardingState, UserProfile } from '../types/api';
 
@@ -209,6 +210,15 @@ export function AppShell() {
       setAuthBusy(false);
     }
   }, [loadSessionAfterLogin]);
+
+  // 알림을 실제로 열었는지 서버에 기록한다(#258). service worker 는 토큰을 못 읽어서
+  // 직접 부르지 못하고, id 만 이쪽으로 넘겨 준다. 로그인 뒤에만 의미가 있으므로
+  // 사용자가 붙은 다음에 시작한다.
+  const hasUser = !!user;
+  useEffect(() => {
+    if (!hasUser) return;
+    return startNotificationOpenReporting();
+  }, [hasUser]);
 
   // 되살릴 수 없는 401 = 세션 종료. 토큰은 api 레이어에서 이미 버렸다.
   // 여기서 로그인 화면으로 돌려보내지 않으면 "데이터만 안 나오는 화면" 에 갇힌다.

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -788,6 +788,12 @@ export const notificationsApi = {
   // FE 가 pushManager.subscribe(applicationServerKey) 에 쓸 서버 발급 공개키.
   // publicKey=null 이면 서버 미설정 — 구독을 만들면 안 된다.
   vapidPublicKey: () => request<VapidPublicKeyResponse>('/notifications/vapid-public-key'),
+
+  // 알림을 실제로 열었다는 기록(#258, BE #335). 204 이고 멱등이라 재호출도 안전하다.
+  // "보냈다"까지만 알던 것을 "닿았다"까지 알게 해, 주 3건인 알림 예산을 데이터로
+  // 조정할 근거를 만든다.
+  opened: (notificationId: string) =>
+    request<void>(`/notifications/${notificationId}/opened`, { method: 'POST' }),
 };
 
 // ── Policy Snapshot (#83) ─────────────────────────────────────

--- a/src/lib/push.ts
+++ b/src/lib/push.ts
@@ -83,3 +83,44 @@ export async function registerServiceWorker(): Promise<void> {
     /* 무시 */
   }
 }
+
+/** 이 주소에 실려 온 알림 id — service worker 가 새 창을 열 때 붙여 준다. */
+const NOTIF_PARAM = 'notif';
+
+/**
+ * 알림 열람을 서버에 기록한다(#258).
+ *
+ * service worker 는 localStorage 에 접근할 수 없어 액세스 토큰을 못 읽는다. 그래서
+ * SW 가 직접 부르지 않고 여기로 id 만 넘어온다 — 창이 이미 떠 있으면 postMessage 로,
+ * 새로 열렸으면 주소의 `?notif=` 로. 어느 쪽이든 호출은 앱이 한다.
+ *
+ * 로그인 뒤에 시작해야 한다(401 이면 기록이 남지 않는다). 실패는 삼킨다 — 열람 기록
+ * 하나 때문에 화면에 오류를 띄울 이유가 없고, endpoint 가 멱등이라 다음 기회에 또 부르면 된다.
+ */
+export function startNotificationOpenReporting(): () => void {
+  if (typeof window === 'undefined') return () => {};
+
+  const report = (id: string) => {
+    if (!id) return;
+    notificationsApi.opened(id).catch(() => { /* 열람 기록 실패는 조용히 넘긴다 */ });
+  };
+
+  // 1) 새 창으로 열린 경우 — 주소에서 집어가고 흔적은 지운다.
+  //    남겨두면 새로고침할 때마다 같은 id 를 다시 보낸다(멱등이라 해롭진 않지만 요청 낭비).
+  const url = new URL(window.location.href);
+  const fromUrl = url.searchParams.get(NOTIF_PARAM);
+  if (fromUrl) {
+    report(fromUrl);
+    url.searchParams.delete(NOTIF_PARAM);
+    window.history.replaceState({}, '', url.pathname + url.search + url.hash);
+  }
+
+  // 2) 이미 떠 있던 창 — SW 가 보낸 메시지를 받는다.
+  if (!('serviceWorker' in navigator)) return () => {};
+  const onMessage = (e: MessageEvent) => {
+    const d = e.data;
+    if (d && d.type === 'notification-opened' && typeof d.id === 'string') report(d.id);
+  };
+  navigator.serviceWorker.addEventListener('message', onMessage);
+  return () => navigator.serviceWorker.removeEventListener('message', onMessage);
+}


### PR DESCRIPTION
## 이슈

Closes #258 (BE: hanium-reaction/reaction-backend#335)

## 왜 service worker 가 직접 부르지 않나

이슈의 3번 항목("인증 처리 — SW 에서 토큰을 어떻게 얻을지 확인 필요")에 대한 답입니다.
**service worker 는 localStorage 에 접근할 수 없어 액세스 토큰을 못 읽습니다.** 토큰을
IndexedDB 에 복제해 두면 SW 가 부를 수는 있지만, 열람 기록 하나 때문에 토큰 사본을 하나 더
만드는 건 손해가 큽니다.

그래서 이슈가 대안으로 제시한 쪽을 택했습니다 — SW 는 id 만 넘기고 호출은 앱이 합니다.

| 상황 | 전달 방법 |
| --- | --- |
| 창이 이미 떠 있음 | `postMessage({ type: 'notification-opened', id })` |
| 새 창으로 열림 | 주소에 `?notif=<id>` 를 붙여 앱이 부팅하며 집어감 |

## 변경

- **`sw.js` push** — 알림 `data` 를 `{ id, url }` 객체로 담습니다. 예전엔 url 문자열만
  담아서 id 가 여기서 버려졌습니다
- **`sw.js` notificationclick** — 위 두 경로로 id 를 앱에 전달합니다. 구버전 알림(문자열 url)이
  트레이에 남아 있어도 깨지지 않게 둘 다 읽습니다
- **`api.ts`** — `notificationsApi.opened(id)`
- **`push.ts`** — `startNotificationOpenReporting()`. 주소의 `?notif=` 를 집어 호출하고
  흔적을 지웁니다(새로고침마다 다시 보내지 않게). SW 메시지도 받습니다
- **`AppShell`** — 사용자가 붙은 뒤에 시작합니다. 401 이면 기록이 안 남으니까요

실패는 삼킵니다. 열람 기록 하나 때문에 화면에 오류를 띄울 이유가 없고, endpoint 가 멱등이라
다음 기회에 또 부르면 됩니다.

## 어떻게 테스트했는지

- `node --check public/sw.js`, `npx tsc --noEmit`, `npm run build` 통과
- `npm run check:api` → **PASS** (GONE 0). 이 경로는 WARN 으로 잡히는데, 저장소의
  `openapi.json` 스냅샷이 BE #335 이전이라서입니다 — `sync-api` 가 돌면 사라집니다
- 실제 푸시 왕복은 확인하지 못했습니다. VAPID 키와 실제 발송이 필요합니다

## 리뷰어 체크 포인트

- 실제 알림을 한 번 보내서 `notification_sends.opened_at` 이 채워지는지 (이게 진짜 판정)
- 백엔드 푸시 payload 에 `id` 가 실제로 실려 오는지 — 안 실려 오면 SW 가 담을 게 없습니다
- 새 창 경로에서 `?notif=` 가 주소창에 잠깐 보였다 사라집니다. 거슬리면 `history.replaceState`
  대신 다른 방법을 찾겠습니다
