### PR TITLE
[today] 일정 시작 카운트다운 초 단위 실시간 표시

### DIFF
--- a/src/screens/TodayScreen.tsx
+++ b/src/screens/TodayScreen.tsx
@@ -226,16 +226,17 @@ function todayShortKo(): string {
   return `${d.getMonth() + 1}월 ${d.getDate()}일 · ${days[d.getDay()]}요일`;
 }
 
-// 미래 주간 일정의 시작까지 남은 시간. 화면은 1분마다 nudgeNow 를 갱신하므로
-// 별도 interval 없이 CTA 카운트다운도 같은 주기로 자연스럽게 줄어든다.
+// 미래 주간 일정의 시작까지 남은 시간. 초 단위 변화가 보이도록 별도 시계를 사용한다.
 function startCountdownLabel(scheduledAt: string, now: Date): string {
-  const remainingMinutes = Math.max(1, Math.ceil((new Date(scheduledAt).getTime() - now.getTime()) / 60_000));
-  const days = Math.floor(remainingMinutes / (24 * 60));
-  const hours = Math.floor((remainingMinutes % (24 * 60)) / 60);
-  const minutes = remainingMinutes % 60;
-  if (days > 0) return `${days}일${hours > 0 ? ` ${hours}시간` : ''} 후 시작`;
-  if (hours > 0) return `${hours}시간${minutes > 0 ? ` ${minutes}분` : ''} 후 시작`;
-  return `${minutes}분 후 시작`;
+  const remainingSeconds = Math.max(0, Math.ceil((new Date(scheduledAt).getTime() - now.getTime()) / 1_000));
+  const days = Math.floor(remainingSeconds / 86_400);
+  const hours = Math.floor((remainingSeconds % 86_400) / 3_600);
+  const minutes = Math.floor((remainingSeconds % 3_600) / 60);
+  const seconds = remainingSeconds % 60;
+  if (remainingSeconds === 0) return '곧 시작';
+  if (days > 0) return `${days}일 ${hours}시간 ${minutes}분 ${seconds}초 후 시작`;
+  if (hours > 0) return `${hours}시간 ${minutes}분 ${seconds}초 후 시작`;
+  return `${minutes}분 ${seconds}초 후 시작`;
 }
 
 export function MergedTodayScreen({ tasks: allTasks, onOpen, onMarkDone, onPartial, onFail, onOpenRecovery, onEvening, onAgendaLoaded, onUncheckedChange }: MergedTodayScreenProps) {
@@ -317,6 +318,12 @@ export function MergedTodayScreen({ tasks: allTasks, onOpen, onMarkDone, onParti
   const [nudgeNow, setNudgeNow] = useState(() => new Date());
   useEffect(() => {
     const id = setInterval(() => setNudgeNow(new Date()), 60_000);
+    return () => clearInterval(id);
+  }, []);
+  // 체크인 목록 계산은 1분 주기로 유지하고, 화면의 카운트다운만 가볍게 매초 갱신한다.
+  const [countdownNow, setCountdownNow] = useState(() => new Date());
+  useEffect(() => {
+    const id = setInterval(() => setCountdownNow(new Date()), 1_000);
     return () => clearInterval(id);
   }, []);
   // dismiss 는 localStorage 만 건드리고 tasks/weeklyPlan 을 바꾸지 않아 useMemo 가
@@ -549,9 +556,9 @@ export function MergedTodayScreen({ tasks: allTasks, onOpen, onMarkDone, onParti
   // 사용자가 row 를 클릭해 다른 카드를 보고 싶다는 의사를 명시했으면 그것이 최우선.
   const heroTask =
     tasks.find((t) => t.id === selectedTaskId) ?? activeTask ?? pendingTasks[0] ?? null;
-  const heroStartsLater = !!heroTask?.scheduledAt && new Date(heroTask.scheduledAt).getTime() > nudgeNow.getTime();
+  const heroStartsLater = !!heroTask?.scheduledAt && new Date(heroTask.scheduledAt).getTime() > countdownNow.getTime();
   const futureStartLabel = heroStartsLater && heroTask?.scheduledAt
-    ? startCountdownLabel(heroTask.scheduledAt, nudgeNow)
+    ? startCountdownLabel(heroTask.scheduledAt, countdownNow)
     : undefined;
 
   // C안: 히어로 아래 나머지 일은 카드 더미가 아니라 시간축으로 읽힌다.


### PR DESCRIPTION
## 변경
- 미래 일정 시작까지 남은 시간을 일·시·분·초로 표시
- 카운트다운만 1초마다 갱신하고 체크인 계산은 기존 1분 주기 유지
- 0초 도달 시 미래 CTA 비활성 상태 해제

## 검증
- npm run build