### PR TITLE
[inbox] 모바일에서 카드 전체를 상세 열기 영역으로 개선

### DIFF
--- a/src/components/InboxItemCard.tsx
+++ b/src/components/InboxItemCard.tsx
@@ -18,6 +18,9 @@ export interface InboxItemCardProps {
   aiCategory?: string;
   /** 우측 정렬 액션 버튼들. */
   actions?: React.ReactNode;
+  /** 카드 전체를 눌렀을 때 실행할 기본 동작. 상세가 있는 카드에만 전달한다. */
+  onOpen?: () => void;
+  openLabel?: string;
 }
 
 /**
@@ -26,9 +29,21 @@ export interface InboxItemCardProps {
  * 원문은 손대지 않고 그대로 보여준다 — AI 가 추측한 분류는 배지로만 옆에 붙여서,
  * 사용자가 그 추측을 그냥 받아들일지 무시할지 고르게 한다.
  */
-export function InboxItemCard({ text, badges = [], aiCategory, actions }: InboxItemCardProps) {
+export function InboxItemCard({ text, badges = [], aiCategory, actions, onOpen, openLabel = '관련 내용 보기' }: InboxItemCardProps) {
+  const interactive = Boolean(onOpen);
   return (
     <div
+      role={interactive ? 'button' : undefined}
+      tabIndex={interactive ? 0 : undefined}
+      aria-label={interactive ? `${text}, ${openLabel}` : undefined}
+      onClick={onOpen}
+      onKeyDown={(event) => {
+        if (!onOpen || event.target !== event.currentTarget) return;
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          onOpen();
+        }
+      }}
       style={{
         background: 'var(--surface-raised)',
         border: '1px solid var(--sand-200)',
@@ -37,6 +52,7 @@ export function InboxItemCard({ text, badges = [], aiCategory, actions }: InboxI
         display: 'flex',
         flexDirection: 'column',
         gap: 8,
+        cursor: interactive ? 'pointer' : undefined,
       }}
     >
       <div style={{ fontSize: 13, color: 'var(--text-1)', lineHeight: 1.5 }}>{text}</div>
@@ -82,8 +98,15 @@ export function InboxItemCard({ text, badges = [], aiCategory, actions }: InboxI
           </span>
         )}
         <div style={{ flex: 1 }} />
-        {actions}
+        <div onClick={(event) => event.stopPropagation()} onKeyDown={(event) => event.stopPropagation()} style={{ display: 'contents' }}>
+          {actions}
+        </div>
       </div>
+      {interactive && (
+        <div aria-hidden="true" style={{ fontSize: 11, fontWeight: 700, color: 'var(--coral-700)', alignSelf: 'flex-end' }}>
+          {openLabel} →
+        </div>
+      )}
     </div>
   );
 }
@@ -103,7 +126,7 @@ export function InboxAction({ children, onClick, icon, tone = 'quiet' }: InboxAc
     <button
       onClick={onClick}
       style={{
-        height: 26,
+        minHeight: 44,
         padding: '0 10px',
         borderRadius: 9999,
         border: `1px solid ${brand ? 'var(--coral-200)' : 'var(--sand-200)'}`,

--- a/src/screens/InboxScreen.tsx
+++ b/src/screens/InboxScreen.tsx
@@ -369,6 +369,8 @@ export function InboxScreen() {
             <InboxItemCard
               key={it.inboxId}
               text={it.rawText}
+              onOpen={isResource && status !== 'archived' ? () => openResource(it) : undefined}
+              openLabel="자료 열기"
               aiCategory={it.aiCategoryGuess ? categoryLabel(it.aiCategoryGuess) : undefined}
               badges={
                 isResource
@@ -385,11 +387,6 @@ export function InboxScreen() {
               }
               actions={
                 <>
-                  {isResource && status !== 'archived' && (
-                    <InboxAction tone="brand" icon={<BookOpen size={11} weight="fill" />} onClick={() => openResource(it)}>
-                      열기
-                    </InboxAction>
-                  )}
                   {!isResource && status !== 'promoted' && status !== 'archived' && (
                     <>
                       <InboxAction icon={<ListChecks size={11} weight="fill" />} onClick={() => convertToAction(it.inboxId)}>
@@ -413,7 +410,7 @@ export function InboxScreen() {
                   {status !== 'archived' && (
                     <button
                       onClick={() => archive(it.inboxId)}
-                      style={{ width: 26, height: 26, borderRadius: 9999, border: 'none', background: 'transparent', color: 'var(--text-3)', cursor: 'pointer', display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}
+                      style={{ width: 44, height: 44, borderRadius: 9999, border: 'none', background: 'transparent', color: 'var(--text-3)', cursor: 'pointer', display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}
                       aria-label="보관"
                       title="보관"
                     >


### PR DESCRIPTION
Closes #275

- 추천 자료 카드 전체 클릭/터치로 상세 열기
- Enter/Space 키보드 접근 지원
- 내부 액션 이벤트 충돌 방지
- 보조 액션 최소 44px 터치 영역

검증: npm run build, npm run check:fields