### PR TITLE
feat: 자료 검색 3단계 HITL 화면 연결 (#259)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -166,6 +166,10 @@
             ],
             "title": "Firststep"
           },
+          "missedCheckIn": {
+            "title": "Missedcheckin",
+            "type": "boolean"
+          },
           "priority": {
             "title": "Priority",
             "type": "integer"
@@ -204,7 +208,8 @@
           "source",
           "whyNow",
           "firstStep",
-          "cancellable"
+          "cancellable",
+          "missedCheckIn"
         ],
         "title": "AgendaCard",
         "type": "object"
@@ -892,6 +897,115 @@
         "title": "DbStatus",
         "type": "object"
       },
+      "DeleteAccountRequest": {
+        "description": "POST /settings/delete-account 요청. `anonymize` 와 동일한 2단계 확인 모양.",
+        "properties": {
+          "confirmationToken": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Confirmationtoken"
+          }
+        },
+        "title": "DeleteAccountRequest",
+        "type": "object"
+      },
+      "DeleteAccountResponse": {
+        "description": "계정 삭제 응답. `status` 로 단계 구분.\n\n- `confirmation_required` — 토큰 발급(미적용).\n- `deleted` — 적용 완료. 이 응답을 받은 뒤로 이 access token 은 다음 요청부터\n  `AUTH_INVALID_TOKEN` 이다(계정 조회 자체가 soft-delete 필터에 걸린다) — 클라이언트는\n  곧바로 로그아웃 처리할 것.",
+        "properties": {
+          "confirmationToken": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Confirmationtoken"
+          },
+          "deletedAt": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Deletedat"
+          },
+          "expiresAt": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expiresat"
+          },
+          "message": {
+            "title": "Message",
+            "type": "string"
+          },
+          "status": {
+            "enum": [
+              "confirmation_required",
+              "deleted"
+            ],
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "message"
+        ],
+        "title": "DeleteAccountResponse",
+        "type": "object"
+      },
+      "EffortMinutes": {
+        "description": "이번 주를 **분**으로 본 요약 (ADR-0009 D5).\n\n`adherenceRate`(건수 비율) 옆에 나란히 둔다. 계획 세션 길이가 작업 내용을 따라가면\n건수와 시간이 갈라진다 — 15분짜리 9개를 끝내고 3시간짜리 1개를 못 하면 건수로는 90%\n지만 실제로는 절반도 못 한 주다.\n\n`actualMinutes` 를 `completedMinutes` 와 나누면 \"예상이 맞았나\" 가 나온다\n(1.0 = 예상대로, 1.3 = 30% 더 걸렸다). 둘 다 **완료한 실행**만 센다.",
+        "properties": {
+          "actualMinutes": {
+            "default": 0,
+            "title": "Actualminutes",
+            "type": "integer"
+          },
+          "adherenceRate": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Adherencerate"
+          },
+          "completedMinutes": {
+            "default": 0,
+            "title": "Completedminutes",
+            "type": "integer"
+          },
+          "plannedMinutes": {
+            "default": 0,
+            "title": "Plannedminutes",
+            "type": "integer"
+          }
+        },
+        "title": "EffortMinutes",
+        "type": "object"
+      },
       "ExecutionEventResponse": {
         "description": "POST /today/focus/{id}/pause·resume 응답 — 집중 세션 일시정지/재개 (#83).\n\npause 는 interruption_events(user_pause) 를 열고, resume 은 그 구간을 닫아\nexecution.pause_total_minutes 에 누적한다. execution 자체는 in_progress 유지.",
         "properties": {
@@ -1007,7 +1121,7 @@
         "type": "object"
       },
       "FailureTagRequest": {
-        "description": "POST /reflection/failure-tags/{executionId} — 실패 사유 0~2개 + 메모.",
+        "description": "POST /reflection/failure-tags/{executionId} — 실패 사유 0~2개 + 메모 + 정서 1문항.\n\n`task_aversiveness`(#299, FE #222): 이 일이 얼마나 하기 싫었는지 1(전혀 안 싫음)~5(매우\n싫음). 선택 사항 — 강제하면 회고 이탈이 늘 것으로 보고 FE 가 선택으로 뒀다.",
         "properties": {
           "memo": {
             "anyOf": [
@@ -1028,6 +1142,19 @@
             "maxItems": 2,
             "title": "Tagcodes",
             "type": "array"
+          },
+          "taskAversiveness": {
+            "anyOf": [
+              {
+                "maximum": 5.0,
+                "minimum": 1.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Taskaversiveness"
           }
         },
         "required": [
@@ -1234,6 +1361,13 @@
             "default": true,
             "title": "Isdraft",
             "type": "boolean"
+          },
+          "milestones": {
+            "items": {
+              "$ref": "#/components/schemas/MilestoneDraft"
+            },
+            "title": "Milestones",
+            "type": "array"
           },
           "planId": {
             "title": "Planid",
@@ -1642,6 +1776,40 @@
         "title": "GoalCandidate",
         "type": "object"
       },
+      "GoalCompletionProposal": {
+        "description": "\"이 목표 끝난 거 맞아요?\" 제안 1건 (ADR-0007 6b).\n\n마일스톤이 **전부** 완료된 목표에 대해 나간다. `NextCycleProposal` 과 **배타적**이다 —\n같은 가드(`has_open_milestone`)의 양쪽 갈래라, 한 목표가 두 카드에 동시에 뜨지 않는다.\n\n확정은 `POST /goals/{goalId}/complete`.",
+        "properties": {
+          "goalId": {
+            "format": "uuid",
+            "title": "Goalid",
+            "type": "string"
+          },
+          "goalTitle": {
+            "title": "Goaltitle",
+            "type": "string"
+          }
+        },
+        "required": [
+          "goalId",
+          "goalTitle"
+        ],
+        "title": "GoalCompletionProposal",
+        "type": "object"
+      },
+      "GoalCompletionRequest": {
+        "description": "POST /goals/{goalId}/complete 요청 — 목표 완료 확정/해제 (ADR-0007 6b).\n\n마일스톤 완료 표시(`PATCH /goals/{goalId}/nodes/{nodeId}`)와 **같은 모양**으로 뒀다 —\n둘 다 \"끝났다\" 를 사용자가 확정하는 HITL 이고, 둘 다 오조작을 되돌릴 수 있어야 한다.",
+        "properties": {
+          "completed": {
+            "title": "Completed",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "completed"
+        ],
+        "title": "GoalCompletionRequest",
+        "type": "object"
+      },
       "GoalCreateRequest": {
         "description": "POST /goals 요청.",
         "properties": {
@@ -1738,6 +1906,18 @@
       "GoalNode": {
         "description": "decompose 응답의 노드 (api-contract §6).\n\n`order_index`/`node_type`/`is_leaf` 는 PR6 에서 additive 로 추가됐다(만다라 렌더의 전제 —\n`orderIndex` 없이는 FE 가 8칸 중 몇 번째인지 알 수 없다). 기존 소비 코드는 무변경.",
         "properties": {
+          "completedAt": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Completedat"
+          },
           "depth": {
             "title": "Depth",
             "type": "integer"
@@ -1845,7 +2025,7 @@
         "type": "object"
       },
       "GoalUpdateRequest": {
-        "description": "PATCH /goals/{id} 요청 — 제목·마감·우선순위·tier·category 변경.",
+        "description": "PATCH /goals/{id} 요청 — 제목·마감·우선순위·tier·category 변경.\n\n`category` 는 `GoalCreateRequest.category` 와 같은 허용값·정규화 규칙을 쓴다(#326,\nFE #216 차단 해소). 생략하면 기존 category 유지 — 재인터뷰 제안 트리거는 FE 가 저장\n성공 후 실제로 값이 달라졌을 때만 띄운다(자동 재계획·강제 이동 없음).",
         "properties": {
           "category": {
             "anyOf": [
@@ -1947,13 +2127,26 @@
         "type": "object"
       },
       "GoogleLoginRequest": {
-        "description": "POST /auth/google 요청 — Google id_token.",
+        "description": "POST /auth/google 요청 — Google id_token (+ 신규 가입만 `inviteCode` 필요, #324).",
         "properties": {
           "idToken": {
             "description": "Google OAuth id_token",
             "minLength": 1,
             "title": "Idtoken",
             "type": "string"
+          },
+          "inviteCode": {
+            "anyOf": [
+              {
+                "maxLength": 32,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "신규 가입에만 필요. 기존 사용자 로그인은 무시된다.",
+            "title": "Invitecode"
           }
         },
         "required": [
@@ -1985,6 +2178,17 @@
           "frequencyPerWeek": {
             "title": "Frequencyperweek",
             "type": "integer"
+          },
+          "goalNodeId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Goalnodeid"
           },
           "habitId": {
             "title": "Habitid",
@@ -2798,17 +3002,21 @@
       },
       "JsonValue": {},
       "LogoutRequest": {
-        "description": "POST /auth/logout 요청.",
+        "description": "POST /auth/logout 요청. `refreshToken` 생략 가능 — `RefreshRequest` 와 동일한 이유(#323).",
         "properties": {
           "refreshToken": {
-            "minLength": 1,
-            "title": "Refreshtoken",
-            "type": "string"
+            "anyOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Refreshtoken"
           }
         },
-        "required": [
-          "refreshToken"
-        ],
         "title": "LogoutRequest",
         "type": "object"
       },
@@ -3079,6 +3287,107 @@
         "title": "MandalaGenerateRequest",
         "type": "object"
       },
+      "MandalaHabitLinkRequest": {
+        "description": "POST /goals/mandala/nodes/{nodeId}/habit(U12) 요청 — 반복형 칸으로 전환(ADR-0008 §1).\n\n\"코딩테스트 1일 1문제\"·\"쓰레기 줍기\" 처럼 끝이 없는 leaf 칸에 새 `Habit` 을 만들어\n링크한다. 계획(action_item)을 만들지 않고 이후 주간 횟수(habit_instances.done_count)로만\n추적한다. `title` 을 생략하면 칸 제목을 그대로 쓴다.",
+        "properties": {
+          "category": {
+            "default": "other",
+            "enum": [
+              "study",
+              "health",
+              "routine",
+              "self_dev",
+              "relationship",
+              "other"
+            ],
+            "title": "Category",
+            "type": "string"
+          },
+          "frequencyPerWeek": {
+            "maximum": 7.0,
+            "minimum": 1.0,
+            "title": "Frequencyperweek",
+            "type": "integer"
+          },
+          "minutesPerSession": {
+            "minimum": 1.0,
+            "title": "Minutespersession",
+            "type": "integer"
+          },
+          "priorityLevel": {
+            "default": 3,
+            "maximum": 5.0,
+            "minimum": 1.0,
+            "title": "Prioritylevel",
+            "type": "integer"
+          },
+          "timePreference": {
+            "default": "anytime",
+            "enum": [
+              "morning",
+              "afternoon",
+              "evening",
+              "anytime"
+            ],
+            "title": "Timepreference",
+            "type": "string"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "maxLength": 200,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          }
+        },
+        "required": [
+          "frequencyPerWeek",
+          "minutesPerSession"
+        ],
+        "title": "MandalaHabitLinkRequest",
+        "type": "object"
+      },
+      "MandalaHabitWeekStat": {
+        "description": "만다라 반복형 칸 1개의 이번 주 체크인 현황.",
+        "properties": {
+          "axisTitle": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Axistitle"
+          },
+          "cellTitle": {
+            "title": "Celltitle",
+            "type": "string"
+          },
+          "doneCount": {
+            "title": "Donecount",
+            "type": "integer"
+          },
+          "targetCount": {
+            "title": "Targetcount",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "cellTitle",
+          "doneCount",
+          "targetCount"
+        ],
+        "title": "MandalaHabitWeekStat",
+        "type": "object"
+      },
       "MandalaNode": {
         "description": "만다라 노드 1개(U8 응답 원소, U9 응답 그대로) — `GoalNode` additive 확장(§6.2).\n\n`progress`/`coverage` 는 컬럼 캐시가 아니라 매 조회 시 파생한다(§7.8, `goal_nodes.progress`\n컬럼을 만들지 않는 이유는 `mandala_adapter.compute_progress` docstring 참고). U9(단일 노드\n편집) 응답에서는 롤업을 다시 계산하지 않고 둘 다 `null` — 필요하면 U8 을 다시 부른다.",
         "properties": {
@@ -3108,6 +3417,17 @@
           "depth": {
             "title": "Depth",
             "type": "integer"
+          },
+          "habitId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Habitid"
           },
           "isLeaf": {
             "title": "Isleaf",
@@ -3201,11 +3521,12 @@
           "orderIndex",
           "nodeType",
           "isLeaf",
+          "completedAt",
           "whyText",
           "source",
           "locked",
-          "completedAt",
           "promotedGoalId",
+          "habitId",
           "progress",
           "coverage"
         ],
@@ -3465,6 +3786,267 @@
         "title": "MandalaTreeResponse",
         "type": "object"
       },
+      "MandalaWeeklySummary": {
+        "description": "`GET /reviews/weekly` 의 '이번 주 만다라트' 절 (ADR-0008 §8 \"E\").\n\n조회 시점에 파생한다(저장 안 함) — 궁극목표가 없거나 아직 승인된 만다라 트리가 없으면\n응답 자체에서 생략된다(`null`).",
+        "properties": {
+          "completedThisWeek": {
+            "title": "Completedthisweek",
+            "type": "integer"
+          },
+          "completedTotal": {
+            "title": "Completedtotal",
+            "type": "integer"
+          },
+          "habits": {
+            "items": {
+              "$ref": "#/components/schemas/MandalaHabitWeekStat"
+            },
+            "title": "Habits",
+            "type": "array"
+          },
+          "totalLeaves": {
+            "title": "Totalleaves",
+            "type": "integer"
+          },
+          "touchedThisWeek": {
+            "title": "Touchedthisweek",
+            "type": "integer"
+          },
+          "untouchedAxisTitles": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Untouchedaxistitles",
+            "type": "array"
+          }
+        },
+        "required": [
+          "completedThisWeek",
+          "completedTotal",
+          "totalLeaves",
+          "touchedThisWeek"
+        ],
+        "title": "MandalaWeeklySummary",
+        "type": "object"
+      },
+      "MaterialSource": {
+        "description": "검색이 실제로 참조한 출처 — 사용자에게 그대로 보여준다 (#259 ⑩).\n\n출처를 숨기고 자료를 쓰면 다른 판·다른 강의를 가져왔을 때 사용자가 알아챌 방법이 없다.",
+        "properties": {
+          "title": {
+            "title": "Title",
+            "type": "string"
+          },
+          "uri": {
+            "title": "Uri",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "uri"
+        ],
+        "title": "MaterialSource",
+        "type": "object"
+      },
+      "MaterialsConfirmRequest": {
+        "description": "POST /plans/materials/confirm — \"이 자료 맞아요\".\n\n`text` 를 그대로 받는 이유: 사용자가 **고쳐서** 보낼 수 있어야 한다. 검색이 다른 판을\n가져왔거나 일부만 맞을 때 지우고 붙이는 게 HITL 의 핵심이다.",
+        "properties": {
+          "interviewSessionId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Interviewsessionid"
+          },
+          "text": {
+            "maxLength": 20000,
+            "minLength": 1,
+            "title": "Text",
+            "type": "string"
+          }
+        },
+        "required": [
+          "text"
+        ],
+        "title": "MaterialsConfirmRequest",
+        "type": "object"
+      },
+      "MaterialsConfirmResponse": {
+        "description": "확정 결과 — 명시 승인이므로 Draft 가 아니다 (ADR-0005 §7.2).",
+        "properties": {
+          "goalTitle": {
+            "title": "Goaltitle",
+            "type": "string"
+          },
+          "notice": {
+            "title": "Notice",
+            "type": "string"
+          },
+          "savedChars": {
+            "title": "Savedchars",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "goalTitle",
+          "savedChars",
+          "notice"
+        ],
+        "title": "MaterialsConfirmResponse",
+        "type": "object"
+      },
+      "MaterialsQueryRequest": {
+        "description": "POST /plans/materials/search-query.",
+        "properties": {
+          "interviewSessionId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Interviewsessionid"
+          }
+        },
+        "title": "MaterialsQueryRequest",
+        "type": "object"
+      },
+      "MaterialsQueryResponse": {
+        "description": "제안된 검색어 — **아직 아무것도 검색하지 않았다.**\n\n`is_draft` 를 쓰지 않는 이유: 이건 AI 산출물이 아니라 목표 제목에서 규칙으로 만든\n문자열이다. LLM 도 외부 호출도 없으므로 Draft 표기 대상이 아니다.",
+        "properties": {
+          "goalTitle": {
+            "title": "Goaltitle",
+            "type": "string"
+          },
+          "notice": {
+            "title": "Notice",
+            "type": "string"
+          },
+          "suggestedQuery": {
+            "title": "Suggestedquery",
+            "type": "string"
+          }
+        },
+        "required": [
+          "suggestedQuery",
+          "goalTitle",
+          "notice"
+        ],
+        "title": "MaterialsQueryResponse",
+        "type": "object"
+      },
+      "MaterialsSearchRequest": {
+        "description": "POST /plans/materials/search — **사용자가 확인·편집한 검색어만** 받는다 (① 결정).\n\n목표 슬롯을 서버가 알아서 질의로 만들지 않는다. 무엇이 외부로 나가는지가 이 필드\n하나로 결정되고, 사용자가 1단계에서 그걸 봤다.",
+        "properties": {
+          "query": {
+            "maxLength": 200,
+            "minLength": 2,
+            "title": "Query",
+            "type": "string"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "title": "MaterialsSearchRequest",
+        "type": "object"
+      },
+      "MaterialsSearchResponse": {
+        "description": "검색 결과 — **저장되지 않았다.** 3단계 확정 전까지는 아무 데도 안 남는다.\n\n`is_draft=True` 가 그 계약이다 (AGENTS §1.4).",
+        "properties": {
+          "aiSource": {
+            "default": "llm",
+            "enum": [
+              "llm",
+              "rule"
+            ],
+            "title": "Aisource",
+            "type": "string"
+          },
+          "isDraft": {
+            "default": true,
+            "title": "Isdraft",
+            "type": "boolean"
+          },
+          "notice": {
+            "title": "Notice",
+            "type": "string"
+          },
+          "remainingToday": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Remainingtoday"
+          },
+          "searchQueries": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Searchqueries",
+            "type": "array"
+          },
+          "sources": {
+            "items": {
+              "$ref": "#/components/schemas/MaterialSource"
+            },
+            "title": "Sources",
+            "type": "array"
+          },
+          "status": {
+            "enum": [
+              "found",
+              "not_found",
+              "blocked_copyright",
+              "quota_exceeded",
+              "unavailable"
+            ],
+            "title": "Status",
+            "type": "string"
+          },
+          "text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Text"
+          }
+        },
+        "required": [
+          "status",
+          "notice"
+        ],
+        "title": "MaterialsSearchResponse",
+        "type": "object"
+      },
+      "MilestoneCompletionRequest": {
+        "description": "PATCH /goals/{goalId}/nodes/{nodeId} 요청 — 마일스톤 완료 표시 (ADR-0007 §3 예외).\n\n제목·요약은 여기서 못 고친다. 뼈대 편집은 마일스톤 확인 화면 → `generate` →\n`approve` 경로 하나로 모여 있고(ADR-0007 PR-6a), 여기서도 고칠 수 있게 하면 같은\n사실을 바꾸는 길이 둘이 된다.",
+        "properties": {
+          "completed": {
+            "title": "Completed",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "completed"
+        ],
+        "title": "MilestoneCompletionRequest",
+        "type": "object"
+      },
       "MilestoneDraft": {
         "description": "중간 목표(마일스톤) 한 개 — 사용자가 확인·편집하는 계획 뼈대 단위(#milestones Phase 2).\n\n사용자가 이 목록을 보고 수정/재배열/추가/삭제해 방향을 확정하면, 분해(Stage B)가 각\n마일스톤을 branch 로 고정하고 그 안에서만 세션(leaf)을 만든다.",
         "properties": {
@@ -3491,7 +4073,8 @@
             "default": "llm",
             "enum": [
               "llm",
-              "rule"
+              "rule",
+              "saved"
             ],
             "title": "Aisource",
             "type": "string"
@@ -3547,6 +4130,37 @@
           "fallbackUsed"
         ],
         "title": "MorningBrief",
+        "type": "object"
+      },
+      "NextCycleProposal": {
+        "description": "다음 2주 열기 제안 1건 (ADR-0008 §8 \"G\") — 승인은 기존 `/plans/generate`(빈 바디)\n+ `/plans/{id}/approve` 를 그대로 쓴다. 이 카드는 새 엔드포인트를 만들지 않는다.",
+        "properties": {
+          "axisTitle": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Axistitle"
+          },
+          "goalId": {
+            "format": "uuid",
+            "title": "Goalid",
+            "type": "string"
+          },
+          "goalTitle": {
+            "title": "Goaltitle",
+            "type": "string"
+          }
+        },
+        "required": [
+          "goalId",
+          "goalTitle"
+        ],
+        "title": "NextCycleProposal",
         "type": "object"
       },
       "NoTouchWindow": {
@@ -3693,6 +4307,247 @@
           "suggestedNextScreen"
         ],
         "title": "OnboardingStatus",
+        "type": "object"
+      },
+      "PolicyApplyRequest": {
+        "description": "POST /policy-snapshot/apply — 사용자가 승인(또는 수정)한 4 영역.\n\n`preview-update` 응답을 그대로 되보내면 룰 그대로 적용이고, 값을 고쳐 보내면 사용자\n수정본이 적용된다 — `source` 로 어느 쪽인지 FE 가 알려준다(`/recovery/decisions` 의\naccepted/edited 와 같은 관례: 사용자가 고쳤는지는 화면이 가장 잘 안다).",
+        "properties": {
+          "behavioralProfile": {
+            "additionalProperties": true,
+            "title": "Behavioralprofile",
+            "type": "object"
+          },
+          "executionConstraints": {
+            "additionalProperties": true,
+            "title": "Executionconstraints",
+            "type": "object"
+          },
+          "interactionStyle": {
+            "additionalProperties": true,
+            "title": "Interactionstyle",
+            "type": "object"
+          },
+          "reasonForUpdate": {
+            "anyOf": [
+              {
+                "maxLength": 200,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reasonforupdate"
+          },
+          "recoveryPolicy": {
+            "additionalProperties": true,
+            "title": "Recoverypolicy",
+            "type": "object"
+          },
+          "source": {
+            "default": "rule",
+            "enum": [
+              "rule",
+              "user_manual"
+            ],
+            "title": "Source",
+            "type": "string"
+          }
+        },
+        "required": [
+          "behavioralProfile",
+          "executionConstraints",
+          "interactionStyle",
+          "recoveryPolicy"
+        ],
+        "title": "PolicyApplyRequest",
+        "type": "object"
+      },
+      "PolicyChangeItem": {
+        "description": "승인 화면에 보여줄 변경 한 줄 — **근거를 숫자로** 담는다.",
+        "properties": {
+          "after": {
+            "title": "After"
+          },
+          "area": {
+            "title": "Area",
+            "type": "string"
+          },
+          "before": {
+            "title": "Before"
+          },
+          "field": {
+            "title": "Field",
+            "type": "string"
+          },
+          "why": {
+            "title": "Why",
+            "type": "string"
+          }
+        },
+        "required": [
+          "area",
+          "field",
+          "before",
+          "after",
+          "why"
+        ],
+        "title": "PolicyChangeItem",
+        "type": "object"
+      },
+      "PolicyHistoryItem": {
+        "description": "GET /policy-snapshot/history 항목 — 4 영역 payload 는 빼고 메타만.\n\n이력 화면은 \"언제 무엇 때문에 바뀌었나\" 를 보는 자리라, 버전마다 JSONB 4개를 전부\n실어 보내면 응답만 커지고 화면은 안 쓴다. 특정 버전의 내용이 필요하면 롤백 미리보기\n(`preview-update` 는 다음 버전용이므로) 대신 `history` 로 고르고 `rollback` 한다.",
+        "properties": {
+          "isActive": {
+            "title": "Isactive",
+            "type": "boolean"
+          },
+          "reasonForUpdate": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reasonforupdate"
+          },
+          "source": {
+            "title": "Source",
+            "type": "string"
+          },
+          "validFrom": {
+            "format": "date-time",
+            "title": "Validfrom",
+            "type": "string"
+          },
+          "validTo": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Validto"
+          },
+          "version": {
+            "title": "Version",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "version",
+          "source",
+          "isActive",
+          "reasonForUpdate",
+          "validFrom",
+          "validTo"
+        ],
+        "title": "PolicyHistoryItem",
+        "type": "object"
+      },
+      "PolicyHistoryResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/PolicyHistoryItem"
+            },
+            "title": "Items",
+            "type": "array"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "PolicyHistoryResponse",
+        "type": "object"
+      },
+      "PolicyPreviewResponse": {
+        "description": "POST /policy-snapshot/preview-update — 다음 버전 후보 (Draft Layer).\n\n**아무것도 저장하지 않는다** (AGENTS §1 자동 적용 금지). `isDraft=true` 로 내려가고,\n사용자가 `POST /policy-snapshot/apply` 를 눌러야 INSERT 된다.\n\n`changes` 가 비면 이번 주엔 바꿀 게 없다는 뜻이다 — FE 는 그때 [적용] 을 비활성화하면\n된다(억지로 새 버전을 만들 이유가 없다).",
+        "properties": {
+          "aiSource": {
+            "default": "llm",
+            "enum": [
+              "llm",
+              "rule"
+            ],
+            "title": "Aisource",
+            "type": "string"
+          },
+          "baseVersion": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Baseversion"
+          },
+          "behavioralProfile": {
+            "additionalProperties": true,
+            "title": "Behavioralprofile",
+            "type": "object"
+          },
+          "changes": {
+            "items": {
+              "$ref": "#/components/schemas/PolicyChangeItem"
+            },
+            "title": "Changes",
+            "type": "array"
+          },
+          "executionConstraints": {
+            "additionalProperties": true,
+            "title": "Executionconstraints",
+            "type": "object"
+          },
+          "interactionStyle": {
+            "additionalProperties": true,
+            "title": "Interactionstyle",
+            "type": "object"
+          },
+          "isDraft": {
+            "default": true,
+            "title": "Isdraft",
+            "type": "boolean"
+          },
+          "nextVersion": {
+            "title": "Nextversion",
+            "type": "integer"
+          },
+          "reasonForUpdate": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reasonforupdate"
+          },
+          "recoveryPolicy": {
+            "additionalProperties": true,
+            "title": "Recoverypolicy",
+            "type": "object"
+          }
+        },
+        "required": [
+          "baseVersion",
+          "nextVersion",
+          "changes",
+          "reasonForUpdate",
+          "behavioralProfile",
+          "executionConstraints",
+          "interactionStyle",
+          "recoveryPolicy"
+        ],
+        "title": "PolicyPreviewResponse",
         "type": "object"
       },
       "PolicySnapshotResponse": {
@@ -4139,6 +4994,17 @@
       "RecoveryCard": {
         "description": "회복 옵션 카드 1장 — recovery_attempts 1행과 대응 (user_decision='pending').",
         "properties": {
+          "acknowledgment": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Acknowledgment"
+          },
           "allowRestMode": {
             "title": "Allowrestmode",
             "type": "boolean"
@@ -4147,6 +5013,17 @@
             "title": "Attemptid",
             "type": "string"
           },
+          "copingClause": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Copingclause"
+          },
           "labelKo": {
             "title": "Labelko",
             "type": "string"
@@ -4154,6 +5031,17 @@
           "minRecoveryUnitMinutes": {
             "title": "Minrecoveryunitminutes",
             "type": "integer"
+          },
+          "obstacle": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Obstacle"
           },
           "optionGroup": {
             "enum": [
@@ -4199,7 +5087,7 @@
         "type": "object"
       },
       "RecoveryDecisionRequest": {
-        "description": "POST /recovery/decisions 요청 (Idempotency-Key 필수, §1.7).\n\n- `decision=\"accepted\"` → `accepted_attempt_id` 필수, 나머지 pending 카드는 rejected.\n- `decision=\"edited\"` → `accepted_attempt_id` + `edited_action_text` 필수. 부수효과는\n  accepted 와 같고(형제 rejected, 새 카드 생성) **새 카드 title 만 사용자 문구**가 된다.\n  AI 원문(`suggested_action_text`)은 보존한다 — \"얼마나 고쳐 썼나\"가 AI 품질 지표다.\n  새 카드를 만들지 않는 그룹(RESCHEDULE/PARK)은 문구를 담을 곳이 없어 422.\n- `decision=\"skipped\"` → 모든 pending 카드 skipped (\"오늘은 쉬기\").",
+        "description": "POST /recovery/decisions 요청 (Idempotency-Key 필수, §1.7).\n\n- `decision=\"accepted\"` → `accepted_attempt_id` 필수, 나머지 pending 카드는 rejected.\n- `decision=\"edited\"` → `accepted_attempt_id` + `edited_action_text` 필수. 부수효과는\n  accepted 와 같고(형제 rejected, 새 카드 생성) **새 카드 title 만 사용자 문구**가 된다.\n  AI 원문(`suggested_action_text`)은 보존한다 — \"얼마나 고쳐 썼나\"가 AI 품질 지표다.\n  새 카드를 만들지 않는 그룹(RESCHEDULE/PARK)은 문구를 담을 곳이 없어 422.\n- `decision=\"skipped\"` → 모든 pending 카드 skipped (\"오늘은 쉬기\").\n\n`re_engagement_anchor_at`(#327, FE #221): PARK/CARRY_OVER 수락에만 유효(그 외 그룹에\n보내면 422 — 조용히 버리면 사용자가 지정한 시점이 사라진 걸 못 알아챈다). 생략하면\n서버가 전략별 기본값(`orchestrator.recovery.re_engagement_anchor_at`)을 계산한다.\n시간대 정보(예: `+09:00`)를 포함한 ISO 8601 이어야 한다.",
         "properties": {
           "acceptedAttemptId": {
             "anyOf": [
@@ -4248,6 +5136,18 @@
           "executionId": {
             "title": "Executionid",
             "type": "string"
+          },
+          "reEngagementAnchorAt": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reengagementanchorat"
           }
         },
         "required": [
@@ -4279,6 +5179,18 @@
             "default": false,
             "title": "Isdraft",
             "type": "boolean"
+          },
+          "reEngagementAnchorAt": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reengagementanchorat"
           },
           "rejectedAttemptIds": {
             "items": {
@@ -4357,6 +5269,15 @@
             "default": true,
             "title": "Isdraft",
             "type": "boolean"
+          },
+          "recoveryMode": {
+            "default": "standard",
+            "enum": [
+              "standard",
+              "goal_renegotiation"
+            ],
+            "title": "Recoverymode",
+            "type": "string"
           }
         },
         "required": [
@@ -4367,7 +5288,7 @@
         "type": "object"
       },
       "ReflectionBatchItem": {
-        "description": "POST /reflection/batch 항목 — 미체크 실행 1건의 최종 결과 + 선택적 실패 사유.\n\n`failure_tags`/`memo` 는 `completion_status` 가 failed/partial_done 일 때만 유효\n(그 외 값과 함께 오면 422). `memo` 는 서버가 at-rest 암호화한다.",
+        "description": "POST /reflection/batch 항목 — 미체크 실행 1건의 최종 결과 + 선택적 실패 사유.\n\n`failure_tags`/`memo`/`task_aversiveness`(#299) 는 `completion_status` 가\nfailed/partial_done 일 때만 유효(그 외 값과 함께 오면 422). `memo` 는 서버가 at-rest\n암호화한다. `task_aversiveness` 는 태그 선택 여부와 무관하게 독립적으로 유효하다.",
         "properties": {
           "completionStatus": {
             "enum": [
@@ -4402,6 +5323,19 @@
               }
             ],
             "title": "Memo"
+          },
+          "taskAversiveness": {
+            "anyOf": [
+              {
+                "maximum": 5.0,
+                "minimum": 1.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Taskaversiveness"
           }
         },
         "required": [
@@ -4508,17 +5442,21 @@
         "type": "object"
       },
       "RefreshRequest": {
-        "description": "POST /auth/refresh 요청.",
+        "description": "POST /auth/refresh 요청.\n\n`refreshToken` 생략 가능(#323) — 웹은 `reaction_refresh` httpOnly 쿠키로 대신 보낼 수\n있다(로그인 시 서버가 body 와 쿠키에 **둘 다** 내려준다, 이행 기간). 본문·쿠키 둘 다\n없으면 401 `AUTH_INVALID_TOKEN`.",
         "properties": {
           "refreshToken": {
-            "minLength": 1,
-            "title": "Refreshtoken",
-            "type": "string"
+            "anyOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Refreshtoken"
           }
         },
-        "required": [
-          "refreshToken"
-        ],
         "title": "RefreshRequest",
         "type": "object"
       },
@@ -4934,6 +5872,26 @@
         "title": "SlotCatalogEntry",
         "type": "object"
       },
+      "StaleAxisProposal": {
+        "description": "3주 연속 손 못 댄 축 — \"줄이거나 바꾸자\" 제안 1건 (ADR-0008 §6, §8 \"H\").\n\n수정 수단은 이미 있는 것을 그대로 쓴다 — 이 카드는 새 엔드포인트를 만들지 않는다.\n칸/축 텍스트는 `PATCH /goals/mandala/nodes/{id}`, 축 8칸 재생성은\n`POST /plans/mandala/{planId}/regenerate-branch`.",
+        "properties": {
+          "axisId": {
+            "format": "uuid",
+            "title": "Axisid",
+            "type": "string"
+          },
+          "axisTitle": {
+            "title": "Axistitle",
+            "type": "string"
+          }
+        },
+        "required": [
+          "axisId",
+          "axisTitle"
+        ],
+        "title": "StaleAxisProposal",
+        "type": "object"
+      },
       "StartSessionRequest": {
         "description": "POST /interview/sessions 요청 — kind 생략 시 계획 인터뷰(하위호환, U0b).",
         "properties": {
@@ -5153,6 +6111,35 @@
           "toneMode"
         ],
         "title": "ToneModeUpdateRequest",
+        "type": "object"
+      },
+      "TopFailureContext": {
+        "description": "실패 사유 상위 3개(BCT 2.3 Self-monitoring, 근거 A5) — #301.\n\n`labelKo` 는 `/reflection/failure-tags` 와 같은 마스터(`failure_reason_tags`)에서 온다\n(이중 관리 방지). `share` 는 0~1 비율이고, LIMIT 이전(태그 전체)을 분모로 하므로 반환된\n3건의 share 합이 1.0 이 아닐 수 있다(태그가 4개 이상인 주).",
+        "properties": {
+          "count": {
+            "title": "Count",
+            "type": "integer"
+          },
+          "labelKo": {
+            "title": "Labelko",
+            "type": "string"
+          },
+          "share": {
+            "title": "Share",
+            "type": "number"
+          },
+          "tagCode": {
+            "title": "Tagcode",
+            "type": "string"
+          }
+        },
+        "required": [
+          "tagCode",
+          "labelKo",
+          "count",
+          "share"
+        ],
+        "title": "TopFailureContext",
         "type": "object"
       },
       "UltimateGoalOutcome": {
@@ -5653,10 +6640,37 @@
             ],
             "title": "Drainwindow"
           },
+          "effort": {
+            "$ref": "#/components/schemas/EffortMinutes"
+          },
           "generatedAt": {
             "format": "date-time",
             "title": "Generatedat",
             "type": "string"
+          },
+          "goalCompletionProposals": {
+            "items": {
+              "$ref": "#/components/schemas/GoalCompletionProposal"
+            },
+            "title": "Goalcompletionproposals",
+            "type": "array"
+          },
+          "mandala": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/MandalaWeeklySummary"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "nextCycleProposals": {
+            "items": {
+              "$ref": "#/components/schemas/NextCycleProposal"
+            },
+            "title": "Nextcycleproposals",
+            "type": "array"
           },
           "oneLiner": {
             "anyOf": [
@@ -5721,6 +6735,20 @@
             ],
             "title": "Restartsuccessrate"
           },
+          "staleAxisProposals": {
+            "items": {
+              "$ref": "#/components/schemas/StaleAxisProposal"
+            },
+            "title": "Staleaxisproposals",
+            "type": "array"
+          },
+          "topFailureContexts": {
+            "items": {
+              "$ref": "#/components/schemas/TopFailureContext"
+            },
+            "title": "Topfailurecontexts",
+            "type": "array"
+          },
           "weekEnd": {
             "format": "date",
             "title": "Weekend",
@@ -5751,7 +6779,7 @@
   "paths": {
     "/auth/google": {
       "post": {
-        "description": "Google id_token 검증 → user upsert → JWT 발급.",
+        "description": "Google id_token 검증 → user upsert → JWT 발급.\n\n기존 사용자(email 이미 존재)는 게이트를 전혀 거치지 않는다 — lock 도 신규 가입\n판정 이후에만 잡는다(로그인은 이미 30명 안에 있던 사람이라 경합 대상이 아니다).",
         "operationId": "login_with_google_auth_google_post",
         "requestBody": {
           "content": {
@@ -5793,8 +6821,26 @@
     },
     "/auth/logout": {
       "post": {
-        "description": "refresh 의 jti 를 revoke set 에 등록. 잘못된 토큰이어도 멱등 204.",
+        "description": "refresh 의 jti 를 revoke set 에 등록 + 쿠키 삭제. 잘못된/없는 토큰이어도 멱등 204.\n\n쿠키는 토큰 유효성과 무관하게 항상 지운다(#323) — 브라우저에 남은 쿠키를 정리하는\n게 목적이라, revoke 대상 jti 를 못 찾는 경우(토큰 없음/깨짐)에도 해야 할 일이다.",
         "operationId": "logout_auth_logout_post",
+        "parameters": [
+          {
+            "in": "cookie",
+            "name": "reaction_refresh",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Reaction Refresh"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -5878,8 +6924,26 @@
     },
     "/auth/refresh": {
       "post": {
-        "description": "refresh → 새 access. refresh 회전 X (refresh 자체 재발급 안 함).",
+        "description": "refresh → 새 access. refresh 회전 X (refresh 자체 재발급 안 함).\n\n토큰 출처는 본문 우선, 없으면 `reaction_refresh` 쿠키(#323) — 웹이 쿠키로 옮겨가도\n네이티브(본문만 보냄)와 과거 웹 클라이언트(둘 다 안 옮긴 상태)가 계속 동작해야 한다.\n둘 다 없으면 애초에 세션이 없는 것이므로 401.\n\n사용자 존재 확인(#321) — 이전에는 jti revoke 여부만 보고 `decoded.user_id` 로 바로\naccess 를 재발급했다. 계정 삭제(`POST /settings/delete-account`)는 개별 jti 를\n모르므로(다중 기기 발급분을 전부 추적하지 않는다) revoke set 에 등록할 수 없다 —\n대신 `UserRepo.get_by_id` 의 `archived_at IS NULL` 필터로 막는다. `get_current_user`\n가 이미 같은 필터로 access token 을 막고 있으니, 여기도 같은 기준을 적용해야\n\"삭제된 계정은 refresh 로도 못 살아난다\"가 성립한다.",
         "operationId": "refresh_access_token_auth_refresh_post",
+        "parameters": [
+          {
+            "in": "cookie",
+            "name": "reaction_refresh",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Reaction Refresh"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -6600,6 +7664,125 @@
         ]
       }
     },
+    "/goals/mandala/nodes/{node_id}/habit": {
+      "delete": {
+        "description": "반복형 → 프로젝트형으로 되돌리기(ADR-0008 §1) — 링크된 습관을 soft delete.\n\n칸(goal_node) 자체는 그대로 남는다. 링크가 없으면(이미 프로젝트형) 그냥 204 —\n\"이미 그 상태\"를 에러로 보지 않는다.",
+        "operationId": "unlink_mandala_habit_goals_mandala_nodes__node_id__habit_delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "node_id",
+            "required": true,
+            "schema": {
+              "title": "Node Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Unlink Mandala Habit",
+        "tags": [
+          "goals"
+        ]
+      },
+      "post": {
+        "description": "셀(leaf) → 반복형 전환(U12, ADR-0008 §1). 새 `Habit` 을 만들어 이 칸에 링크한다.\n\n\"코딩테스트 1일 1문제\"·\"쓰레기 줍기\" 처럼 끝이 없는 칸은 계획(action_item)으로 내려보내지\n않고 이 링크로 주간 횟수(habit_instances.done_count)만 추적한다.\n\n**칸(leaf, depth=2)만 대상이다** — 축·중앙은 8칸을 아우르는 단위라 반복 횟수 개념이 안\n맞는다(depth≠2 면 422, `promote` 의 depth≠1 가드와 같은 자리). 이미 이 칸에 링크된 활성\n습관이 있으면 새로 만들지 않고 그 습관을 그대로 반환한다(멱등 — `promote` 와 같은 이유,\n두 번 눌러도 중복 습관이 쌓이면 안 된다).",
+        "operationId": "link_mandala_habit_goals_mandala_nodes__node_id__habit_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "node_id",
+            "required": true,
+            "schema": {
+              "title": "Node Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MandalaHabitLinkRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Habit"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Link Mandala Habit",
+        "tags": [
+          "goals"
+        ]
+      }
+    },
     "/goals/mandala/nodes/{node_id}/promote": {
       "post": {
         "description": "하위목표(축, depth=1) → 이번 학기 `Goal(status=\"proposed\")` 승격(U10).\n\n**중앙(core)·셀(leaf)은 승격 대상이 아니다** — 만다라트의 \"축\" 단위만 학기 목표가 된다.\n이미 승격된 축을 다시 누르면(그 Goal 이 아직 살아있으면) **새로 만들지 않고 그 행을\n그대로 반환**(멱등) — U1 이 \"사용자당 1개\" 를 지키는 것과 같은 이유로, 같은 축을 두\n번 승격해 중복 목표가 쌓이면 안 된다.",
@@ -6781,7 +7964,7 @@
         ]
       },
       "patch": {
-        "description": "목표 부분 수정. tier 변경 시 한도 재검사.",
+        "description": "목표 부분 수정. tier 변경 시 한도 재검사, category 변경 시 값 검증(#326).",
         "operationId": "update_goal_goals__goal_id__patch",
         "parameters": [
           {
@@ -6843,6 +8026,75 @@
           }
         },
         "summary": "Update Goal",
+        "tags": [
+          "goals"
+        ]
+      }
+    },
+    "/goals/{goal_id}/complete": {
+      "post": {
+        "description": "목표 완료 확정 — \"이 목표 끝난 거 맞아요?\" 에 대한 사용자 확인 (ADR-0007 6b).\n\n마일스톤이 다 끝나면 주간 리뷰가 `goalCompletionProposals` 로 제안하지만, **여기에\n가드를 걸지 않는다.** 마일스톤 완료 표시와 같은 이유다 — 다른 경로로 달성했거나 방향이\n바뀌어 여기서 접는 경우가 있고, 그 판단은 AI 가 아니라 사용자 몫이다(§3).\n\n완료는 **보관(soft delete)이 아니다.** `archived_at` 을 건드리지 않아 목록에 남고,\nFE 가 `status` 로 배지를 단다. 끝낸 것과 치운 것은 다른 뜻이다.\n\n완료가 실제로 뜻하는 바 두 가지가 함께 성립한다:\n- **tier 한도(Focus≤3)를 더 안 먹는다** — 성실히 완주할수록 새 목표를 못 만들면 곤란하다.\n- **새 계획 후보에서 빠진다** — 안 그러면 \"완료\" 배지를 단 채 다음 주기 카드가 쏟아진다.\n\n멱등 — 같은 값을 다시 보내도 200. `completed=false` 로 되돌릴 수 있다(오조작 복구).\n\n⚠️ **진행 중(`active`)인 목표만 완료할 수 있다.** `proposed` 를 완료로 보내면 해제할 때\n`active` 로 나와 계획 승인 없이 승격되고, 잠정 목표 만료 cron 대상에서도 빠진다.\n\n⚠️ **되돌리기는 tier 한도를 다시 검사한다.** 완료하면 한도 집계에서 빠지므로, 안 재면\n\"완료 → 새 목표 생성 → 완료 해제\" 로 Focus≤3 을 넘길 수 있다(AGENTS §1 잠금 결정).\n한도가 찼으면 422 `GOAL_TIER_LIMIT_EXCEEDED` — 먼저 다른 목표를 정리해야 한다.\n\n완료하면 **그 목표의 남은 예정 카드와 블록이 정리된다**(soft) — 안 그러면 끝냈다고\n확인한 목표가 다음 날 아침 브리프에 그대로 뜬다. 시작·완료·실패한 카드와 사용자가\n시간을 옮긴 카드는 보존된다. ⚠️ **만다라 유래 카드와 회복 카드는 안 걸린다**(위 참고).\n⚠️ **되돌려도 카드는 안 돌아온다** — 다시 하려면 되돌리기 → generate → approve 를\n거쳐야 하고, 그 되돌리기가 tier 한도에 걸릴 수 있다(soft 정리라 데이터는 남는다).",
+        "operationId": "complete_goal_goals__goal_id__complete_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "goal_id",
+            "required": true,
+            "schema": {
+              "title": "Goal Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GoalCompletionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Goal"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Complete Goal",
         "tags": [
           "goals"
         ]
@@ -6961,6 +8213,84 @@
           }
         },
         "summary": "List Goal Nodes",
+        "tags": [
+          "goals"
+        ]
+      }
+    },
+    "/goals/{goal_id}/nodes/{node_id}": {
+      "patch": {
+        "description": "마일스톤 완료 표시 — ADR-0007 §3 이 정한 **유일한 저장 예외**.\n\n진척도는 저장하지 않고 `action_items.status` 에서 파생한다(§3). 마일스톤 완료만\n예외인 이유는 롤업으로 표현할 수 없는 두 상태가 있어서다: \"세션은 다 했는데 아직\n아니다\" 와 \"세션은 안 했지만 다른 경로로 달성했다\". **그 판단은 AI 가 아니라 사용자\n몫**이라 자동 판정하지 않고 이 endpoint 로만 찍는다.\n\n`nodeType=\"milestone\"` 인 계획 트리 노드만 받는다(저장소에서 좁힌다). subgoal/leaf 는\n404 — leaf 에 완료를 찍게 하면 `action_items.status` 와 진실이 갈린다. 만다라 칸도\n404, 그쪽은 `PATCH /goals/mandala/nodes/{nodeId}` 다.\n\n`completed=false` 로 되돌릴 수 있다(오조작 복구). 멱등 — 같은 값을 다시 보내도 200.",
+        "operationId": "update_milestone_completion_goals__goal_id__nodes__node_id__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "goal_id",
+            "required": true,
+            "schema": {
+              "title": "Goal Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "node_id",
+            "required": true,
+            "schema": {
+              "title": "Node Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MilestoneCompletionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GoalNode"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update Milestone Completion",
         "tags": [
           "goals"
         ]
@@ -8600,6 +9930,58 @@
         ]
       }
     },
+    "/notifications/{notification_id}/opened": {
+      "post": {
+        "description": "이 알림을 열었다고 표시 (멱등 — 최초 1회만 `openedAt` 을 채운다).\n\n`notificationId` 는 push payload 의 `id` 필드를 그대로 넘긴다 — 서버가 발송 **전에**\n미리 만들어 실어 보낸 값이라(`notify_sweeps.py`), 이 발송 이력 행의 PK 와 항상 같다.\n\n⚠️ **이 endpoint 를 호출하는 FE 콜백(push `notificationclick` 핸들러)은 아직 없다.**\n인프라만 미리 준비해 둔 것 — 배선되기 전까지는 아무도 이 경로를 타지 않는다.",
+        "operationId": "mark_notification_opened_notifications__notification_id__opened_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "notification_id",
+            "required": true,
+            "schema": {
+              "title": "Notification Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Mark Notification Opened",
+        "tags": [
+          "notifications"
+        ]
+      }
+    },
     "/onboarding/status": {
       "get": {
         "description": "현재 사용자의 onboarding 상태 + 다음 가야 할 화면 hint.",
@@ -9027,9 +10409,189 @@
         ]
       }
     },
+    "/plans/materials/confirm": {
+      "post": {
+        "description": "\"이 자료 맞아요\" — 확정본을 `goals.materials` 슬롯에 쓴다 (② HITL 결정).\n\n여기서부터는 **붙여넣기와 구분되지 않는다.** 다음 계획 생성이 기존 경로로 이 값을\n집어가고, 자료 텍스트는 `materials_for_prompt` 의 울타리 안에 들어간다(#260).\n\n사용자가 고친 텍스트를 그대로 받는다 — 검색이 다른 판을 가져왔거나 일부만 맞을 때\n지우고 붙일 수 있어야 HITL 이다.",
+        "operationId": "confirm_materials_plans_materials_confirm_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MaterialsConfirmRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MaterialsConfirmResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Confirm Materials",
+        "tags": [
+          "planning"
+        ]
+      }
+    },
+    "/plans/materials/search": {
+      "post": {
+        "description": "사용자가 확정한 검색어로 자료를 찾는다. 결과는 **Draft — 저장하지 않는다.**\n\n동시 요청을 락으로 직렬화하는 이유는 성능이 아니라 **예산**이다. 그라운딩은 건당\n과금인데, 두 요청이 나란히 들어오면 둘 다 잔량 검사를 통과한 뒤 둘 다 호출해\n상한을 넘길 수 있다(TOCTOU). 락 안에서 검사→호출→기록이 한 트랜잭션으로 끝난다.",
+        "operationId": "search_materials_plans_materials_search_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MaterialsSearchRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MaterialsSearchResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Search Materials",
+        "tags": [
+          "planning"
+        ]
+      }
+    },
+    "/plans/materials/search-query": {
+      "post": {
+        "description": "검색어를 제안한다. **아직 아무것도 검색하지 않는다.**\n\n외부 호출이 0회라 과금도 예산 차감도 없다 — 사용자가 몇 번을 다시 열어봐도 무료다.",
+        "operationId": "propose_search_query_plans_materials_search_query_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MaterialsQueryRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MaterialsQueryResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Propose Search Query",
+        "tags": [
+          "planning"
+        ]
+      }
+    },
     "/plans/milestones": {
       "post": {
-        "description": "Stage A(#milestones) — 목표를 중간 목표 3~5개로. 사용자가 확인·편집 후 generate 로 넘긴다.\n\n입력은 generate 와 동일(interviewSessionId/outcome + density). LLM 1콜 + 룰 폴백이라 가볍다.",
+        "description": "Stage A(#milestones) — 목표를 중간 목표 3~5개로. 사용자가 확인·편집 후 generate 로 넘긴다.\n\n입력은 generate 와 동일(interviewSessionId/outcome + density). LLM 1콜 + 룰 폴백이라 가볍다.\n\n**이미 확정·영속된 뼈대가 있으면 LLM 을 돌리지 않고 그걸 그대로 돌려준다**\n(`aiSource=\"saved\"`, ADR-0007 PR-2.5). 마일스톤은 매 주기 교체되는 leaf 트리와 달리\n마감까지 살아남는 층이라(§1), 2주기에 새로 지어내면 사용자가 1주기에 확정한 뼈대와\n다른 목록이 나오고 — 그 새 목록으로 계획이 만들어지는데 승인 경로는 이미 마일스톤이\n있다는 이유로 저장을 건너뛰므로 — DB 의 뼈대와 실제 계획이 갈라진 채 굳는다.\n부수 효과로 2주기 이후 이 endpoint 의 LLM 콜이 0 이 된다.",
         "operationId": "generate_milestones_plans_milestones_post",
         "parameters": [
           {
@@ -9510,6 +11072,66 @@
         ]
       }
     },
+    "/policy-snapshot/apply": {
+      "post": {
+        "description": "사용자 승인 후 새 버전 INSERT — HITL 게이트가 여기다.\n\n본문은 `preview-update` 응답을 그대로(=룰 그대로) 또는 사용자가 고친 값이다. 서버가\n후보를 다시 계산해 덮어쓰지 않는다 — 그러면 사용자가 화면에서 본 값과 저장된 값이\n달라질 수 있다(미리보기와 적용 사이에 KPI 가 갱신되면). **본 것이 저장된다.**",
+        "operationId": "apply_policy_update_policy_snapshot_apply_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PolicyApplyRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PolicySnapshotResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Apply Policy Update",
+        "tags": [
+          "policy"
+        ]
+      }
+    },
     "/policy-snapshot/current": {
       "get": {
         "description": "현재 활성 PolicySnapshot (#83) — 없으면 404 (FE 는 카운트-only 폴백 유지).",
@@ -9555,6 +11177,165 @@
           }
         },
         "summary": "Get Current Policy",
+        "tags": [
+          "policy"
+        ]
+      }
+    },
+    "/policy-snapshot/history": {
+      "get": {
+        "description": "버전 이력 — 최신이 앞. 비어 있으면 `items: []` (404 아님).\n\n`current` 와 달리 404 를 내지 않는다: \"아직 정책이 없다\" 는 이력 화면에서 **정상 상태**\n이고, 빈 목록으로 표현하는 게 클라이언트에 더 쉽다.",
+        "operationId": "get_policy_history_policy_snapshot_history_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PolicyHistoryResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Policy History",
+        "tags": [
+          "policy"
+        ]
+      }
+    },
+    "/policy-snapshot/preview-update": {
+      "post": {
+        "description": "다음 버전 후보 — **저장하지 않는다** (AGENTS §1 자동 적용 금지).\n\n입력은 가장 최근 주간 요약(`period_summaries`). 아직 한 주도 집계 안 됐으면 KPI 없이\n현재 값을 그대로 후보로 돌려준다(`changes: []`) — 그 자체가 \"바꿀 근거가 아직 없다\"다.",
+        "operationId": "preview_policy_update_policy_snapshot_preview_update_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PolicyPreviewResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Preview Policy Update",
+        "tags": [
+          "policy"
+        ]
+      }
+    },
+    "/policy-snapshot/rollback/{version}": {
+      "post": {
+        "description": "지난 버전의 값을 **새 버전으로** 되살린다.\n\n옛 행의 `is_active` 를 다시 켜지 않는 이유: 그러면 그 행의 `valid_from` 이 최초 활성화\n시각 그대로라 **언제 롤백했는지가 이력에서 사라진다.** 정책 이력은 감사 기록이므로\n(ADR-0001 §3.2 append-only) 값을 복사한 새 행을 만들어 타임라인을 온전히 남긴다.\n버전 번호는 계속 늘어난다 — v5 에서 v2 로 롤백하면 v2 의 값을 가진 v6 이 생긴다.\n\n없는 버전은 404, 이미 활성인 버전은 409(같은 값을 한 번 더 쌓을 이유가 없다).",
+        "operationId": "rollback_policy_policy_snapshot_rollback__version__post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "version",
+            "required": true,
+            "schema": {
+              "title": "Version",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PolicySnapshotResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Rollback Policy",
         "tags": [
           "policy"
         ]
@@ -10488,6 +12269,66 @@
         ]
       }
     },
+    "/settings/delete-account": {
+      "post": {
+        "description": "계정 삭제 — 2단계 확인 (#321, FE #237 §4, Play Store 정책 요구).\n\n`anonymize`(S28, 계정은 유지한 채 과거 텍스트만 마스킹)와는 다른 작업이다 — 이건 앱에\n다시 들어올 수 없게 만드는 것까지 포함한다. hard delete 는 하지 않는다(AGENTS §2) —\n같은 `anonymize_user()` PII 마스킹 위에 `archived_at` 을 얹어 **soft delete** 한다.\n\n`archived_at` 을 세우는 순간 `UserRepo.get_by_id`/`get_by_email` 의 `archived_at IS NULL`\n필터에 걸려, 이미 발급된 access token 은 다음 요청의 `get_current_user` 에서 그대로\n401 `AUTH_INVALID_TOKEN` 이 된다 — 별도 access-token 블랙리스트가 필요 없다. refresh\ntoken 은 `/auth/refresh` 가 이제 같은 필터로 사용자 존재를 확인하므로(이 PR 에서 함께\n고침) 동일하게 막힌다.\n\nemail 도 함께 마스킹한다 — `email` 에 hard UNIQUE 제약이 있어(파샬 인덱스 아님) 원본을\n남기면 그 이메일로 재가입이 영영 불가능해진다. `user.id` 는 유일하므로 유니크 제약을\n깨지 않는 결정적 sentinel 로 치환.",
+        "operationId": "delete_account_settings_delete_account_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeleteAccountRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteAccountResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete Account",
+        "tags": [
+          "settings"
+        ]
+      }
+    },
     "/settings/profile": {
       "get": {
         "description": "지속형 프로필 메모리 — 에너지/시간(behavioral) + 톤/빈도(interaction) + 회복 선호.\n\n인터뷰가 아직 안 채웠으면 해당 항목 null (행/키를 생성하지 않는다).",
@@ -11054,7 +12895,7 @@
     },
     "/today/actions/{action_id}/start": {
       "post": {
-        "description": "[▶ 시작] → execution_events 생성 (#19-B).\n\n카드의 미종결 scheduled_block 이 있으면 사용, 없으면 즉석 블록 생성\n(source='user_edit'). 같은 카드의 in_progress 실행이 있으면 409.",
+        "description": "[▶ 시작] → execution_events 생성 (#19-B).\n\n카드의 미종결 scheduled_block 이 있으면 사용, 없으면 즉석 블록 생성\n(source='user_edit'). 같은 카드의 in_progress 실행이 있으면 409.\n\n카드는 **행 잠금으로 읽는다**(#368). 계획 교체·목표 완료가 같은 카드를 보관하는\n중이면 여기서 기다렸다가 `archived_at IS NULL` 재평가에 걸려 404 로 끝난다 —\nexecution_events·scheduled_block 을 만들기 **전에** 걸러야 한다. 상태만 조건부로\n막으면 실행 행이 남고, `list_pending_reflection` 은 `action_items` 에 join 하지\n않으므로 그 실행이 회고 화면까지 새어 나간다.",
         "operationId": "start_action_today_actions__action_id__start_post",
         "parameters": [
           {

--- a/openapi.json
+++ b/openapi.json
@@ -1845,8 +1845,19 @@
         "type": "object"
       },
       "GoalUpdateRequest": {
-        "description": "PATCH /goals/{id} 요청 — 제목·마감·우선순위·tier 변경.",
+        "description": "PATCH /goals/{id} 요청 — 제목·마감·우선순위·tier·category 변경.",
         "properties": {
+          "category": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Category"
+          },
           "deadline": {
             "anyOf": [
               {

--- a/public/sw.js
+++ b/public/sw.js
@@ -26,25 +26,47 @@ self.addEventListener('push', (event) => {
     body,
     icon: '/icon.svg',
     badge: '/icon.svg',
-    data: data.url || '/',
+    // 클릭 시 앱이 인증된 컨텍스트에서 opened API 를 호출할 수 있도록 id 를 보존한다.
+    // SW 에서 localStorage 토큰을 읽을 수 없으므로 여기서는 서버 호출을 하지 않는다.
+    data: {
+      id: typeof data.id === 'string' ? data.id : null,
+      url: typeof data.url === 'string' ? data.url : '/',
+    },
   };
   event.waitUntil(self.registration.showNotification(title, options));
 });
 
 self.addEventListener('notificationclick', (event) => {
   event.notification.close();
-  const url = (event.notification.data && typeof event.notification.data === 'string')
-    ? event.notification.data
-    : '/';
+  const data = event.notification.data;
+  // 이전 SW 가 만든 알림(data=string)도 계속 열 수 있게 하위호환한다.
+  const rawUrl = typeof data === 'string' ? data : data && data.url;
+  const notificationId = typeof data === 'object' && data && typeof data.id === 'string'
+    ? data.id
+    : null;
+  const url = notificationOpenUrl(rawUrl, notificationId);
   event.waitUntil(
-    self.clients.matchAll({ type: 'window' }).then((cs) => {
+    self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then((cs) => {
       for (const c of cs) {
-        if ('focus' in c) return c.focus();
+        if ('navigate' in c) return c.navigate(url).then((client) => (client || c).focus());
       }
       return self.clients.openWindow(url);
     }),
   );
 });
+
+function notificationOpenUrl(rawUrl, notificationId) {
+  let url;
+  try {
+    url = new URL(typeof rawUrl === 'string' ? rawUrl : '/', self.location.origin);
+    // push payload 로 외부 출처를 열어 피싱에 악용되는 것을 막는다.
+    if (url.origin !== self.location.origin) url = new URL('/', self.location.origin);
+  } catch {
+    url = new URL('/', self.location.origin);
+  }
+  if (notificationId) url.searchParams.set('notificationId', notificationId);
+  return url.href;
+}
 
 function safeParse(s) {
   try { return JSON.parse(s); } catch { return {}; }

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -6,6 +6,7 @@ import { NavigationContext, STATE_TO_SCREEN } from '../contexts/NavigationContex
 import { ToastProvider } from '../contexts/ToastContext';
 import { IosInstallCard } from '../components/IosInstallCard';
 import { ApiError, authApi, clearSession, friendlyError, getAccessToken, getAuthKind, getRefreshToken, initTokenStore, onAuthExpired, onboardingApi, setSession, stubLoginAllowed } from '../lib/api';
+import { markNotificationOpenedFromLaunch } from '../lib/push';
 import type { ScreenId, TabId } from '../types';
 import type { MilestoneDraft, OnboardingState, UserProfile } from '../types/api';
 
@@ -219,6 +220,12 @@ export function AppShell() {
     });
     return () => onAuthExpired(null);
   }, []);
+
+  // 알림 클릭은 SW 가 쿼리로 넘긴 id 만 보존한다. 사용자 세션이 확인된 뒤 호출해야
+  // Authorization 헤더가 붙고, 로그인 화면을 거친 경우에도 같은 id 를 놓치지 않는다.
+  useEffect(() => {
+    if (user && !needsLogin) void markNotificationOpenedFromLaunch();
+  }, [user, needsLogin]);
 
   // 부팅 — /auth/me 로 사용자 상태 확인 후 applyProfile 이 계정 onboarding_state
   // 로 진입 화면을 결정한다(#120). ACTIVE→today, 중간 상태→resume, WELCOME→intro.

--- a/src/app/ReActionMerged.tsx
+++ b/src/app/ReActionMerged.tsx
@@ -113,6 +113,8 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
   // task.id → 실 executionId. FocusScreen(시작) 또는 markFailed(실패시 auto-start)로 채워지며,
   // 회복 화면들(MergedRecoveryScreen/RecoveredScreen)이 이 값으로 실 API 를 호출한다(#80).
   const [executionIds, setExecutionIds] = useState<Record<string, string>>({});
+  const [recoveryReadyIds, setRecoveryReadyIds] = useState<Record<string, string>>({});
+  const [recoveryPreparationError, setRecoveryPreparationError] = useState<string | null>(null);
   // 이번 세션에서 수락한 복구 횟수 (백엔드 누적 집계 엔드포인트가 없어 세션 카운트로 정직하게).
   const [recoveryCount, setRecoveryCount] = useState(0);
   // 사용자가 회복 화면에서 고른 제안 — RecoveredScreen 의 before→after 카드용.
@@ -134,8 +136,10 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
 
   const markFailed = (id: string, reason: string, tagCodes?: string[], memo?: string, taskAversiveness?: number) => {
     setTasks((ts) => ts.map((t) => t.id === id ? { ...t, status: 'failed', failReason: reason } : t));
-    setActiveTask(tasks.find((t) => t.id === id) || null);
+    const failedTask = tasks.find((t) => t.id === id);
+    setActiveTask(failedTask ? { ...failedTask, status: 'failed', failReason: reason } : null);
     setFailReason(reason);
+    setRecoveryPreparationError(null);
     setScreen('recovery');
 
     // 실패 경로는 TodayScreen 실패시트 → 여기로 직행해 FocusScreen 을 거치지 않을 수
@@ -148,20 +152,23 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
           return e.executionId;
         });
 
-    // task_aversiveness(#222) — "이 일이 얼마나 하기 싫었나요?" 1~5. FailureTagRequest(openapi.json)에
-    // 아직 이 필드가 없어(백엔드 미구현) tagExecution() body 에 싣지 않는다. 백엔드가 필드를 추가하면
-    // 이 한 곳(reflectionApi.tagExecution 호출)에 `taskAversiveness` 를 넣어 연결한다. (현재 파라미터는
-    // 그때까지 미사용 — 스펙에 없는 필드를 임의로 요청 본문에 넣지 않기 위함.)
+    // failure-tags와 recovery generate는 failed/partial_done 실행만 받으므로, 체크인을
+    // 먼저 확정하고 태그 저장까지 끝난 뒤에만 회복 제안 생성을 허용한다(#269).
     ensureExecutionId
-      .then((execId) =>
-        ((tagCodes && tagCodes.length > 0)
-          ? reflectionApi.tagExecution(execId, { tagCodes, memo: memo ?? null }).catch(() => {})
-          : Promise.resolve())
-          .then(() =>
-            todayApi.checkIn({ executionId: execId, completionStatus: 'failed' }, `check-${execId}`).catch(() => {}),
-          ),
-      )
-      .catch(() => { /* start 실패(미구현/오류) — 로컬 흐름만 유지 */ });
+      .then(async (execId) => {
+        await todayApi.checkIn({ executionId: execId, completionStatus: 'failed' }, `check-${execId}`);
+        if ((tagCodes && tagCodes.length > 0) || taskAversiveness != null || memo?.trim()) {
+          await reflectionApi.tagExecution(execId, {
+            tagCodes: tagCodes ?? [],
+            memo: memo?.trim() || null,
+            taskAversiveness: taskAversiveness ?? null,
+          });
+        }
+        setRecoveryReadyIds((m) => ({ ...m, [id]: execId }));
+      })
+      .catch(() => {
+        setRecoveryPreparationError('실행 결과를 저장하지 못했어요. 오늘 화면에서 다시 시도해 주세요.');
+      });
   };
 
   // 실제 시작 트리거 — task 를 in_progress 로 전이하고 focus 화면으로.
@@ -294,7 +301,11 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
             failReason={failReason}
             onAccept={acceptRecovery}
             onDismiss={() => setScreen('today')}
-            executionId={activeTask ? executionIds[activeTask.id] : undefined}
+            executionId={activeTask
+              ? (activeTask.status === 'failed' ? recoveryReadyIds[activeTask.id] : executionIds[activeTask.id])
+              : undefined}
+            preparationError={recoveryPreparationError}
+            onOpenWeekly={() => { setWeekOffset(0); setTab('weekly'); setScreen('weekly'); }}
           />
         )}
         {screen === 'recovered' && (

--- a/src/app/ReActionMerged.tsx
+++ b/src/app/ReActionMerged.tsx
@@ -6,6 +6,7 @@ import { GoalIntakeScreen } from '../screens/GoalIntakeScreen';
 import { GoalClassificationScreen } from '../screens/GoalClassificationScreen';
 import { SetupScreen } from '../screens/SetupScreen';
 import { MilestoneConfirmScreen } from '../screens/MilestoneConfirmScreen';
+import { MaterialsSearchScreen } from '../screens/MaterialsSearchScreen';
 import { WeeklyPlanGenerationScreen } from '../screens/WeeklyPlanGenerationScreen';
 import { MorningBriefScreen } from '../screens/MorningBriefScreen';
 import { InboxScreen } from '../screens/InboxScreen';
@@ -38,6 +39,7 @@ const NAV_META: Record<ScreenId, { label: string; back: ScreenId | null }> = {
   'goal-classify':          { label: '목표 분류',      back: 'goal-intake' },
   'setup':                  { label: '마무리 확인',    back: 'goal-classify' },
   'milestone-confirm':      { label: '계획의 큰 그림', back: 'setup' },
+  'materials-search':       { label: '참고 자료 찾기',  back: 'milestone-confirm' },
   'weekly-plan':            { label: '주간 계획 생성', back: 'milestone-confirm' },
   'morning-brief':          { label: '모닝 브리프',    back: 'weekly-plan' },
   'today':                  { label: '오늘의 실행',    back: null },
@@ -262,6 +264,7 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
           <SetupScreen onDone={() => setScreen('milestone-confirm')} />
         )}
         {screen === 'milestone-confirm' && <MilestoneConfirmScreen />}
+        {screen === 'materials-search' && <MaterialsSearchScreen />}
         {screen === 'weekly-plan' && (
           <WeeklyPlanGenerationScreen onContinue={() => setScreen('morning-brief')} />
         )}

--- a/src/components/FailureTagPicker.tsx
+++ b/src/components/FailureTagPicker.tsx
@@ -41,8 +41,7 @@ interface FailureTagPickerProps {
   memo: string;
   onMemoChange: (memo: string) => void;
   memoPlaceholder?: string;
-  // task_aversiveness(#222) 1~5 문항. 값을 보낼 곳이 있는 화면에서만 켠다.
-  // 백엔드에 저장 필드가 아직 없으므로(#299), 답을 받아도 버려지는 화면에서는 묻지 않는다.
+  // task_aversiveness(#222) 1~5 문항. 서버 태그 요청에 값을 보낼 화면에서 켠다.
   aversiveness?: number | null;
   onAversivenessChange?: (v: number | null) => void;
 }

--- a/src/components/MandalaCellSheet.tsx
+++ b/src/components/MandalaCellSheet.tsx
@@ -145,7 +145,7 @@ export function MandalaCellSheet({ board, slot, mode, onClose, onUpdated, onProm
           <Badge icon={slot.source === 'user' ? <PencilSimple size={10} weight="fill" /> : <Sparkle size={10} weight="fill" />}>
             {SOURCE_LABEL[slot.source]}
           </Badge>
-          {slot.locked && <Badge icon={<LockSimple size={10} weight="fill" />}>내가 직접 말한 축 · 재생성 제외</Badge>}
+          {slot.locked && <Badge icon={<LockSimple size={10} weight="fill" />}>내가 직접 말한 축 · 다시 뽑아도 유지</Badge>}
           {slot.completedAt && <Badge tone="success" icon={<Check size={10} weight="bold" />}>{formatDone(slot.completedAt)} 완료</Badge>}
           {slot.role === 'axis' && slot.progress != null && (
             <Badge icon={<Gauge size={10} weight="fill" />}>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -745,16 +745,10 @@ export const recoveryApi = {
       body: { executionId } satisfies RecoveryGenerateRequest,
     }),
 
-  // reEngagementAnchorAt — PARK/CARRY_OVER 카드를 accepted 로 결정할 때 "다음에 다시
-  // 볼 시점"(#221). 백엔드에 `re_engagement_anchor_at` 컬럼·저장 로직이 아직 없고
-  // openapi 스펙에도 없어(0건, 확인함) 지금 보내면 4xx 를 유발한다. 그래서 인자로는
-  // 받아 두되 body 엔 아직 싣지 않는다 — 스펙에 필드가 생기면 아래 스프레드 뒤에
-  // `reEngagementAnchorAt` 한 줄만 추가해 연결한다.
   decide: (body: RecoveryDecisionRequest, idempotencyKey: string, reEngagementAnchorAt?: string | null) => {
-    void reEngagementAnchorAt; // TODO(#221): 스펙에 필드 추가되면 request body 에 연결
     return request<RecoveryDecisionResponse>('/recovery/decisions', {
       method: 'POST',
-      body,
+      body: { ...body, reEngagementAnchorAt },
       idempotencyKey,
     });
   },
@@ -788,6 +782,12 @@ export const notificationsApi = {
   // FE 가 pushManager.subscribe(applicationServerKey) 에 쓸 서버 발급 공개키.
   // publicKey=null 이면 서버 미설정 — 구독을 만들면 안 된다.
   vapidPublicKey: () => request<VapidPublicKeyResponse>('/notifications/vapid-public-key'),
+
+  // 알림 클릭 기록. 백엔드가 멱등(재호출도 204)으로 보장한다.
+  markOpened: (notificationId: string) =>
+    request<void>(`/notifications/${encodeURIComponent(notificationId)}/opened`, {
+      method: 'POST',
+    }),
 };
 
 // ── Policy Snapshot (#83) ─────────────────────────────────────

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -30,6 +30,9 @@ import type {
   FirstPlanGenerateRequest,
   FirstPlanResponse,
   MilestoneListResponse,
+  MaterialsQueryResponse,
+  MaterialsSearchResponse,
+  MaterialsConfirmResponse,
   FixedSchedule,
   FixedScheduleCreateRequest,
   FixedScheduleUpdateRequest,
@@ -632,6 +635,21 @@ export const todayApi = {
 
 // ── Plans (S06·S14·S15·S16) — generate/get/approve 는 백엔드 #18 구현됨 ──
 export const plansApi = {
+  materialsQuery: (interviewSessionId?: string | null) =>
+    request<MaterialsQueryResponse>('/plans/materials/search-query', {
+      method: 'POST', body: { interviewSessionId: interviewSessionId ?? null },
+    }),
+
+  materialsSearch: (query: string) =>
+    request<MaterialsSearchResponse>('/plans/materials/search', {
+      method: 'POST', body: { query },
+    }),
+
+  materialsConfirm: (text: string, interviewSessionId?: string | null) =>
+    request<MaterialsConfirmResponse>('/plans/materials/confirm', {
+      method: 'POST', body: { text, interviewSessionId: interviewSessionId ?? null },
+    }),
+
   // Idempotency-Key 동봉 시 같은 키 재요청은 동일 planId 를 돌려준다(재시도 안전, #6).
   generate: (body: FirstPlanGenerateRequest = {}, idempotencyKey?: string) =>
     request<FirstPlanResponse>('/plans/generate', { method: 'POST', body, idempotencyKey }),

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -27,4 +27,9 @@ export function defaultReEngagementAnchorDate(d: Date = new Date()): string {
   nextMonday.setDate(nextMonday.getDate() - ((nextMonday.getDay() + 6) % 7) + 7);
   return localDateStr(nextMonday);
 }
+export function defaultCarryOverAnchorDate(d: Date = new Date()): string {
+  const tomorrow = new Date(d);
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  return localDateStr(tomorrow);
+}
 export const DEFAULT_REENGAGEMENT_TIME = '09:00';

--- a/src/lib/goalIdentity.ts
+++ b/src/lib/goalIdentity.ts
@@ -1,0 +1,9 @@
+/**
+ * 서버 목표와 화면에서만 쓰는 임시 목표를 구분한다.
+ *
+ * API 의 goalId 는 형식이 정해지지 않은 string 이므로 `goal_` 같은 접두사를
+ * 서버 ID의 조건으로 사용하면 UUID 목표의 변경 요청이 통째로 생략된다.
+ */
+export function isPersistedGoalId(goalId: string): boolean {
+  return !goalId.startsWith('demo-') && !goalId.startsWith('cand_');
+}

--- a/src/lib/push.ts
+++ b/src/lib/push.ts
@@ -11,6 +11,11 @@ import { notificationsApi } from './api';
 const FALLBACK_VAPID_PUBLIC_KEY =
   'BNcRdreALRFXTkOOUHK1EtK2wtaz5Ry4YfYCA_0QTpQtUbVlUls0VJXg7A8u-Ts1XbjhazAkj7I99e8QcYP7DkM';
 
+const NOTIFICATION_ID_PARAM = 'notificationId';
+const PENDING_OPEN_KEY = 'reaction.pendingNotificationOpen';
+const SAFE_NOTIFICATION_ID = /^[A-Za-z0-9_-]{1,128}$/;
+let markOpenedInFlight: Promise<void> | null = null;
+
 async function resolveVapidPublicKey(): Promise<string> {
   const envKey = import.meta.env.VITE_VAPID_PUBLIC_KEY;
   if (envKey) return envKey;
@@ -82,4 +87,51 @@ export async function registerServiceWorker(): Promise<void> {
   } catch {
     /* 무시 */
   }
+}
+
+/**
+ * SW 가 딥링크로 넘긴 알림 id 를 인증 부팅이 끝난 뒤 서버에 기록한다.
+ *
+ * URL 에서 id 는 즉시 지워 주소 공유/로그에 오래 남지 않게 하고, 요청이 실패하면
+ * sessionStorage 에 보존한다. opened API 는 멱등이므로 다음 부팅에서 재호출해도 안전하다.
+ */
+export function markNotificationOpenedFromLaunch(): Promise<void> {
+  if (typeof window === 'undefined') return Promise.resolve();
+  if (markOpenedInFlight) return markOpenedInFlight;
+
+  const url = new URL(window.location.href);
+  const fromUrl = url.searchParams.get(NOTIFICATION_ID_PARAM);
+  if (fromUrl !== null) {
+    url.searchParams.delete(NOTIFICATION_ID_PARAM);
+    window.history.replaceState(window.history.state, '', `${url.pathname}${url.search}${url.hash}`);
+  }
+
+  let pending: string | null = null;
+  try {
+    pending = window.sessionStorage.getItem(PENDING_OPEN_KEY);
+  } catch {
+    /* 저장소가 차단된 브라우저에서는 이번 URL 값만 처리한다. */
+  }
+  const notificationId = fromUrl ?? pending;
+  if (!notificationId || !SAFE_NOTIFICATION_ID.test(notificationId)) {
+    if (notificationId) {
+      try { window.sessionStorage.removeItem(PENDING_OPEN_KEY); } catch { /* 무시 */ }
+    }
+    return Promise.resolve();
+  }
+
+  try { window.sessionStorage.setItem(PENDING_OPEN_KEY, notificationId); } catch { /* 무시 */ }
+  markOpenedInFlight = notificationsApi.markOpened(notificationId)
+    .then(() => {
+      try {
+        if (window.sessionStorage.getItem(PENDING_OPEN_KEY) === notificationId) {
+          window.sessionStorage.removeItem(PENDING_OPEN_KEY);
+        }
+      } catch { /* 무시 */ }
+    })
+    .catch(() => {
+      // 앱 진입을 방해하지 않는다. 저장된 id 는 다음 부팅 때 다시 보낸다.
+    })
+    .finally(() => { markOpenedInFlight = null; });
+  return markOpenedInFlight;
 }

--- a/src/screens/EveningCheckInScreen.tsx
+++ b/src/screens/EveningCheckInScreen.tsx
@@ -101,6 +101,7 @@ export function EveningCheckInScreen({ onDone }: EveningCheckInScreenProps) {
   const [tagIndex, setTagIndex] = useState(0);
   const [tagSelected, setTagSelected] = useState<FailureTagOption[]>([]);
   const [tagMemo, setTagMemo] = useState('');
+  const [tagAversiveness, setTagAversiveness] = useState<number | null>(null);
   const [tagSaving, setTagSaving] = useState(false);
   const [tagError, setTagError] = useState<string | null>(null);
   // 완료 화면 안내용 집계. tagTargets 는 batch 를 새로 보낼 때마다 갈리므로, 이번 체크인에서
@@ -154,6 +155,7 @@ export function EveningCheckInScreen({ onDone }: EveningCheckInScreenProps) {
         setTagIndex(0);
         setTagSelected([]);
         setTagMemo('');
+        setTagAversiveness(null);
         setTagError(null);
         // 종결된 실행은 더 이상 미체크가 아니다 — 목록에서 뺀다.
         const done = new Set(items.map((i) => i.executionId));
@@ -171,6 +173,7 @@ export function EveningCheckInScreen({ onDone }: EveningCheckInScreenProps) {
   const advanceTagStep = () => {
     setTagSelected([]);
     setTagMemo('');
+    setTagAversiveness(null);
     setTagError(null);
     const next = tagIndex + 1;
     if (next >= tagTargets.length) setStep('tomorrow');
@@ -200,6 +203,7 @@ export function EveningCheckInScreen({ onDone }: EveningCheckInScreenProps) {
     reflectionApi.tagExecution(target.executionId, {
       tagCodes: tagSelected.map((t) => t.code),
       memo: tagMemo.trim() || null,
+      taskAversiveness: tagAversiveness,
     }).then(
       () => {
         setTaggedCount((c) => c + 1);
@@ -283,15 +287,14 @@ export function EveningCheckInScreen({ onDone }: EveningCheckInScreenProps) {
               <span style={{ fontSize: 11, color: 'var(--text-3)', flexShrink: 0 }}>{statusLabel}</span>
             )}
           </div>
-          {/* 정서 1문항(#222)은 여기서 묻지 않는다 — POST /reflection/failure-tags 에 담을
-              필드가 아직 없어(BE #299) 답을 받아도 버려지기 때문이다. 필드가 생기면
-              onAversivenessChange 를 넘겨 주기만 하면 된다. */}
           <FailureTagPicker
             reasons={failReasons}
             selected={tagSelected}
             onChange={setTagSelected}
             memo={tagMemo}
             onMemoChange={setTagMemo}
+            aversiveness={tagAversiveness}
+            onAversivenessChange={setTagAversiveness}
           />
         </div>
 

--- a/src/screens/GoalClassificationScreen.tsx
+++ b/src/screens/GoalClassificationScreen.tsx
@@ -1,13 +1,14 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { Sparkle, Check } from '@phosphor-icons/react';
 import { GOAL_STATUS_META } from '../data';
-import { ApiError, friendlyError, goalsApi } from '../lib/api';
+import { friendlyError, goalsApi } from '../lib/api';
 import type { ApiGoal, GoalCandidate, GoalsByTier, InterviewOutcome } from '../types/api';
 import type { Goal, GoalStatus } from '../types';
 import { SetupProgress } from '../components/SetupProgress';
 import { AiDraftCard } from '../components/AiDraftCard';
 import { ErrorBanner } from '../components/ErrorBanner';
 import { SkeletonBlock } from '../components/SkeletonBlock';
+import { isPersistedGoalId } from '../lib/goalIdentity';
 
 interface GoalClassificationScreenProps {
   onNext: () => void;
@@ -31,8 +32,8 @@ function toUiGoal(api: ApiGoal): Goal {
 }
 
 // 인터뷰 outcome.coreGoals → 화면용 Goal. 아직 goals 테이블에 저장되기 전(#75)이라
-// goalId 가 없다 — synthetic id(cand_N, "goal_" 로 시작 안 함)를 부여해 changeStatus 가
-// 기존 더미 데이터와 동일하게 로컬로만 처리하도록 한다(서버 저장은 First Plan 승인 때).
+// goalId 가 없다 — synthetic id(cand_N)를 부여해 changeStatus 가 로컬로만
+// 처리하도록 한다(서버 저장은 First Plan 승인 때).
 function toUiGoalFromCandidate(c: GoalCandidate, idx: number): Goal {
   return {
     id: `cand_${idx}`,
@@ -104,23 +105,20 @@ export function GoalClassificationScreen({ onNext, outcome }: GoalClassification
   );
 
   // 재분류 영속화: parked 는 전용 park 엔드포인트(tier 한도 자유), focus/maintain 은 PATCH.
-  // 더미 데이터(goal_ 접두사 없는 id)는 로컬만 변경해 데모 흐름을 유지하고,
+  // 화면 전용 임시 데이터(cand_ id)는 로컬만 변경해 인터뷰 흐름을 유지하고,
   // tier 한도 초과(422) 등 서버 검증 실패 시에는 되돌리고 사유를 표시한다.
   const changeStatus = async (id: string, s: GoalStatus) => {
     const prev = goals;
     setGoals((gs) => gs.map((g) => (g.id === id ? { ...g, status: s } : g)));
     setSelected(null);
-    if (!id.startsWith('goal_')) return;
+    if (!isPersistedGoalId(id)) return;
     setError(null);
     try {
       if (s === 'parked') await goalsApi.park(id);
       else await goalsApi.update(id, { goalTier: s });
     } catch (err: unknown) {
-      if (err instanceof ApiError) {
-        setGoals(prev);
-        setError(friendlyError(err, '분류를 바꾸지 못했어요.'));
-      }
-      // 네트워크/비-ApiError 는 데모 흐름 유지 — 로컬 변경을 그대로 둔다.
+      setGoals(prev);
+      setError(friendlyError(err, '분류를 바꾸지 못했어요.'));
     }
   };
 

--- a/src/screens/GoalsScreen.tsx
+++ b/src/screens/GoalsScreen.tsx
@@ -11,15 +11,15 @@ import { EmptyState } from '../components/EmptyState';
 import { ErrorBanner } from '../components/ErrorBanner';
 import { SkeletonBlock } from '../components/SkeletonBlock';
 import { ReinterviewSheet } from '../components/ReinterviewSheet';
+import { isPersistedGoalId } from '../lib/goalIdentity';
 
 // Focus ≤ 3 / Maintain ≤ 5. Parked 는 한도 자유 (백엔드 _TIER_LIMITS 와 동일).
 const TIER_LIMIT: Record<GoalTier, number | null> = { focus: 3, maintain: 5, parked: null };
 const TIER_ORDER: GoalTier[] = ['focus', 'maintain', 'parked'];
 
-const isReal = (id: string) => id.startsWith('goal_');
-
 interface EditDraft {
   title: string;
+  category: string;
   deadline: string;
   priorityLevel: number;
 }
@@ -87,30 +87,29 @@ export function GoalsScreen() {
     const prev = goals;
     setGoals((gs) => gs.map((g) => (g.goalId === goal.goalId ? { ...g, goalTier: tier } : g)));
     setError(null);
-    if (!isReal(goal.goalId)) return; // 더미 — 로컬만
+    if (!isPersistedGoalId(goal.goalId)) return; // 화면 전용 더미 — 로컬만
     try {
       const updated = tier === 'parked'
         ? await goalsApi.park(goal.goalId)
         : await goalsApi.update(goal.goalId, { goalTier: tier });
       setGoals((gs) => gs.map((g) => (g.goalId === updated.goalId ? updated : g)));
     } catch (err: unknown) {
-      if (err instanceof ApiError) {
-        setGoals(prev); // 422 한도 초과 등 — 되돌리고 사유 표시
-        setError(friendlyError(err, '분류를 바꾸지 못했어요.'));
-      }
+      setGoals(prev); // 한도 초과·네트워크 오류 모두 서버 상태로 되돌린다.
+      setError(friendlyError(err, '분류를 바꾸지 못했어요.'));
     }
   };
 
-  // ── 인라인 수정 (제목/마감/우선순위) ──
+  // ── 인라인 수정 (제목/테마/마감/우선순위) ──
   const startEdit = (goal: ApiGoal) => {
     setEditId(goal.goalId);
-    setEdit({ title: goal.title, deadline: goal.deadline ?? '', priorityLevel: goal.priorityLevel });
+    setEdit({ title: goal.title, category: goal.category, deadline: goal.deadline ?? '', priorityLevel: goal.priorityLevel });
   };
 
   const saveEdit = async (goal: ApiGoal) => {
     if (!edit) return;
     const body = {
       title: edit.title.trim(),
+      category: edit.category,
       deadline: edit.deadline.trim() || null,
       priorityLevel: edit.priorityLevel,
     };
@@ -119,15 +118,16 @@ export function GoalsScreen() {
     setEditId(null);
     setEdit(null);
     setError(null);
-    if (!isReal(goal.goalId)) return;
+    if (!isPersistedGoalId(goal.goalId)) return;
     try {
       const updated = await goalsApi.update(goal.goalId, body);
       setGoals((gs) => gs.map((g) => (g.goalId === updated.goalId ? updated : g)));
+      // 요청값이 아니라 서버가 영속화해 돌려준 값으로만 변경을 확정한다. 저장 실패나
+      // 서버 정규화로 기존 값이 유지된 경우에는 재인터뷰를 권하지 않는다.
+      if (updated.category !== goal.category) setConfirmReinterview(true);
     } catch (err: unknown) {
-      if (err instanceof ApiError) {
-        setGoals(prev);
-        setError(friendlyError(err, '목표를 수정하지 못했어요.'));
-      }
+      setGoals(prev);
+      setError(friendlyError(err, '목표를 수정하지 못했어요.'));
     }
   };
 
@@ -137,14 +137,12 @@ export function GoalsScreen() {
     setGoals((gs) => gs.filter((g) => g.goalId !== goal.goalId));
     setConfirmDeleteId(null);
     setExpandedId(null);
-    if (!isReal(goal.goalId)) return;
+    if (!isPersistedGoalId(goal.goalId)) return;
     try {
       await goalsApi.remove(goal.goalId);
     } catch (err: unknown) {
-      if (err instanceof ApiError) {
-        setGoals(prev);
-        setError(friendlyError(err, '목표를 삭제하지 못했어요.'));
-      }
+      setGoals(prev);
+      setError(friendlyError(err, '목표를 삭제하지 못했어요.'));
     }
   };
 
@@ -318,6 +316,9 @@ export function GoalsScreen() {
                     {isEditing && edit && (
                       <>
                         <input value={edit.title} onChange={(e) => setEdit({ ...edit, title: e.target.value })} placeholder="제목" style={inputStyle} />
+                        <select value={edit.category} onChange={(e) => setEdit({ ...edit, category: e.target.value })} style={inputStyle} aria-label="목표 테마">
+                          {GOAL_CATEGORY_OPTIONS.map((c) => <option key={c.value} value={c.value}>{c.label}</option>)}
+                        </select>
                         <div style={{ display: 'flex', gap: 6 }}>
                           <input value={edit.deadline} onChange={(e) => setEdit({ ...edit, deadline: e.target.value })} placeholder="마감 YYYY-MM-DD" style={{ ...inputStyle, flex: 1 }} />
                           <select value={edit.priorityLevel} onChange={(e) => setEdit({ ...edit, priorityLevel: Number(e.target.value) })} style={{ ...inputStyle, width: 96 }}>

--- a/src/screens/MandalaDraftScreen.tsx
+++ b/src/screens/MandalaDraftScreen.tsx
@@ -326,7 +326,7 @@ export function MandalaDraftScreen({ goalId, onApproved, onLeave }: MandalaDraft
               ))}
             </div>
             <p style={{ fontSize: 11, color: 'var(--text-3)', margin: 0, lineHeight: 1.5 }}>
-              {filledAxes}/{AXIS_COUNT}개 축이 채워졌어요. 자물쇠가 붙은 축은 인터뷰에서 직접 말한 축이라 AI 재생성이 건드리지 않아요.
+              {filledAxes}/{AXIS_COUNT}개 축이 채워졌어요. 자물쇠가 붙은 축은 인터뷰에서 직접 말한 축이라 축을 다시 뽑아도 유지돼요.
             </p>
             <div style={{ display: 'flex', gap: 8 }}>
               <ReButton variant="ghost" onClick={() => void loadSubgoals()} disabled={busy != null}>

--- a/src/screens/MaterialsSearchScreen.tsx
+++ b/src/screens/MaterialsSearchScreen.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useState } from 'react';
+import { ArrowRight, Check, MagnifyingGlass, PencilSimple, SkipForward } from '@phosphor-icons/react';
+import { ApiError, plansApi } from '../lib/api';
+import { useNavigation } from '../contexts/NavigationContext';
+import type { MaterialsSearchResponse } from '../types/api';
+
+const STATUS_MESSAGE: Record<Exclude<MaterialsSearchResponse['status'], 'found'>, string> = {
+  not_found: '맞는 자료를 찾지 못했어요. 검색어를 조금 더 구체적으로 바꿔보세요.',
+  blocked_copyright: '저작권 때문에 내용을 가져올 수 없어요. 가지고 있는 자료를 직접 붙여넣어 주세요.',
+  quota_exceeded: '오늘의 자료 검색 횟수를 모두 사용했어요. 내일 다시 시도하거나 건너뛸 수 있어요.',
+  unavailable: '검색 서비스가 잠시 불안정해요. 잠시 후 다시 시도하거나 건너뛸 수 있어요.',
+};
+
+export function MaterialsSearchScreen() {
+  const { interviewSessionId, setScreen } = useNavigation();
+  const [query, setQuery] = useState('');
+  const [notice, setNotice] = useState('');
+  const [result, setResult] = useState<MaterialsSearchResponse | null>(null);
+  const [text, setText] = useState('');
+  const [loadingQuery, setLoadingQuery] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    plansApi.materialsQuery(interviewSessionId).then((res) => {
+      if (!cancelled) { setQuery(res.suggestedQuery); setNotice(res.notice); }
+    }).catch(() => { if (!cancelled) setError('검색어 제안을 불러오지 못했어요. 직접 입력하거나 건너뛸 수 있어요.'); })
+      .finally(() => { if (!cancelled) setLoadingQuery(false); });
+    return () => { cancelled = true; };
+  }, [interviewSessionId]);
+
+  const search = async () => {
+    const trimmed = query.trim();
+    if (trimmed.length < 2 || trimmed.length > 200) { setError('검색어는 2~200자로 입력해 주세요.'); return; }
+    setBusy(true); setError(null);
+    try {
+      const next = await plansApi.materialsSearch(trimmed);
+      setResult(next); setText(next.text ?? '');
+    } catch (err) {
+      setError(err instanceof ApiError && err.status === 429 ? '오늘의 자료 검색 횟수를 모두 사용했어요.' : '자료 검색에 실패했어요. 다시 시도해 주세요.');
+    } finally { setBusy(false); }
+  };
+
+  const confirm = async () => {
+    const trimmed = text.trim();
+    if (!trimmed) { setError('계획에 참고할 내용을 남겨 주세요.'); return; }
+    if (trimmed.length > 20_000) { setError('자료는 20,000자까지 저장할 수 있어요.'); return; }
+    setBusy(true); setError(null);
+    try { await plansApi.materialsConfirm(trimmed, interviewSessionId); setScreen('weekly-plan'); }
+    catch { setError('자료를 저장하지 못했어요. 다시 시도해 주세요.'); setBusy(false); }
+  };
+
+  const found = result?.status === 'found';
+  return (
+    <div style={{ height: '100%', overflowY: 'auto', padding: '18px 18px 32px', background: 'var(--surface-ground)' }}>
+      <div style={{ maxWidth: 640, margin: '0 auto', display: 'flex', flexDirection: 'column', gap: 16 }}>
+        <div><h1 style={{ margin: 0, fontSize: 22 }}>계획에 참고할 자료가 있나요?</h1>
+          <p style={{ color: 'var(--text-2)', fontSize: 13, lineHeight: 1.6 }}>검색어와 검색 결과를 직접 확인한 뒤에만 계획에 반영해요. 필요 없으면 건너뛰어도 됩니다.</p></div>
+
+        <section style={{ background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', borderRadius: 16, padding: 16 }}>
+          <div style={{ display: 'flex', gap: 7, alignItems: 'center', fontWeight: 800, marginBottom: 10 }}><MagnifyingGlass size={18} /> 1. 검색어 확인</div>
+          <div style={{ display: 'flex', gap: 8 }}>
+            <input aria-label="자료 검색어" value={query} disabled={loadingQuery || busy} onChange={(e) => { setQuery(e.target.value); setResult(null); }} maxLength={200}
+              placeholder={loadingQuery ? '검색어를 제안하는 중…' : '직접 검색어를 입력하세요'} style={{ flex: 1, minWidth: 0, border: '1px solid var(--sand-300)', borderRadius: 10, padding: '11px 12px', fontSize: 14 }} />
+            <button onClick={search} disabled={loadingQuery || busy || query.trim().length < 2} style={{ border: 0, borderRadius: 10, padding: '0 15px', background: 'var(--brand)', color: 'white', fontWeight: 800 }}>검색</button>
+          </div>
+          {notice && <p style={{ color: 'var(--text-3)', fontSize: 12, lineHeight: 1.5, marginBottom: 0 }}>{notice}</p>}
+        </section>
+
+        {result && result.status !== 'found' && <div role="status" style={{ padding: 14, borderRadius: 12, background: 'var(--surface-raised)', fontSize: 13, lineHeight: 1.6 }}>{STATUS_MESSAGE[result.status]}</div>}
+        {found && <section style={{ background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', borderRadius: 16, padding: 16 }}>
+          <div style={{ display: 'flex', gap: 7, alignItems: 'center', fontWeight: 800, marginBottom: 6 }}><PencilSimple size={18} /> 2. 찾은 내용 확인·편집</div>
+          <p style={{ color: 'var(--text-2)', fontSize: 12, lineHeight: 1.5 }}>내용이 다르면 고치거나 지워도 돼요. 아직 계획에는 저장되지 않았습니다.</p>
+          <textarea aria-label="확정할 자료 내용" value={text} onChange={(e) => setText(e.target.value)} maxLength={20000} rows={12} style={{ width: '100%', boxSizing: 'border-box', resize: 'vertical', border: '1px solid var(--sand-300)', borderRadius: 10, padding: 12, fontSize: 13, lineHeight: 1.6 }} />
+          <div style={{ textAlign: 'right', color: 'var(--text-3)', fontSize: 11 }}>{text.length.toLocaleString()} / 20,000자</div>
+          {!!result.sources?.length && <div style={{ marginTop: 10, fontSize: 12 }}><b>참고 출처</b>{result.sources.map((s) => <div key={s.uri}><a href={s.uri} target="_blank" rel="noreferrer">{s.title || s.uri}</a></div>)}</div>}
+          <button onClick={confirm} disabled={busy || !text.trim()} style={{ marginTop: 14, width: '100%', border: 0, borderRadius: 11, padding: 13, background: 'var(--brand)', color: 'white', fontWeight: 800 }}><Check size={16} /> 3. 이 자료를 계획에 반영</button>
+        </section>}
+
+        {error && <div role="alert" style={{ color: 'var(--coral-700)', fontSize: 13 }}>{error}</div>}
+        <button onClick={() => setScreen('weekly-plan')} disabled={busy} style={{ background: 'transparent', border: 0, color: 'var(--text-2)', padding: 10, cursor: 'pointer' }}><SkipForward size={16} /> 자료 없이 계획 계속하기 <ArrowRight size={14} /></button>
+      </div>
+    </div>
+  );
+}

--- a/src/screens/MilestoneConfirmScreen.tsx
+++ b/src/screens/MilestoneConfirmScreen.tsx
@@ -181,11 +181,11 @@ export function MilestoneConfirmScreen() {
       .map((m) => ({ title: m.title.trim(), summary: (m.summary ?? '').trim() }))
       .filter((m) => m.title);
     setPlannedMilestones(cleaned.length > 0 ? cleaned : null);
-    setScreen('weekly-plan');
+    setScreen('materials-search');
   };
   const skip = () => {
     setPlannedMilestones(null);
-    setScreen('weekly-plan');
+    setScreen('materials-search');
   };
 
   const canConfirm = milestones.some((m) => m.title.trim());

--- a/src/screens/RecoveredScreen.tsx
+++ b/src/screens/RecoveredScreen.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import { ArrowsClockwise, ArrowDown, XCircle, CheckCircle, Clock } from '@phosphor-icons/react';
-import { replanApi } from '../lib/api';
+import { friendlyError, replanApi } from '../lib/api';
 import type { ReplanDiff } from '../types/api';
 import { DemoNotice } from '../components/DemoNotice';
+import { ErrorBanner } from '../components/ErrorBanner';
 
 // 적용된 복구 내역 — RecoveryScreen 에서 사용자가 고른 제안 + 실패한 카드.
 // 백엔드 replan diff(#20-B) 가 응답하면 그 before/after 로 교체, 아니면 이 props 로 표시.
@@ -44,12 +45,15 @@ export function RecoveredScreen({ recoveryCount, applied, onDone, executionId }:
   // mock-and-replace: 진입 시 replan diff 조회 — 실제 executionId 가 있을 때만.
   // 백엔드(#20-B)가 before/after 를 주면 실데이터로 교체, 실패/없음이면 applied props fallback.
   const [diff, setDiff] = useState<ReplanDiff | null>(null);
+  const [diffError, setDiffError] = useState<string | null>(null);
+  const [approveError, setApproveError] = useState<string | null>(null);
+  const [approving, setApproving] = useState(false);
   useEffect(() => {
     if (!executionId) return;
     let cancelled = false;
     replanApi.diff(executionId).then(
       (d) => { if (!cancelled && d?.before && d?.after) setDiff(d); },
-      () => { /* 미구현/오류 ok — applied props 사용 */ },
+      (err) => { if (!cancelled) setDiffError(friendlyError(err, '실제 일정 변경 내용을 불러오지 못했어요.')); },
     );
     return () => { cancelled = true; };
   }, [executionId]);
@@ -66,15 +70,22 @@ export function RecoveredScreen({ recoveryCount, applied, onDone, executionId }:
       }
     : applied ?? null;
 
-  const handleDone = () => {
+  const handleDone = async () => {
     // 알겠어요 클릭 시 approve 시도. executionId 없으면 skip.
     // Idempotency-Key 는 반드시 "대상 스코프"여야 한다(#164) — approve 는 body 가 없어
     // 모든 호출의 body 해시가 같으므로, Date.now() 같은 전역 값을 쓰면 재시도마다 키가
     // 달라져 멱등 보호가 무력해진다. executionId 로 고정한다.
     if (executionId) {
-      replanApi
-        .approve(executionId, `replan-${executionId}`)
-        .catch((err) => { console.warn('[replan] approve 실패', err); });
+      setApproving(true);
+      setApproveError(null);
+      try {
+        await replanApi.approve(executionId, `replan-${executionId}`);
+      } catch (err) {
+        setApproveError(friendlyError(err, '일정 반영을 완료하지 못했어요. 다시 시도해 주세요.'));
+        setApproving(false);
+        return;
+      }
+      setApproving(false);
     }
     onDone();
   };
@@ -134,6 +145,11 @@ export function RecoveredScreen({ recoveryCount, applied, onDone, executionId }:
       )}
 
       {/* 이번 세션 회복 카드 (백엔드 누적 집계 엔드포인트가 없어 세션 카운트로 정직하게) */}
+      {(diffError || approveError) && (
+        <div style={{ width: '100%', maxWidth: 320 }}>
+          <ErrorBanner>{approveError ?? diffError}</ErrorBanner>
+        </div>
+      )}
       <div style={{ background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', borderRadius: 18, padding: 18, width: '100%', maxWidth: 320, textAlign: 'left', flexShrink: 0 }}>
         <div style={{ fontSize: 12, fontWeight: 600, letterSpacing: '-0.01em', color: 'var(--text-3)', marginBottom: 8 }}>이번 세션 회복</div>
         <div style={{ display: 'flex', alignItems: 'baseline', gap: 6 }}>
@@ -144,7 +160,7 @@ export function RecoveredScreen({ recoveryCount, applied, onDone, executionId }:
         </div>
       </div>
 
-      <button onClick={handleDone} style={{ width: 160, height: 44, borderRadius: 12, border: 'none', background: 'var(--brand-surface)', color: '#FFFCF6', fontWeight: 700, fontSize: 14, fontFamily: 'inherit', cursor: 'pointer', flexShrink: 0 }}>알겠어요</button>
+      <button onClick={handleDone} disabled={approving} style={{ width: 160, height: 44, borderRadius: 12, border: 'none', background: 'var(--brand-surface)', color: '#FFFCF6', fontWeight: 700, fontSize: 14, fontFamily: 'inherit', cursor: approving ? 'default' : 'pointer', opacity: approving ? 0.6 : 1, flexShrink: 0 }}>{approving ? '반영하는 중…' : approveError ? '다시 시도' : '알겠어요'}</button>
     </div>
   );
 }

--- a/src/screens/RecoveryScreen.tsx
+++ b/src/screens/RecoveryScreen.tsx
@@ -13,7 +13,7 @@ import { RecoveryOptionCard } from '../components/RecoveryOptionCard';
 import { ReEngagementAnchorPicker } from '../components/ReEngagementAnchorPicker';
 import { EmptyState } from '../components/EmptyState';
 import { ErrorBanner } from '../components/ErrorBanner';
-import { localDateStr, defaultReEngagementAnchorDate, DEFAULT_REENGAGEMENT_TIME } from '../lib/dates';
+import { localDateStr, defaultCarryOverAnchorDate, defaultReEngagementAnchorDate, DEFAULT_REENGAGEMENT_TIME } from '../lib/dates';
 import type { Task, RecoveryProposal } from '../types';
 import type { RecoveryCard } from '../types/api';
 
@@ -94,27 +94,6 @@ function dedupeByGroup(cards: RecoveryCard[]): RecoveryCard[] {
   });
 }
 
-// ── 재협상 3장 판정 (#223) ──────────────────────────────────────────────
-// "같은 목표 4회 연속 실패 / 회복 2회 연속 거절" 같은 재협상 발동 기준은 백엔드
-// 로직(recovery-evidence-base.md §5.2 L3)이고, RecoveryProposalsResponse /
-// RecoveryCard 스키마(src/types/openapi.d.ts) 에는 그 기준을 알려주는 필드가
-// 없다 — 연속 실패 횟수, "재협상 카드" 플래그, 그룹 조합을 명시하는 값 전부
-// 응답에 없다(확인 완료). 그래서 FE 가 "몇 번 실패했는지"를 따로 세서 재협상
-// 여부를 스스로 판정하지 않는다 — 그건 근거 없이 클라이언트가 지어내는 것이다.
-//
-// 지금 유일하게 관찰 가능한 건 "내려온 카드 구성" 뿐이다: 통상 4그룹 카드엔
-// 보통 CARRY_OVER 가 섞이는데, 재협상 3장은 정확히 DOWNSCOPE/RESCHEDULE/PARK
-// 조합이고 CARRY_OVER 가 없다(§5.2 L3 정의). 이걸로 화면 톤만 바꾸는 임시
-// 휴리스틱이며, 판정 지점은 이 함수 하나로 좁혀둔다 — 백엔드가 명시 신호(예:
-// isRenegotiation 플래그, consecutiveFailCount)를 응답에 추가하면 이 함수만
-// 고치면 된다. PR 본문에 "백엔드 신호 대기"로 남긴다.
-const RENEGOTIATION_GROUPS = new Set(['DOWNSCOPE', 'RESCHEDULE', 'PARK']);
-function isRenegotiationSet(proposals: RecoveryProposal[]): boolean {
-  if (proposals.length !== 3) return false;
-  const groups = new Set(proposals.map((p) => p.type));
-  return groups.size === 3 && proposals.every((p) => RENEGOTIATION_GROUPS.has(p.type));
-}
-
 interface MergedRecoveryScreenProps {
   task: Task | null;
   failReason?: string;
@@ -126,9 +105,11 @@ interface MergedRecoveryScreenProps {
   // 있으면 백엔드 LLM 회복 제안(POST /recovery/proposals/generate)과 연동한다.
   // task.id 는 task id 일 뿐 executionId 가 아니라서 그것으로는 호출하지 않는다.
   executionId?: string;
+  preparationError?: string | null;
+  onOpenWeekly: () => void;
 }
 
-export function MergedRecoveryScreen({ task, failReason, onAccept, onDismiss, executionId }: MergedRecoveryScreenProps) {
+export function MergedRecoveryScreen({ task, failReason, onAccept, onDismiss, executionId, preparationError, onOpenWeekly }: MergedRecoveryScreenProps) {
   const [sel, setSel] = useState<string | null>(null);
   const [showWhy, setShowWhy] = useState<string | null>(null);
   const [accepted, setAccepted] = useState(false);
@@ -142,6 +123,10 @@ export function MergedRecoveryScreen({ task, failReason, onAccept, onDismiss, ex
   const [decideError, setDecideError] = useState<string | null>(null);
   // 이 실행은 이미 회복 결정을 마침(generate 409) — 오류가 아니라 정상 상태.
   const [alreadyDecided, setAlreadyDecided] = useState(false);
+  const [loadingProposals, setLoadingProposals] = useState(false);
+  const [proposalError, setProposalError] = useState<string | null>(null);
+  const [manualScheduleNeeded, setManualScheduleNeeded] = useState(false);
+  const [recoveryMode, setRecoveryMode] = useState<'standard' | 'goal_renegotiation'>('standard');
   // 재관여 앵커(#221) — PARK/CARRY_OVER 수락 시 "다음에 다시 볼 시점". 기본값은 다음
   // 주간 리뷰(다음 주 월요일 09:00)로 미리 채워, 마찰 없이 그대로 확인만 해도 되게 한다.
   const [anchorDate, setAnchorDate] = useState(() => defaultReEngagementAnchorDate());
@@ -150,36 +135,61 @@ export function MergedRecoveryScreen({ task, failReason, onAccept, onDismiss, ex
   const selectedProposal = proposals.find((p) => p.id === sel);
   const needsAnchor = !!selectedProposal && REENGAGEMENT_GROUPS.has(selectedProposal.type);
 
-  // 재협상 3장인지(#223) — isRenegotiationSet 판정을 그대로 쓴다. 통상 카드와
-  // 인터랙션(선택 → 3버튼)은 동일하게 재사용하고, 헤더 카피/톤만 바꿔서
-  // "지금은 다시 정하는 시점"이라는 신호를 준다(별도 화면을 새로 만들지 않음).
-  const renegotiating = usingRealProposals && isRenegotiationSet(proposals);
+  const renegotiating = usingRealProposals && recoveryMode === 'goal_renegotiation';
+
+  useEffect(() => {
+    if (selectedProposal?.type === 'CARRY_OVER') {
+      setAnchorDate(defaultCarryOverAnchorDate());
+      setAnchorTime(DEFAULT_REENGAGEMENT_TIME);
+    } else if (selectedProposal?.type === 'PARK') {
+      setAnchorDate(defaultReEngagementAnchorDate());
+      setAnchorTime(DEFAULT_REENGAGEMENT_TIME);
+    }
+  }, [selectedProposal?.type]);
 
   // 진입 시 + "다른 제안" 버튼에서 LLM 회복 제안 생성. executionId 있을 때만(데모 task 는 skip).
   // 4 UX 그룹당 ≤1 로 dedup. hooks 는 early-return 앞에 둔다(호출 순서 고정).
   const loadProposals = React.useCallback(() => {
     if (!executionId) return;
     setDecideError(null);
+    setProposalError(null);
+    setLoadingProposals(true);
     recoveryApi.generateProposals(executionId).then(
       (res) => {
         setProposals(dedupeByGroup(res.cards ?? []).map(cardToProposal));
         setAiSource(res.aiSource === 'rule' ? 'rule' : 'llm');
+        setRecoveryMode(res.recoveryMode === 'goal_renegotiation' ? 'goal_renegotiation' : 'standard');
         setUsingRealProposals(true);
         setSel(null);
         setAlreadyDecided(false);
+        setLoadingProposals(false);
       },
       (err: unknown) => {
         // 409 RECOVERY_ALREADY_DECIDED — 이미 결정을 끝낸 실행에 재진입한 것. 오류가
         // 아니므로 에러 토스트 대신 "이미 결정함" 안내를 보여준다(#164).
         if (err instanceof ApiError && err.status === 409) {
           setAlreadyDecided(true);
+          setLoadingProposals(false);
           return;
         }
-        /* 그 외 오류 — 빈 상태 */
+        setUsingRealProposals(false);
+        setProposalError(friendlyError(err, '회복 제안을 불러오지 못했어요. 다시 시도해 주세요.'));
+        setLoadingProposals(false);
       },
     );
   }, [executionId]);
   useEffect(() => { loadProposals(); }, [loadProposals]);
+
+  if (manualScheduleNeeded) {
+    return (
+      <div style={{ position: 'absolute', inset: 0, zIndex: 50, background: 'var(--surface-ground)', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '40px 24px', gap: 14 }}>
+        <div style={{ fontWeight: 700, fontSize: 22 }}>시간은 주간 계획에서 옮겨주세요</div>
+        <p style={{ fontSize: 13, color: 'var(--text-2)', maxWidth: 280, margin: 0, lineHeight: 1.6 }}>이 선택은 새 일정을 자동으로 만들지 않아요. 주간 계획에서 원하는 시간으로 직접 옮길 수 있어요.</p>
+        <button onClick={onOpenWeekly} style={{ height: 44, padding: '0 20px', borderRadius: 12, border: 'none', background: 'var(--text-1)', color: '#FAF6EE', fontWeight: 700, fontSize: 14, fontFamily: 'inherit', cursor: 'pointer' }}>주간 계획 열기</button>
+        <button onClick={onDismiss} style={{ border: 'none', background: 'none', color: 'var(--text-3)', fontSize: 12, fontFamily: 'inherit', cursor: 'pointer' }}>오늘로 돌아가기</button>
+      </div>
+    );
+  }
 
   // 이미 회복 결정을 마친 실행에 재진입 — 에러가 아니라 정상 상태로 안내한다(#164).
   if (alreadyDecided) {
@@ -231,11 +241,15 @@ export function MergedRecoveryScreen({ task, failReason, onAccept, onDismiss, ex
       // recoveryApi.decide 안에서 버려지지만, 값 자체는 여기서부터 만들어 둔다.
       const reEngagementAnchorAt = needsAnchor ? `${anchorDate}T${anchorTime}:00+09:00` : null;
       try {
-        await recoveryApi.decide(
+        const result = await recoveryApi.decide(
           { executionId, decision: 'accepted', acceptedAttemptId: sel },
           `rec-${executionId}-${sel}`,
           reEngagementAnchorAt,
         );
+        if (result.resultingActionItemId === null) {
+          setManualScheduleNeeded(true);
+          return;
+        }
       } catch (err) {
         setDecideError(friendlyError(err, '회복 계획을 저장하지 못했어요. 잠시 후 다시 시도해 주세요.'));
         return;
@@ -303,11 +317,16 @@ export function MergedRecoveryScreen({ task, failReason, onAccept, onDismiss, ex
               : '끝까지 가지 못해도 괜찮아요. 다시 시작할 방법이 있어요.'}
           </p>
 
-          {!usingRealProposals && (
+          {!usingRealProposals && !proposalError && !preparationError && (
             <div style={{ marginBottom: 14 }}>
               <DemoNotice storageKey="recovery-proposals">
-                복구 제안을 아직 준비 중이에요. 실제 실행 중 막혔을 때 AI 제안이 연결됩니다.
+                {loadingProposals || executionId ? '회복 제안을 준비하고 있어요.' : '실행 결과를 저장한 뒤 회복 제안을 준비할게요.'}
               </DemoNotice>
+            </div>
+          )}
+          {(proposalError || preparationError) && (
+            <div style={{ marginBottom: 14 }}>
+              <ErrorBanner>{proposalError ?? preparationError}</ErrorBanner>
             </div>
           )}
           {usingRealProposals && proposals.length === 0 && (
@@ -365,7 +384,7 @@ export function MergedRecoveryScreen({ task, failReason, onAccept, onDismiss, ex
           {/* 3버튼: 나중에(거절) / 다른 제안(수정=재생성) / 이 방법으로(수락) — S19 */}
           <div style={{ display: 'flex', gap: 8, marginTop: 14 }}>
             <button onClick={reject} style={{ flex: 1, height: 44, borderRadius: 12, border: '1px solid var(--sand-200)', background: 'transparent', color: 'var(--text-3)', fontWeight: 600, fontSize: 13, fontFamily: 'inherit', cursor: 'pointer' }}>나중에</button>
-            <button onClick={loadProposals} disabled={!usingRealProposals} style={{ flex: 1, height: 44, borderRadius: 12, border: '1px solid var(--sand-200)', background: 'var(--surface-ground)', color: 'var(--text-2)', fontWeight: 600, fontSize: 13, fontFamily: 'inherit', cursor: usingRealProposals ? 'pointer' : 'not-allowed', opacity: usingRealProposals ? 1 : 0.4, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 4 }}><ArrowsClockwise size={13} /> 다른 제안</button>
+            <button onClick={loadProposals} disabled={!executionId || loadingProposals} style={{ flex: 1, height: 44, borderRadius: 12, border: '1px solid var(--sand-200)', background: 'var(--surface-ground)', color: 'var(--text-2)', fontWeight: 600, fontSize: 13, fontFamily: 'inherit', cursor: executionId && !loadingProposals ? 'pointer' : 'not-allowed', opacity: executionId && !loadingProposals ? 1 : 0.4, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 4 }}><ArrowsClockwise size={13} /> {proposalError ? '다시 시도' : '다른 제안'}</button>
             <button onClick={accept} disabled={!sel || deciding} style={{ flex: 1.6, height: 44, borderRadius: 12, border: 'none', background: 'var(--brand-surface)', color: '#FFFCF6', fontWeight: 700, fontSize: 13, fontFamily: 'inherit', cursor: sel && !deciding ? 'pointer' : 'not-allowed', opacity: sel && !deciding ? 1 : 0.35, transition: 'opacity 160ms' }}>{deciding ? '저장하는 중…' : '이 방법으로'}</button>
           </div>
         </div>

--- a/src/screens/WeeklyReviewScreen.tsx
+++ b/src/screens/WeeklyReviewScreen.tsx
@@ -7,6 +7,28 @@ import { localDateStr } from '../lib/dates';
 import { DemoNotice } from '../components/DemoNotice';
 import { useNavigation } from '../contexts/NavigationContext';
 import type { WeeklyReviewResponse, HabitPenaltyCandidate } from '../types/api';
+
+// #256의 주간 만다라 필드는 기존 리뷰 응답에 additive로 붙는다. API 타입 동기화와
+// 화면 작업의 배포 순서가 달라도 안전하게 소비할 수 있도록 이 화면에서만 확장한다.
+interface MandalaWeeklyHabit {
+  axisTitle: string;
+  cellTitle: string;
+  doneCount: number;
+  targetCount: number;
+}
+
+interface MandalaWeeklySummary {
+  completedThisWeek: number;
+  completedTotal: number;
+  totalLeaves: number;
+  touchedThisWeek: number;
+  untouchedAxisTitles: string[];
+  habits: MandalaWeeklyHabit[];
+}
+
+type WeeklyReviewWithMandala = WeeklyReviewResponse & {
+  mandala?: MandalaWeeklySummary | null;
+};
 import { categoryLabel, isKnownCategory } from '../data';
 
 // 이번 주 월요일 (YYYY-MM-DD)
@@ -53,7 +75,7 @@ function toPct(v: number | null | undefined): number | null {
 export function WeeklyReviewScreenV2() {
   const { setScreen, setTab, setWeekOffset } = useNavigation();
   // 백엔드 실제 주간 리뷰. 들어오면 hero 점수/복구율/한줄요약을 실데이터로 덮는다.
-  const [real, setReal] = useState<WeeklyReviewResponse | null>(null);
+  const [real, setReal] = useState<WeeklyReviewWithMandala | null>(null);
   // 주간 리뷰 fetch가 끝날 때까지 true. 끝나기 전엔 더미 대신 스켈레톤을 보여 플래시를 막는다.
   const [reviewLoading, setReviewLoading] = useState(true);
   // Habit Penalty 후보(3주 연속 미달) — 있으면 재설계 제안 카드로 표시(S22).
@@ -184,6 +206,10 @@ export function WeeklyReviewScreenV2() {
           </div>
         ))}
 
+        {/* 만다라 실행 리포트 — 완료 가능한 칸과 끝이 없는 반복형 칸을 섞지 않는다.
+            특히 손 못 댄 축은 비율 대신 이름을 보여 다음 주 행동으로 이어지게 한다. */}
+        {!reviewLoading && real?.mandala && <MandalaWeeklySection summary={real.mandala} />}
+
         {reviewLoading ? (
           /* 데이터 의존 영역 스켈레톤 — fetch가 끝날 때까지 더미 KPI 대신 표시. */
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }} aria-hidden="true">
@@ -307,6 +333,76 @@ export function WeeklyReviewScreenV2() {
           다음 주 계획 확인 <ArrowRight size={15} />
         </button>
       </div>
+    </div>
+  );
+}
+
+function MandalaWeeklySection({ summary }: { summary: MandalaWeeklySummary }) {
+  const untouchedCount = summary.untouchedAxisTitles.length;
+
+  return (
+    <section
+      aria-labelledby="weekly-mandala-title"
+      style={{ background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', borderRadius: 16, padding: '14px 16px' }}
+    >
+      <div id="weekly-mandala-title" style={{ fontSize: 14, fontWeight: 800, color: 'var(--text-1)', marginBottom: 12 }}>
+        이번 주 만다라트
+      </div>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 9 }}>
+        <MandalaStat
+          label="끝낸 칸"
+          value={`${summary.completedThisWeek}칸`}
+          detail={`누적 ${summary.completedTotal} / ${summary.totalLeaves}`}
+        />
+        <MandalaStat label="굴린 칸" value={`${summary.touchedThisWeek}칸`} detail="이번 주에 손댄 칸" />
+        <MandalaStat
+          label="손 못 댄 축"
+          value={`${untouchedCount}개`}
+          detail={untouchedCount > 0 ? summary.untouchedAxisTitles.join(', ') : '모든 축을 한 번 이상 굴렸어요'}
+          detailTone={untouchedCount > 0 ? 'attention' : 'normal'}
+        />
+      </div>
+
+      {summary.habits.length > 0 && (
+        <div style={{ marginTop: 14, paddingTop: 12, borderTop: '1px solid var(--sand-200)' }}>
+          <div style={{ fontSize: 11, fontWeight: 700, color: 'var(--text-3)', marginBottom: 8 }}>반복 중</div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            {summary.habits.map((habit, index) => (
+              <div key={`${habit.axisTitle}-${habit.cellTitle}-${index}`} style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 12 }}>
+                <div style={{ minWidth: 0 }}>
+                  <div style={{ fontSize: 12, fontWeight: 700, color: 'var(--text-1)', lineHeight: 1.45, overflowWrap: 'anywhere' }}>{habit.cellTitle}</div>
+                  <div style={{ fontSize: 10, color: 'var(--text-3)', marginTop: 1 }}>{habit.axisTitle}</div>
+                </div>
+                <div className="tnum" style={{ flexShrink: 0, fontSize: 12, color: 'var(--text-2)', lineHeight: 1.45 }}>
+                  <b style={{ color: 'var(--brand-ink)' }}>{habit.doneCount}회</b>
+                  <span style={{ color: 'var(--text-3)' }}> / 목표 {habit.targetCount}회</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function MandalaStat({
+  label,
+  value,
+  detail,
+  detailTone = 'normal',
+}: {
+  label: string;
+  value: string;
+  detail: string;
+  detailTone?: 'normal' | 'attention';
+}) {
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: '76px 48px minmax(0, 1fr)', alignItems: 'baseline', gap: 8 }}>
+      <span style={{ fontSize: 12, color: 'var(--text-2)', fontWeight: 600 }}>{label}</span>
+      <strong className="tnum" style={{ fontSize: 13, color: 'var(--text-1)', whiteSpace: 'nowrap' }}>{value}</strong>
+      <span style={{ fontSize: 11, color: detailTone === 'attention' ? 'var(--warning-ink)' : 'var(--text-3)', lineHeight: 1.45, overflowWrap: 'anywhere' }}>{detail}</span>
     </div>
   );
 }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -954,6 +954,41 @@ export interface MilestoneListResponse {
   aiSource?: 'llm' | 'rule';
 }
 
+export interface MaterialsQueryResponse {
+  suggestedQuery: string;
+  goalTitle: string;
+  notice: string;
+}
+
+export interface MaterialSource {
+  title: string;
+  uri: string;
+}
+
+export type MaterialsSearchStatus =
+  | 'found'
+  | 'not_found'
+  | 'blocked_copyright'
+  | 'quota_exceeded'
+  | 'unavailable';
+
+export interface MaterialsSearchResponse {
+  status: MaterialsSearchStatus;
+  text?: string | null;
+  sources?: MaterialSource[];
+  searchQueries?: string[];
+  remainingToday?: number | null;
+  notice: string;
+  aiSource: 'llm' | 'rule';
+  isDraft: boolean;
+}
+
+export interface MaterialsConfirmResponse {
+  goalTitle: string;
+  savedChars: number;
+  notice: string;
+}
+
 // POST /plans/{planId}/approve
 export interface FirstPlanApproveResponse {
   planId: string;

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -155,6 +155,7 @@ export interface GoalsByTier {
 
 export interface GoalUpdateRequest {
   title?: string;
+  category?: string;
   deadline?: string | null; // YYYY-MM-DD
   priorityLevel?: number;
   goalTier?: GoalTier;
@@ -707,6 +708,7 @@ export interface FailureTagMaster {
 export interface FailureTagRequest {
   tagCodes: (FailureTagCode | string)[];
   memo?: string | null; // 클라이언트 암호화 메모(선택)
+  taskAversiveness?: number | null; // 1~5, 선택
 }
 
 export interface FailureTagResponse {
@@ -769,6 +771,7 @@ export interface RecoveryProposalsResponse {
   executionId: string;
   cards: RecoveryCard[];
   aiSource?: string;
+  recoveryMode: 'standard' | 'goal_renegotiation';
   isDraft?: boolean;
 }
 
@@ -784,6 +787,7 @@ export interface RecoveryDecisionRequest {
   acceptedAttemptId?: string | null;
   editedActionText?: string | null; // decision='edited' 일 때 1~300자
   decisionReason?: string | null;
+  reEngagementAnchorAt?: string | null; // timezone 포함 ISO 8601
 }
 
 export interface RecoveryDecisionResponse {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -20,6 +20,7 @@ export type ScreenId =
   | 'goal-classify'
   | 'setup'
   | 'milestone-confirm'
+  | 'materials-search'
   | 'weekly-plan'
   | 'morning-brief'
   | 'today'

--- a/src/types/openapi.d.ts
+++ b/src/types/openapi.d.ts
@@ -16,6 +16,9 @@ export interface paths {
         /**
          * Login With Google
          * @description Google id_token 검증 → user upsert → JWT 발급.
+         *
+         *     기존 사용자(email 이미 존재)는 게이트를 전혀 거치지 않는다 — lock 도 신규 가입
+         *     판정 이후에만 잡는다(로그인은 이미 30명 안에 있던 사람이라 경합 대상이 아니다).
          */
         post: operations["login_with_google_auth_google_post"];
         delete?: never;
@@ -35,7 +38,10 @@ export interface paths {
         put?: never;
         /**
          * Logout
-         * @description refresh 의 jti 를 revoke set 에 등록. 잘못된 토큰이어도 멱등 204.
+         * @description refresh 의 jti 를 revoke set 에 등록 + 쿠키 삭제. 잘못된/없는 토큰이어도 멱등 204.
+         *
+         *     쿠키는 토큰 유효성과 무관하게 항상 지운다(#323) — 브라우저에 남은 쿠키를 정리하는
+         *     게 목적이라, revoke 대상 jti 를 못 찾는 경우(토큰 없음/깨짐)에도 해야 할 일이다.
          */
         post: operations["logout_auth_logout_post"];
         delete?: never;
@@ -76,6 +82,17 @@ export interface paths {
         /**
          * Refresh Access Token
          * @description refresh → 새 access. refresh 회전 X (refresh 자체 재발급 안 함).
+         *
+         *     토큰 출처는 본문 우선, 없으면 `reaction_refresh` 쿠키(#323) — 웹이 쿠키로 옮겨가도
+         *     네이티브(본문만 보냄)와 과거 웹 클라이언트(둘 다 안 옮긴 상태)가 계속 동작해야 한다.
+         *     둘 다 없으면 애초에 세션이 없는 것이므로 401.
+         *
+         *     사용자 존재 확인(#321) — 이전에는 jti revoke 여부만 보고 `decoded.user_id` 로 바로
+         *     access 를 재발급했다. 계정 삭제(`POST /settings/delete-account`)는 개별 jti 를
+         *     모르므로(다중 기기 발급분을 전부 추적하지 않는다) revoke set 에 등록할 수 없다 —
+         *     대신 `UserRepo.get_by_id` 의 `archived_at IS NULL` 필터로 막는다. `get_current_user`
+         *     가 이미 같은 필터로 access token 을 막고 있으니, 여기도 같은 기준을 적용해야
+         *     "삭제된 계정은 refresh 로도 못 살아난다"가 성립한다.
          */
         post: operations["refresh_access_token_auth_refresh_post"];
         delete?: never;
@@ -272,6 +289,41 @@ export interface paths {
         patch: operations["update_mandala_node_goals_mandala_nodes__node_id__patch"];
         trace?: never;
     };
+    "/goals/mandala/nodes/{node_id}/habit": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Link Mandala Habit
+         * @description 셀(leaf) → 반복형 전환(U12, ADR-0008 §1). 새 `Habit` 을 만들어 이 칸에 링크한다.
+         *
+         *     "코딩테스트 1일 1문제"·"쓰레기 줍기" 처럼 끝이 없는 칸은 계획(action_item)으로 내려보내지
+         *     않고 이 링크로 주간 횟수(habit_instances.done_count)만 추적한다.
+         *
+         *     **칸(leaf, depth=2)만 대상이다** — 축·중앙은 8칸을 아우르는 단위라 반복 횟수 개념이 안
+         *     맞는다(depth≠2 면 422, `promote` 의 depth≠1 가드와 같은 자리). 이미 이 칸에 링크된 활성
+         *     습관이 있으면 새로 만들지 않고 그 습관을 그대로 반환한다(멱등 — `promote` 와 같은 이유,
+         *     두 번 눌러도 중복 습관이 쌓이면 안 된다).
+         */
+        post: operations["link_mandala_habit_goals_mandala_nodes__node_id__habit_post"];
+        /**
+         * Unlink Mandala Habit
+         * @description 반복형 → 프로젝트형으로 되돌리기(ADR-0008 §1) — 링크된 습관을 soft delete.
+         *
+         *     칸(goal_node) 자체는 그대로 남는다. 링크가 없으면(이미 프로젝트형) 그냥 204 —
+         *     "이미 그 상태"를 에러로 보지 않는다.
+         */
+        delete: operations["unlink_mandala_habit_goals_mandala_nodes__node_id__habit_delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/goals/mandala/nodes/{node_id}/promote": {
         parameters: {
             query?: never;
@@ -340,9 +392,55 @@ export interface paths {
         head?: never;
         /**
          * Update Goal
-         * @description 목표 부분 수정. tier 변경 시 한도 재검사.
+         * @description 목표 부분 수정. tier 변경 시 한도 재검사, category 변경 시 값 검증(#326).
          */
         patch: operations["update_goal_goals__goal_id__patch"];
+        trace?: never;
+    };
+    "/goals/{goal_id}/complete": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Complete Goal
+         * @description 목표 완료 확정 — "이 목표 끝난 거 맞아요?" 에 대한 사용자 확인 (ADR-0007 6b).
+         *
+         *     마일스톤이 다 끝나면 주간 리뷰가 `goalCompletionProposals` 로 제안하지만, **여기에
+         *     가드를 걸지 않는다.** 마일스톤 완료 표시와 같은 이유다 — 다른 경로로 달성했거나 방향이
+         *     바뀌어 여기서 접는 경우가 있고, 그 판단은 AI 가 아니라 사용자 몫이다(§3).
+         *
+         *     완료는 **보관(soft delete)이 아니다.** `archived_at` 을 건드리지 않아 목록에 남고,
+         *     FE 가 `status` 로 배지를 단다. 끝낸 것과 치운 것은 다른 뜻이다.
+         *
+         *     완료가 실제로 뜻하는 바 두 가지가 함께 성립한다:
+         *     - **tier 한도(Focus≤3)를 더 안 먹는다** — 성실히 완주할수록 새 목표를 못 만들면 곤란하다.
+         *     - **새 계획 후보에서 빠진다** — 안 그러면 "완료" 배지를 단 채 다음 주기 카드가 쏟아진다.
+         *
+         *     멱등 — 같은 값을 다시 보내도 200. `completed=false` 로 되돌릴 수 있다(오조작 복구).
+         *
+         *     ⚠️ **진행 중(`active`)인 목표만 완료할 수 있다.** `proposed` 를 완료로 보내면 해제할 때
+         *     `active` 로 나와 계획 승인 없이 승격되고, 잠정 목표 만료 cron 대상에서도 빠진다.
+         *
+         *     ⚠️ **되돌리기는 tier 한도를 다시 검사한다.** 완료하면 한도 집계에서 빠지므로, 안 재면
+         *     "완료 → 새 목표 생성 → 완료 해제" 로 Focus≤3 을 넘길 수 있다(AGENTS §1 잠금 결정).
+         *     한도가 찼으면 422 `GOAL_TIER_LIMIT_EXCEEDED` — 먼저 다른 목표를 정리해야 한다.
+         *
+         *     완료하면 **그 목표의 남은 예정 카드와 블록이 정리된다**(soft) — 안 그러면 끝냈다고
+         *     확인한 목표가 다음 날 아침 브리프에 그대로 뜬다. 시작·완료·실패한 카드와 사용자가
+         *     시간을 옮긴 카드는 보존된다. ⚠️ **만다라 유래 카드와 회복 카드는 안 걸린다**(위 참고).
+         *     ⚠️ **되돌려도 카드는 안 돌아온다** — 다시 하려면 되돌리기 → generate → approve 를
+         *     거쳐야 하고, 그 되돌리기가 tier 한도에 걸릴 수 있다(soft 정리라 데이터는 남는다).
+         */
+        post: operations["complete_goal_goals__goal_id__complete_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
         trace?: never;
     };
     "/goals/{goal_id}/mandala": {
@@ -394,6 +492,37 @@ export interface paths {
         options?: never;
         head?: never;
         patch?: never;
+        trace?: never;
+    };
+    "/goals/{goal_id}/nodes/{node_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Update Milestone Completion
+         * @description 마일스톤 완료 표시 — ADR-0007 §3 이 정한 **유일한 저장 예외**.
+         *
+         *     진척도는 저장하지 않고 `action_items.status` 에서 파생한다(§3). 마일스톤 완료만
+         *     예외인 이유는 롤업으로 표현할 수 없는 두 상태가 있어서다: "세션은 다 했는데 아직
+         *     아니다" 와 "세션은 안 했지만 다른 경로로 달성했다". **그 판단은 AI 가 아니라 사용자
+         *     몫**이라 자동 판정하지 않고 이 endpoint 로만 찍는다.
+         *
+         *     `nodeType="milestone"` 인 계획 트리 노드만 받는다(저장소에서 좁힌다). subgoal/leaf 는
+         *     404 — leaf 에 완료를 찍게 하면 `action_items.status` 와 진실이 갈린다. 만다라 칸도
+         *     404, 그쪽은 `PATCH /goals/mandala/nodes/{nodeId}` 다.
+         *
+         *     `completed=false` 로 되돌릴 수 있다(오조작 복구). 멱등 — 같은 값을 다시 보내도 200.
+         */
+        patch: operations["update_milestone_completion_goals__goal_id__nodes__node_id__patch"];
         trace?: never;
     };
     "/goals/{goal_id}/park": {
@@ -935,6 +1064,32 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/notifications/{notification_id}/opened": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Mark Notification Opened
+         * @description 이 알림을 열었다고 표시 (멱등 — 최초 1회만 `openedAt` 을 채운다).
+         *
+         *     `notificationId` 는 push payload 의 `id` 필드를 그대로 넘긴다 — 서버가 발송 **전에**
+         *     미리 만들어 실어 보낸 값이라(`notify_sweeps.py`), 이 발송 이력 행의 PK 와 항상 같다.
+         *
+         *     ⚠️ **이 endpoint 를 호출하는 FE 콜백(push `notificationclick` 핸들러)은 아직 없다.**
+         *     인프라만 미리 준비해 둔 것 — 배선되기 전까지는 아무도 이 경로를 타지 않는다.
+         */
+        post: operations["mark_notification_opened_notifications__notification_id__opened_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/onboarding/status": {
         parameters: {
             query?: never;
@@ -1089,6 +1244,78 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/plans/materials/confirm": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Confirm Materials
+         * @description "이 자료 맞아요" — 확정본을 `goals.materials` 슬롯에 쓴다 (② HITL 결정).
+         *
+         *     여기서부터는 **붙여넣기와 구분되지 않는다.** 다음 계획 생성이 기존 경로로 이 값을
+         *     집어가고, 자료 텍스트는 `materials_for_prompt` 의 울타리 안에 들어간다(#260).
+         *
+         *     사용자가 고친 텍스트를 그대로 받는다 — 검색이 다른 판을 가져왔거나 일부만 맞을 때
+         *     지우고 붙일 수 있어야 HITL 이다.
+         */
+        post: operations["confirm_materials_plans_materials_confirm_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/plans/materials/search": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Search Materials
+         * @description 사용자가 확정한 검색어로 자료를 찾는다. 결과는 **Draft — 저장하지 않는다.**
+         *
+         *     동시 요청을 락으로 직렬화하는 이유는 성능이 아니라 **예산**이다. 그라운딩은 건당
+         *     과금인데, 두 요청이 나란히 들어오면 둘 다 잔량 검사를 통과한 뒤 둘 다 호출해
+         *     상한을 넘길 수 있다(TOCTOU). 락 안에서 검사→호출→기록이 한 트랜잭션으로 끝난다.
+         */
+        post: operations["search_materials_plans_materials_search_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/plans/materials/search-query": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Propose Search Query
+         * @description 검색어를 제안한다. **아직 아무것도 검색하지 않는다.**
+         *
+         *     외부 호출이 0회라 과금도 예산 차감도 없다 — 사용자가 몇 번을 다시 열어봐도 무료다.
+         */
+        post: operations["propose_search_query_plans_materials_search_query_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/plans/milestones": {
         parameters: {
             query?: never;
@@ -1103,6 +1330,13 @@ export interface paths {
          * @description Stage A(#milestones) — 목표를 중간 목표 3~5개로. 사용자가 확인·편집 후 generate 로 넘긴다.
          *
          *     입력은 generate 와 동일(interviewSessionId/outcome + density). LLM 1콜 + 룰 폴백이라 가볍다.
+         *
+         *     **이미 확정·영속된 뼈대가 있으면 LLM 을 돌리지 않고 그걸 그대로 돌려준다**
+         *     (`aiSource="saved"`, ADR-0007 PR-2.5). 마일스톤은 매 주기 교체되는 leaf 트리와 달리
+         *     마감까지 살아남는 층이라(§1), 2주기에 새로 지어내면 사용자가 1주기에 확정한 뼈대와
+         *     다른 목록이 나오고 — 그 새 목록으로 계획이 만들어지는데 승인 경로는 이미 마일스톤이
+         *     있다는 이유로 저장을 건너뛰므로 — DB 의 뼈대와 실제 계획이 갈라진 채 굳는다.
+         *     부수 효과로 2주기 이후 이 endpoint 의 LLM 콜이 0 이 된다.
          */
         post: operations["generate_milestones_plans_milestones_post"];
         delete?: never;
@@ -1316,6 +1550,30 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/policy-snapshot/apply": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Apply Policy Update
+         * @description 사용자 승인 후 새 버전 INSERT — HITL 게이트가 여기다.
+         *
+         *     본문은 `preview-update` 응답을 그대로(=룰 그대로) 또는 사용자가 고친 값이다. 서버가
+         *     후보를 다시 계산해 덮어쓰지 않는다 — 그러면 사용자가 화면에서 본 값과 저장된 값이
+         *     달라질 수 있다(미리보기와 적용 사이에 KPI 가 갱신되면). **본 것이 저장된다.**
+         */
+        post: operations["apply_policy_update_policy_snapshot_apply_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/policy-snapshot/current": {
         parameters: {
             query?: never;
@@ -1330,6 +1588,79 @@ export interface paths {
         get: operations["get_current_policy_policy_snapshot_current_get"];
         put?: never;
         post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/policy-snapshot/history": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Policy History
+         * @description 버전 이력 — 최신이 앞. 비어 있으면 `items: []` (404 아님).
+         *
+         *     `current` 와 달리 404 를 내지 않는다: "아직 정책이 없다" 는 이력 화면에서 **정상 상태**
+         *     이고, 빈 목록으로 표현하는 게 클라이언트에 더 쉽다.
+         */
+        get: operations["get_policy_history_policy_snapshot_history_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/policy-snapshot/preview-update": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Preview Policy Update
+         * @description 다음 버전 후보 — **저장하지 않는다** (AGENTS §1 자동 적용 금지).
+         *
+         *     입력은 가장 최근 주간 요약(`period_summaries`). 아직 한 주도 집계 안 됐으면 KPI 없이
+         *     현재 값을 그대로 후보로 돌려준다(`changes: []`) — 그 자체가 "바꿀 근거가 아직 없다"다.
+         */
+        post: operations["preview_policy_update_policy_snapshot_preview_update_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/policy-snapshot/rollback/{version}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Rollback Policy
+         * @description 지난 버전의 값을 **새 버전으로** 되살린다.
+         *
+         *     옛 행의 `is_active` 를 다시 켜지 않는 이유: 그러면 그 행의 `valid_from` 이 최초 활성화
+         *     시각 그대로라 **언제 롤백했는지가 이력에서 사라진다.** 정책 이력은 감사 기록이므로
+         *     (ADR-0001 §3.2 append-only) 값을 복사한 새 행을 만들어 타임라인을 온전히 남긴다.
+         *     버전 번호는 계속 늘어난다 — v5 에서 v2 로 롤백하면 v2 의 값을 가진 v6 이 생긴다.
+         *
+         *     없는 버전은 404, 이미 활성인 버전은 409(같은 값을 한 번 더 쌓을 이유가 없다).
+         */
+        post: operations["rollback_policy_policy_snapshot_rollback__version__post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -1677,6 +2008,40 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/settings/delete-account": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Delete Account
+         * @description 계정 삭제 — 2단계 확인 (#321, FE #237 §4, Play Store 정책 요구).
+         *
+         *     `anonymize`(S28, 계정은 유지한 채 과거 텍스트만 마스킹)와는 다른 작업이다 — 이건 앱에
+         *     다시 들어올 수 없게 만드는 것까지 포함한다. hard delete 는 하지 않는다(AGENTS §2) —
+         *     같은 `anonymize_user()` PII 마스킹 위에 `archived_at` 을 얹어 **soft delete** 한다.
+         *
+         *     `archived_at` 을 세우는 순간 `UserRepo.get_by_id`/`get_by_email` 의 `archived_at IS NULL`
+         *     필터에 걸려, 이미 발급된 access token 은 다음 요청의 `get_current_user` 에서 그대로
+         *     401 `AUTH_INVALID_TOKEN` 이 된다 — 별도 access-token 블랙리스트가 필요 없다. refresh
+         *     token 은 `/auth/refresh` 가 이제 같은 필터로 사용자 존재를 확인하므로(이 PR 에서 함께
+         *     고침) 동일하게 막힌다.
+         *
+         *     email 도 함께 마스킹한다 — `email` 에 hard UNIQUE 제약이 있어(파샬 인덱스 아님) 원본을
+         *     남기면 그 이메일로 재가입이 영영 불가능해진다. `user.id` 는 유일하므로 유니크 제약을
+         *     깨지 않는 결정적 sentinel 로 치환.
+         */
+        post: operations["delete_account_settings_delete_account_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/settings/profile": {
         parameters: {
             query?: never;
@@ -1865,6 +2230,12 @@ export interface paths {
          *
          *     카드의 미종결 scheduled_block 이 있으면 사용, 없으면 즉석 블록 생성
          *     (source='user_edit'). 같은 카드의 in_progress 실행이 있으면 409.
+         *
+         *     카드는 **행 잠금으로 읽는다**(#368). 계획 교체·목표 완료가 같은 카드를 보관하는
+         *     중이면 여기서 기다렸다가 `archived_at IS NULL` 재평가에 걸려 404 로 끝난다 —
+         *     execution_events·scheduled_block 을 만들기 **전에** 걸러야 한다. 상태만 조건부로
+         *     막으면 실행 행이 남고, `list_pending_reflection` 은 `action_items` 에 join 하지
+         *     않으므로 그 실행이 회고 화면까지 새어 나간다.
          */
         post: operations["start_action_today_actions__action_id__start_post"];
         delete?: never;
@@ -2032,6 +2403,8 @@ export interface components {
             estimatedMinutes: number;
             /** Firststep */
             firstStep: string | null;
+            /** Missedcheckin */
+            missedCheckIn: boolean;
             /** Priority */
             priority: number;
             /** Source */
@@ -2353,6 +2726,68 @@ export interface components {
             ok: boolean;
         };
         /**
+         * DeleteAccountRequest
+         * @description POST /settings/delete-account 요청. `anonymize` 와 동일한 2단계 확인 모양.
+         */
+        DeleteAccountRequest: {
+            /** Confirmationtoken */
+            confirmationToken?: string | null;
+        };
+        /**
+         * DeleteAccountResponse
+         * @description 계정 삭제 응답. `status` 로 단계 구분.
+         *
+         *     - `confirmation_required` — 토큰 발급(미적용).
+         *     - `deleted` — 적용 완료. 이 응답을 받은 뒤로 이 access token 은 다음 요청부터
+         *       `AUTH_INVALID_TOKEN` 이다(계정 조회 자체가 soft-delete 필터에 걸린다) — 클라이언트는
+         *       곧바로 로그아웃 처리할 것.
+         */
+        DeleteAccountResponse: {
+            /** Confirmationtoken */
+            confirmationToken?: string | null;
+            /** Deletedat */
+            deletedAt?: string | null;
+            /** Expiresat */
+            expiresAt?: string | null;
+            /** Message */
+            message: string;
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "confirmation_required" | "deleted";
+        };
+        /**
+         * EffortMinutes
+         * @description 이번 주를 **분**으로 본 요약 (ADR-0009 D5).
+         *
+         *     `adherenceRate`(건수 비율) 옆에 나란히 둔다. 계획 세션 길이가 작업 내용을 따라가면
+         *     건수와 시간이 갈라진다 — 15분짜리 9개를 끝내고 3시간짜리 1개를 못 하면 건수로는 90%
+         *     지만 실제로는 절반도 못 한 주다.
+         *
+         *     `actualMinutes` 를 `completedMinutes` 와 나누면 "예상이 맞았나" 가 나온다
+         *     (1.0 = 예상대로, 1.3 = 30% 더 걸렸다). 둘 다 **완료한 실행**만 센다.
+         */
+        EffortMinutes: {
+            /**
+             * Actualminutes
+             * @default 0
+             */
+            actualMinutes: number;
+            /** Adherencerate */
+            adherenceRate?: number | null;
+            /**
+             * Completedminutes
+             * @default 0
+             */
+            completedMinutes: number;
+            /**
+             * Plannedminutes
+             * @default 0
+             */
+            plannedMinutes: number;
+        };
+        /**
          * ExecutionEventResponse
          * @description POST /today/focus/{id}/pause·resume 응답 — 집중 세션 일시정지/재개 (#83).
          *
@@ -2411,13 +2846,18 @@ export interface components {
         };
         /**
          * FailureTagRequest
-         * @description POST /reflection/failure-tags/{executionId} — 실패 사유 0~2개 + 메모.
+         * @description POST /reflection/failure-tags/{executionId} — 실패 사유 0~2개 + 메모 + 정서 1문항.
+         *
+         *     `task_aversiveness`(#299, FE #222): 이 일이 얼마나 하기 싫었는지 1(전혀 안 싫음)~5(매우
+         *     싫음). 선택 사항 — 강제하면 회고 이탈이 늘 것으로 보고 FE 가 선택으로 뒀다.
          */
         FailureTagRequest: {
             /** Memo */
             memo?: string | null;
             /** Tagcodes */
             tagCodes: string[];
+            /** Taskaversiveness */
+            taskAversiveness?: number | null;
         };
         /**
          * FailureTagResponse
@@ -2520,6 +2960,8 @@ export interface components {
              * @default true
              */
             isDraft: boolean;
+            /** Milestones */
+            milestones?: components["schemas"]["MilestoneDraft"][];
             /** Planid */
             planId: string;
             /** Policyviolations */
@@ -2654,6 +3096,35 @@ export interface components {
             whyNow?: string | null;
         };
         /**
+         * GoalCompletionProposal
+         * @description "이 목표 끝난 거 맞아요?" 제안 1건 (ADR-0007 6b).
+         *
+         *     마일스톤이 **전부** 완료된 목표에 대해 나간다. `NextCycleProposal` 과 **배타적**이다 —
+         *     같은 가드(`has_open_milestone`)의 양쪽 갈래라, 한 목표가 두 카드에 동시에 뜨지 않는다.
+         *
+         *     확정은 `POST /goals/{goalId}/complete`.
+         */
+        GoalCompletionProposal: {
+            /**
+             * Goalid
+             * Format: uuid
+             */
+            goalId: string;
+            /** Goaltitle */
+            goalTitle: string;
+        };
+        /**
+         * GoalCompletionRequest
+         * @description POST /goals/{goalId}/complete 요청 — 목표 완료 확정/해제 (ADR-0007 6b).
+         *
+         *     마일스톤 완료 표시(`PATCH /goals/{goalId}/nodes/{nodeId}`)와 **같은 모양**으로 뒀다 —
+         *     둘 다 "끝났다" 를 사용자가 확정하는 HITL 이고, 둘 다 오조작을 되돌릴 수 있어야 한다.
+         */
+        GoalCompletionRequest: {
+            /** Completed */
+            completed: boolean;
+        };
+        /**
          * GoalCreateRequest
          * @description POST /goals 요청.
          */
@@ -2696,6 +3167,8 @@ export interface components {
          *     `orderIndex` 없이는 FE 가 8칸 중 몇 번째인지 알 수 없다). 기존 소비 코드는 무변경.
          */
         GoalNode: {
+            /** Completedat */
+            completedAt?: string | null;
             /** Depth */
             depth: number;
             /** Isleaf */
@@ -2737,13 +3210,17 @@ export interface components {
         };
         /**
          * GoalUpdateRequest
-         * @description PATCH /goals/{id} 요청 — 제목·마감·우선순위·tier 변경.
+         * @description PATCH /goals/{id} 요청 — 제목·마감·우선순위·tier·category 변경.
+         *
+         *     `category` 는 `GoalCreateRequest.category` 와 같은 허용값·정규화 규칙을 쓴다(#326,
+         *     FE #216 차단 해소). 생략하면 기존 category 유지 — 재인터뷰 제안 트리거는 FE 가 저장
+         *     성공 후 실제로 값이 달라졌을 때만 띄운다(자동 재계획·강제 이동 없음).
          */
         GoalUpdateRequest: {
-            /** Deadline */
-            deadline?: string | null;
             /** Category */
             category?: string | null;
+            /** Deadline */
+            deadline?: string | null;
             /** Goaltier */
             goalTier?: ("focus" | "maintain" | "parked") | null;
             /** Prioritylevel */
@@ -2765,7 +3242,7 @@ export interface components {
         };
         /**
          * GoogleLoginRequest
-         * @description POST /auth/google 요청 — Google id_token.
+         * @description POST /auth/google 요청 — Google id_token (+ 신규 가입만 `inviteCode` 필요, #324).
          */
         GoogleLoginRequest: {
             /**
@@ -2773,6 +3250,11 @@ export interface components {
              * @description Google OAuth id_token
              */
             idToken: string;
+            /**
+             * Invitecode
+             * @description 신규 가입에만 필요. 기존 사용자 로그인은 무시된다.
+             */
+            inviteCode?: string | null;
         };
         /** HTTPValidationError */
         HTTPValidationError: {
@@ -2788,6 +3270,8 @@ export interface components {
             category: string;
             /** Frequencyperweek */
             frequencyPerWeek: number;
+            /** Goalnodeid */
+            goalNodeId?: string | null;
             /** Habitid */
             habitId: string;
             /** Minutespersession */
@@ -3154,11 +3638,11 @@ export interface components {
         JsonValue: unknown;
         /**
          * LogoutRequest
-         * @description POST /auth/logout 요청.
+         * @description POST /auth/logout 요청. `refreshToken` 생략 가능 — `RefreshRequest` 와 동일한 이유(#323).
          */
         LogoutRequest: {
             /** Refreshtoken */
-            refreshToken: string;
+            refreshToken?: string | null;
         };
         /**
          * MandalaApproveRequest
@@ -3288,6 +3772,53 @@ export interface components {
             subgoals: components["schemas"]["MandalaSubgoal"][];
         };
         /**
+         * MandalaHabitLinkRequest
+         * @description POST /goals/mandala/nodes/{nodeId}/habit(U12) 요청 — 반복형 칸으로 전환(ADR-0008 §1).
+         *
+         *     "코딩테스트 1일 1문제"·"쓰레기 줍기" 처럼 끝이 없는 leaf 칸에 새 `Habit` 을 만들어
+         *     링크한다. 계획(action_item)을 만들지 않고 이후 주간 횟수(habit_instances.done_count)로만
+         *     추적한다. `title` 을 생략하면 칸 제목을 그대로 쓴다.
+         */
+        MandalaHabitLinkRequest: {
+            /**
+             * Category
+             * @default other
+             * @enum {string}
+             */
+            category: "study" | "health" | "routine" | "self_dev" | "relationship" | "other";
+            /** Frequencyperweek */
+            frequencyPerWeek: number;
+            /** Minutespersession */
+            minutesPerSession: number;
+            /**
+             * Prioritylevel
+             * @default 3
+             */
+            priorityLevel: number;
+            /**
+             * Timepreference
+             * @default anytime
+             * @enum {string}
+             */
+            timePreference: "morning" | "afternoon" | "evening" | "anytime";
+            /** Title */
+            title?: string | null;
+        };
+        /**
+         * MandalaHabitWeekStat
+         * @description 만다라 반복형 칸 1개의 이번 주 체크인 현황.
+         */
+        MandalaHabitWeekStat: {
+            /** Axistitle */
+            axisTitle?: string | null;
+            /** Celltitle */
+            cellTitle: string;
+            /** Donecount */
+            doneCount: number;
+            /** Targetcount */
+            targetCount: number;
+        };
+        /**
          * MandalaNode
          * @description 만다라 노드 1개(U8 응답 원소, U9 응답 그대로) — `GoalNode` additive 확장(§6.2).
          *
@@ -3302,6 +3833,8 @@ export interface components {
             coverage: number | null;
             /** Depth */
             depth: number;
+            /** Habitid */
+            habitId: string | null;
             /** Isleaf */
             isLeaf: boolean;
             /** Locked */
@@ -3450,6 +3983,144 @@ export interface components {
             statement: string;
         };
         /**
+         * MandalaWeeklySummary
+         * @description `GET /reviews/weekly` 의 '이번 주 만다라트' 절 (ADR-0008 §8 "E").
+         *
+         *     조회 시점에 파생한다(저장 안 함) — 궁극목표가 없거나 아직 승인된 만다라 트리가 없으면
+         *     응답 자체에서 생략된다(`null`).
+         */
+        MandalaWeeklySummary: {
+            /** Completedthisweek */
+            completedThisWeek: number;
+            /** Completedtotal */
+            completedTotal: number;
+            /** Habits */
+            habits?: components["schemas"]["MandalaHabitWeekStat"][];
+            /** Totalleaves */
+            totalLeaves: number;
+            /** Touchedthisweek */
+            touchedThisWeek: number;
+            /** Untouchedaxistitles */
+            untouchedAxisTitles?: string[];
+        };
+        /**
+         * MaterialSource
+         * @description 검색이 실제로 참조한 출처 — 사용자에게 그대로 보여준다 (#259 ⑩).
+         *
+         *     출처를 숨기고 자료를 쓰면 다른 판·다른 강의를 가져왔을 때 사용자가 알아챌 방법이 없다.
+         */
+        MaterialSource: {
+            /** Title */
+            title: string;
+            /** Uri */
+            uri: string;
+        };
+        /**
+         * MaterialsConfirmRequest
+         * @description POST /plans/materials/confirm — "이 자료 맞아요".
+         *
+         *     `text` 를 그대로 받는 이유: 사용자가 **고쳐서** 보낼 수 있어야 한다. 검색이 다른 판을
+         *     가져왔거나 일부만 맞을 때 지우고 붙이는 게 HITL 의 핵심이다.
+         */
+        MaterialsConfirmRequest: {
+            /** Interviewsessionid */
+            interviewSessionId?: string | null;
+            /** Text */
+            text: string;
+        };
+        /**
+         * MaterialsConfirmResponse
+         * @description 확정 결과 — 명시 승인이므로 Draft 가 아니다 (ADR-0005 §7.2).
+         */
+        MaterialsConfirmResponse: {
+            /** Goaltitle */
+            goalTitle: string;
+            /** Notice */
+            notice: string;
+            /** Savedchars */
+            savedChars: number;
+        };
+        /**
+         * MaterialsQueryRequest
+         * @description POST /plans/materials/search-query.
+         */
+        MaterialsQueryRequest: {
+            /** Interviewsessionid */
+            interviewSessionId?: string | null;
+        };
+        /**
+         * MaterialsQueryResponse
+         * @description 제안된 검색어 — **아직 아무것도 검색하지 않았다.**
+         *
+         *     `is_draft` 를 쓰지 않는 이유: 이건 AI 산출물이 아니라 목표 제목에서 규칙으로 만든
+         *     문자열이다. LLM 도 외부 호출도 없으므로 Draft 표기 대상이 아니다.
+         */
+        MaterialsQueryResponse: {
+            /** Goaltitle */
+            goalTitle: string;
+            /** Notice */
+            notice: string;
+            /** Suggestedquery */
+            suggestedQuery: string;
+        };
+        /**
+         * MaterialsSearchRequest
+         * @description POST /plans/materials/search — **사용자가 확인·편집한 검색어만** 받는다 (① 결정).
+         *
+         *     목표 슬롯을 서버가 알아서 질의로 만들지 않는다. 무엇이 외부로 나가는지가 이 필드
+         *     하나로 결정되고, 사용자가 1단계에서 그걸 봤다.
+         */
+        MaterialsSearchRequest: {
+            /** Query */
+            query: string;
+        };
+        /**
+         * MaterialsSearchResponse
+         * @description 검색 결과 — **저장되지 않았다.** 3단계 확정 전까지는 아무 데도 안 남는다.
+         *
+         *     `is_draft=True` 가 그 계약이다 (AGENTS §1.4).
+         */
+        MaterialsSearchResponse: {
+            /**
+             * Aisource
+             * @default llm
+             * @enum {string}
+             */
+            aiSource: "llm" | "rule";
+            /**
+             * Isdraft
+             * @default true
+             */
+            isDraft: boolean;
+            /** Notice */
+            notice: string;
+            /** Remainingtoday */
+            remainingToday?: number | null;
+            /** Searchqueries */
+            searchQueries?: string[];
+            /** Sources */
+            sources?: components["schemas"]["MaterialSource"][];
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "found" | "not_found" | "blocked_copyright" | "quota_exceeded" | "unavailable";
+            /** Text */
+            text?: string | null;
+        };
+        /**
+         * MilestoneCompletionRequest
+         * @description PATCH /goals/{goalId}/nodes/{nodeId} 요청 — 마일스톤 완료 표시 (ADR-0007 §3 예외).
+         *
+         *     제목·요약은 여기서 못 고친다. 뼈대 편집은 마일스톤 확인 화면 → `generate` →
+         *     `approve` 경로 하나로 모여 있고(ADR-0007 PR-6a), 여기서도 고칠 수 있게 하면 같은
+         *     사실을 바꾸는 길이 둘이 된다.
+         */
+        MilestoneCompletionRequest: {
+            /** Completed */
+            completed: boolean;
+        };
+        /**
          * MilestoneDraft
          * @description 중간 목표(마일스톤) 한 개 — 사용자가 확인·편집하는 계획 뼈대 단위(#milestones Phase 2).
          *
@@ -3475,7 +4146,7 @@ export interface components {
              * @default llm
              * @enum {string}
              */
-            aiSource: "llm" | "rule";
+            aiSource: "llm" | "rule" | "saved";
             /** Milestones */
             milestones: components["schemas"]["MilestoneDraft"][];
         };
@@ -3492,6 +4163,22 @@ export interface components {
             fallbackUsed: boolean;
             /** Headline */
             headline: string;
+        };
+        /**
+         * NextCycleProposal
+         * @description 다음 2주 열기 제안 1건 (ADR-0008 §8 "G") — 승인은 기존 `/plans/generate`(빈 바디)
+         *     + `/plans/{id}/approve` 를 그대로 쓴다. 이 카드는 새 엔드포인트를 만들지 않는다.
+         */
+        NextCycleProposal: {
+            /** Axistitle */
+            axisTitle?: string | null;
+            /**
+             * Goalid
+             * Format: uuid
+             */
+            goalId: string;
+            /** Goaltitle */
+            goalTitle: string;
         };
         /**
          * NoTouchWindow
@@ -3555,6 +4242,133 @@ export interface components {
             currentState: string;
             /** Suggestednextscreen */
             suggestedNextScreen: string;
+        };
+        /**
+         * PolicyApplyRequest
+         * @description POST /policy-snapshot/apply — 사용자가 승인(또는 수정)한 4 영역.
+         *
+         *     `preview-update` 응답을 그대로 되보내면 룰 그대로 적용이고, 값을 고쳐 보내면 사용자
+         *     수정본이 적용된다 — `source` 로 어느 쪽인지 FE 가 알려준다(`/recovery/decisions` 의
+         *     accepted/edited 와 같은 관례: 사용자가 고쳤는지는 화면이 가장 잘 안다).
+         */
+        PolicyApplyRequest: {
+            /** Behavioralprofile */
+            behavioralProfile: {
+                [key: string]: unknown;
+            };
+            /** Executionconstraints */
+            executionConstraints: {
+                [key: string]: unknown;
+            };
+            /** Interactionstyle */
+            interactionStyle: {
+                [key: string]: unknown;
+            };
+            /** Reasonforupdate */
+            reasonForUpdate?: string | null;
+            /** Recoverypolicy */
+            recoveryPolicy: {
+                [key: string]: unknown;
+            };
+            /**
+             * Source
+             * @default rule
+             * @enum {string}
+             */
+            source: "rule" | "user_manual";
+        };
+        /**
+         * PolicyChangeItem
+         * @description 승인 화면에 보여줄 변경 한 줄 — **근거를 숫자로** 담는다.
+         */
+        PolicyChangeItem: {
+            /** After */
+            after: unknown;
+            /** Area */
+            area: string;
+            /** Before */
+            before: unknown;
+            /** Field */
+            field: string;
+            /** Why */
+            why: string;
+        };
+        /**
+         * PolicyHistoryItem
+         * @description GET /policy-snapshot/history 항목 — 4 영역 payload 는 빼고 메타만.
+         *
+         *     이력 화면은 "언제 무엇 때문에 바뀌었나" 를 보는 자리라, 버전마다 JSONB 4개를 전부
+         *     실어 보내면 응답만 커지고 화면은 안 쓴다. 특정 버전의 내용이 필요하면 롤백 미리보기
+         *     (`preview-update` 는 다음 버전용이므로) 대신 `history` 로 고르고 `rollback` 한다.
+         */
+        PolicyHistoryItem: {
+            /** Isactive */
+            isActive: boolean;
+            /** Reasonforupdate */
+            reasonForUpdate: string | null;
+            /** Source */
+            source: string;
+            /**
+             * Validfrom
+             * Format: date-time
+             */
+            validFrom: string;
+            /** Validto */
+            validTo: string | null;
+            /** Version */
+            version: number;
+        };
+        /** PolicyHistoryResponse */
+        PolicyHistoryResponse: {
+            /** Items */
+            items: components["schemas"]["PolicyHistoryItem"][];
+        };
+        /**
+         * PolicyPreviewResponse
+         * @description POST /policy-snapshot/preview-update — 다음 버전 후보 (Draft Layer).
+         *
+         *     **아무것도 저장하지 않는다** (AGENTS §1 자동 적용 금지). `isDraft=true` 로 내려가고,
+         *     사용자가 `POST /policy-snapshot/apply` 를 눌러야 INSERT 된다.
+         *
+         *     `changes` 가 비면 이번 주엔 바꿀 게 없다는 뜻이다 — FE 는 그때 [적용] 을 비활성화하면
+         *     된다(억지로 새 버전을 만들 이유가 없다).
+         */
+        PolicyPreviewResponse: {
+            /**
+             * Aisource
+             * @default llm
+             * @enum {string}
+             */
+            aiSource: "llm" | "rule";
+            /** Baseversion */
+            baseVersion: number | null;
+            /** Behavioralprofile */
+            behavioralProfile: {
+                [key: string]: unknown;
+            };
+            /** Changes */
+            changes: components["schemas"]["PolicyChangeItem"][];
+            /** Executionconstraints */
+            executionConstraints: {
+                [key: string]: unknown;
+            };
+            /** Interactionstyle */
+            interactionStyle: {
+                [key: string]: unknown;
+            };
+            /**
+             * Isdraft
+             * @default true
+             */
+            isDraft: boolean;
+            /** Nextversion */
+            nextVersion: number;
+            /** Reasonforupdate */
+            reasonForUpdate: string | null;
+            /** Recoverypolicy */
+            recoveryPolicy: {
+                [key: string]: unknown;
+            };
         };
         /**
          * PolicySnapshotResponse
@@ -3716,14 +4530,20 @@ export interface components {
          * @description 회복 옵션 카드 1장 — recovery_attempts 1행과 대응 (user_decision='pending').
          */
         RecoveryCard: {
+            /** Acknowledgment */
+            acknowledgment?: string | null;
             /** Allowrestmode */
             allowRestMode: boolean;
             /** Attemptid */
             attemptId: string;
+            /** Copingclause */
+            copingClause?: string | null;
             /** Labelko */
             labelKo: string;
             /** Minrecoveryunitminutes */
             minRecoveryUnitMinutes: number;
+            /** Obstacle */
+            obstacle?: string | null;
             /**
              * Optiongroup
              * @enum {string}
@@ -3746,6 +4566,11 @@ export interface components {
          *       AI 원문(`suggested_action_text`)은 보존한다 — "얼마나 고쳐 썼나"가 AI 품질 지표다.
          *       새 카드를 만들지 않는 그룹(RESCHEDULE/PARK)은 문구를 담을 곳이 없어 422.
          *     - `decision="skipped"` → 모든 pending 카드 skipped ("오늘은 쉬기").
+         *
+         *     `re_engagement_anchor_at`(#327, FE #221): PARK/CARRY_OVER 수락에만 유효(그 외 그룹에
+         *     보내면 422 — 조용히 버리면 사용자가 지정한 시점이 사라진 걸 못 알아챈다). 생략하면
+         *     서버가 전략별 기본값(`orchestrator.recovery.re_engagement_anchor_at`)을 계산한다.
+         *     시간대 정보(예: `+09:00`)를 포함한 ISO 8601 이어야 한다.
          */
         RecoveryDecisionRequest: {
             /** Acceptedattemptid */
@@ -3761,6 +4586,8 @@ export interface components {
             editedActionText?: string | null;
             /** Executionid */
             executionId: string;
+            /** Reengagementanchorat */
+            reEngagementAnchorAt?: string | null;
         };
         /**
          * RecoveryDecisionResponse
@@ -3776,6 +4603,8 @@ export interface components {
              * @default false
              */
             isDraft: boolean;
+            /** Reengagementanchorat */
+            reEngagementAnchorAt?: string | null;
             /** Rejectedattemptids */
             rejectedAttemptIds: string[];
             /** Resultingactionitemid */
@@ -3811,13 +4640,20 @@ export interface components {
              * @default true
              */
             isDraft: boolean;
+            /**
+             * Recoverymode
+             * @default standard
+             * @enum {string}
+             */
+            recoveryMode: "standard" | "goal_renegotiation";
         };
         /**
          * ReflectionBatchItem
          * @description POST /reflection/batch 항목 — 미체크 실행 1건의 최종 결과 + 선택적 실패 사유.
          *
-         *     `failure_tags`/`memo` 는 `completion_status` 가 failed/partial_done 일 때만 유효
-         *     (그 외 값과 함께 오면 422). `memo` 는 서버가 at-rest 암호화한다.
+         *     `failure_tags`/`memo`/`task_aversiveness`(#299) 는 `completion_status` 가
+         *     failed/partial_done 일 때만 유효(그 외 값과 함께 오면 422). `memo` 는 서버가 at-rest
+         *     암호화한다. `task_aversiveness` 는 태그 선택 여부와 무관하게 독립적으로 유효하다.
          */
         ReflectionBatchItem: {
             /**
@@ -3831,6 +4667,8 @@ export interface components {
             failureTags?: string[];
             /** Memo */
             memo?: string | null;
+            /** Taskaversiveness */
+            taskAversiveness?: number | null;
         };
         /**
          * ReflectionBatchRequest
@@ -3882,10 +4720,14 @@ export interface components {
         /**
          * RefreshRequest
          * @description POST /auth/refresh 요청.
+         *
+         *     `refreshToken` 생략 가능(#323) — 웹은 `reaction_refresh` httpOnly 쿠키로 대신 보낼 수
+         *     있다(로그인 시 서버가 body 와 쿠키에 **둘 다** 내려준다, 이행 기간). 본문·쿠키 둘 다
+         *     없으면 401 `AUTH_INVALID_TOKEN`.
          */
         RefreshRequest: {
             /** Refreshtoken */
-            refreshToken: string;
+            refreshToken?: string | null;
         };
         /**
          * ReplanApproveResponse
@@ -4118,6 +4960,23 @@ export interface components {
             slotKey: string;
         };
         /**
+         * StaleAxisProposal
+         * @description 3주 연속 손 못 댄 축 — "줄이거나 바꾸자" 제안 1건 (ADR-0008 §6, §8 "H").
+         *
+         *     수정 수단은 이미 있는 것을 그대로 쓴다 — 이 카드는 새 엔드포인트를 만들지 않는다.
+         *     칸/축 텍스트는 `PATCH /goals/mandala/nodes/{id}`, 축 8칸 재생성은
+         *     `POST /plans/mandala/{planId}/regenerate-branch`.
+         */
+        StaleAxisProposal: {
+            /**
+             * Axisid
+             * Format: uuid
+             */
+            axisId: string;
+            /** Axistitle */
+            axisTitle: string;
+        };
+        /**
          * StartSessionRequest
          * @description POST /interview/sessions 요청 — kind 생략 시 계획 인터뷰(하위호환, U0b).
          */
@@ -4225,6 +5084,24 @@ export interface components {
              * @enum {string}
              */
             toneMode: "gentle" | "strict" | "encouraging";
+        };
+        /**
+         * TopFailureContext
+         * @description 실패 사유 상위 3개(BCT 2.3 Self-monitoring, 근거 A5) — #301.
+         *
+         *     `labelKo` 는 `/reflection/failure-tags` 와 같은 마스터(`failure_reason_tags`)에서 온다
+         *     (이중 관리 방지). `share` 는 0~1 비율이고, LIMIT 이전(태그 전체)을 분모로 하므로 반환된
+         *     3건의 share 합이 1.0 이 아닐 수 있다(태그가 4개 이상인 주).
+         */
+        TopFailureContext: {
+            /** Count */
+            count: number;
+            /** Labelko */
+            labelKo: string;
+            /** Share */
+            share: number;
+            /** Tagcode */
+            tagCode: string;
         };
         /**
          * UltimateGoalOutcome
@@ -4469,11 +5346,17 @@ export interface components {
             consistencyDays?: number | null;
             /** Drainwindow */
             drainWindow?: string | null;
+            effort?: components["schemas"]["EffortMinutes"];
             /**
              * Generatedat
              * Format: date-time
              */
             generatedAt: string;
+            /** Goalcompletionproposals */
+            goalCompletionProposals?: components["schemas"]["GoalCompletionProposal"][];
+            mandala?: components["schemas"]["MandalaWeeklySummary"] | null;
+            /** Nextcycleproposals */
+            nextCycleProposals?: components["schemas"]["NextCycleProposal"][];
             /** Oneliner */
             oneLiner?: string | null;
             /** Peakwindow */
@@ -4488,6 +5371,10 @@ export interface components {
             resilienceRate?: number | null;
             /** Restartsuccessrate */
             restartSuccessRate?: number | null;
+            /** Staleaxisproposals */
+            staleAxisProposals?: components["schemas"]["StaleAxisProposal"][];
+            /** Topfailurecontexts */
+            topFailureContexts?: components["schemas"]["TopFailureContext"][];
             /**
              * Weekend
              * Format: date
@@ -4546,7 +5433,9 @@ export interface operations {
             query?: never;
             header?: never;
             path?: never;
-            cookie?: never;
+            cookie?: {
+                reaction_refresh?: string | null;
+            };
         };
         requestBody: {
             content: {
@@ -4608,7 +5497,9 @@ export interface operations {
             query?: never;
             header?: never;
             path?: never;
-            cookie?: never;
+            cookie?: {
+                reaction_refresh?: string | null;
+            };
         };
         requestBody: {
             content: {
@@ -5035,6 +5926,74 @@ export interface operations {
             };
         };
     };
+    link_mandala_habit_goals_mandala_nodes__node_id__habit_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                node_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["MandalaHabitLinkRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Habit"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    unlink_mandala_habit_goals_mandala_nodes__node_id__habit_delete: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                node_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     promote_mandala_node_goals_mandala_nodes__node_id__promote_post: {
         parameters: {
             query?: never;
@@ -5175,6 +6134,43 @@ export interface operations {
             };
         };
     };
+    complete_goal_goals__goal_id__complete_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                goal_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["GoalCompletionRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Goal"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     get_mandala_tree_goals__goal_id__mandala_get: {
         parameters: {
             query?: never;
@@ -5228,6 +6224,44 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["GoalDecomposition"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_milestone_completion_goals__goal_id__nodes__node_id__patch: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                goal_id: string;
+                node_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["MilestoneCompletionRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GoalNode"];
                 };
             };
             /** @description Validation Error */
@@ -6164,6 +7198,37 @@ export interface operations {
             };
         };
     };
+    mark_notification_opened_notifications__notification_id__opened_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                notification_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     get_onboarding_status_onboarding_status_get: {
         parameters: {
             query?: never;
@@ -6394,6 +7459,111 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["MandalaDraftResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    confirm_materials_plans_materials_confirm_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["MaterialsConfirmRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MaterialsConfirmResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    search_materials_plans_materials_search_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["MaterialsSearchRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MaterialsSearchResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    propose_search_query_plans_materials_search_query_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["MaterialsQueryRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MaterialsQueryResponse"];
                 };
             };
             /** @description Validation Error */
@@ -6674,6 +7844,41 @@ export interface operations {
             };
         };
     };
+    apply_policy_update_policy_snapshot_apply_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PolicyApplyRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PolicySnapshotResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     get_current_policy_policy_snapshot_current_get: {
         parameters: {
             query?: never;
@@ -6687,6 +7892,101 @@ export interface operations {
         responses: {
             /** @description Successful Response */
             200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PolicySnapshotResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_policy_history_policy_snapshot_history_get: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PolicyHistoryResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    preview_policy_update_policy_snapshot_preview_update_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PolicyPreviewResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    rollback_policy_policy_snapshot_rollback__version__post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                version: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            201: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -7226,6 +8526,41 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AnonymizeResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_account_settings_delete_account_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["DeleteAccountRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DeleteAccountResponse"];
                 };
             };
             /** @description Validation Error */

--- a/src/types/openapi.d.ts
+++ b/src/types/openapi.d.ts
@@ -2742,6 +2742,8 @@ export interface components {
         GoalUpdateRequest: {
             /** Deadline */
             deadline?: string | null;
+            /** Category */
+            category?: string | null;
             /** Goaltier */
             goalTier?: ("focus" | "maintain" | "parked") | null;
             /** Prioritylevel */


### PR DESCRIPTION
## 변경 사항

- 마일스톤 확인 다음, 주간 계획 생성 직전에 자료 검색 선택 단계를 연결했습니다.
- 검색어 제안 → 사용자 확인/편집 → 검색 → 결과 확인/편집 → 명시적 확정의 3단계 HITL을 구현했습니다.
- `found`, `not_found`, `blocked_copyright`, `quota_exceeded`, `unavailable` 상태별 다음 행동을 안내합니다.
- 각 단계에서 자료 없이 계획 생성을 계속할 수 있습니다.
- backend main과 `auto/api-sync`의 최신 OpenAPI 계약을 반영했습니다.

## 검증

- `npm run build`
- `npm run check:api` (WARN/GONE 0)
- `npm run check:fields` (PHANTOM/MISREF 0)
- `git diff --check`

Closes #259
