### PR TITLE
feat: show explicit execution outcomes on Today

### DIFF
--- a/src/components/TaskRow.tsx
+++ b/src/components/TaskRow.tsx
@@ -52,6 +52,15 @@ export function TaskRow({
   const failed = task.status === 'failed';
   const partial = task.status === 'partial_done' || task.status === 'recovery_pending';
   const inProgress = task.status === 'in_progress';
+  const resultLabel = done
+    ? '완료'
+    : failed
+      ? '실패'
+      : task.status === 'recovery_pending'
+        ? '회복 대기'
+        : partial
+          ? '일부 완료'
+          : null;
   const onClick = !interactive || done ? undefined : failed ? onFailedRecover : partial ? onPartialRecover : onSelect;
   const shownTime = time ?? task.time;
   const shownDur = dur ?? task.dur;
@@ -98,18 +107,27 @@ export function TaskRow({
         )}
       </span>
       <span style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 2 }}>
-        <span
-          style={{
-            fontSize: 14,
-            color: done ? 'var(--text-3)' : failed ? 'var(--danger-ink)' : 'var(--text-1)',
-            textDecoration: done ? 'line-through' : 'none',
-            whiteSpace: 'nowrap',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            fontWeight: partial ? 600 : 500,
-          }}
-        >
-          {task.title}
+        <span style={{ display: 'flex', alignItems: 'center', gap: 7, minWidth: 0 }}>
+          <span
+            style={{
+              flex: 1,
+              minWidth: 0,
+              fontSize: 14,
+              color: done ? 'var(--text-3)' : failed ? 'var(--danger-ink)' : 'var(--text-1)',
+              textDecoration: done ? 'line-through' : 'none',
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              fontWeight: partial ? 600 : 500,
+            }}
+          >
+            {task.title}
+          </span>
+          {resultLabel && (
+            <span style={{ flexShrink: 0, minHeight: 22, padding: '0 8px', borderRadius: 9999, display: 'inline-flex', alignItems: 'center', background: done ? '#E5EFE3' : failed ? '#FBE5E2' : 'var(--brand-soft)', color: done ? 'var(--success-ink)' : failed ? 'var(--danger-ink)' : 'var(--brand-ink)', fontSize: 10, fontWeight: 800 }}>
+              {resultLabel}
+            </span>
+          )}
         </span>
         {/* 히어로 카드와 같은 정보를 같은 순서로 — 목록에서도 "얼마나·무슨 목표"가 읽히게. */}
         {hasMeta && (

--- a/src/components/TodayTimeline.tsx
+++ b/src/components/TodayTimeline.tsx
@@ -1,3 +1,4 @@
+import { useId } from 'react';
 import type { Task } from '../types';
 import { TaskRow } from './TaskRow';
 
@@ -28,12 +29,13 @@ function statusColor(task: Task): string {
 
 /** 홈 C안의 시간축 목록. 카드 묶음보다 오늘이 어떤 순서로 흐르는지를 먼저 읽게 한다. */
 export function TodayTimeline({ items, title = '오늘의 타임라인', orderLabel = '시간순', interactive = true, onSelect, onFailedRecover, onPartialRecover }: TodayTimelineProps) {
+  const titleId = useId();
   if (items.length === 0) return null;
 
   return (
-    <section aria-labelledby="today-timeline-title">
+    <section aria-labelledby={titleId}>
       <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', marginBottom: 8 }}>
-        <h2 id="today-timeline-title" style={{ margin: 0, fontSize: 14, fontWeight: 750, color: 'var(--text-1)' }}>{title}</h2>
+        <h2 id={titleId} style={{ margin: 0, fontSize: 14, fontWeight: 750, color: 'var(--text-1)' }}>{title}</h2>
         <span style={{ fontSize: 11, color: 'var(--text-3)' }}>{orderLabel}</span>
       </div>
       <div style={{ display: 'flex', flexDirection: 'column' }}>

--- a/src/screens/TodayScreen.tsx
+++ b/src/screens/TodayScreen.tsx
@@ -118,6 +118,8 @@ function actionStatusToTaskStatus(s: string): TaskStatus {
   switch (s) {
     case 'in_progress':
     case 'done':
+    case 'over_done':
+      return 'done';
     case 'partial_done':
     case 'failed':
     case 'recovery_pending':
@@ -553,7 +555,7 @@ export function MergedTodayScreen({ tasks: allTasks, onOpen, onMarkDone, onParti
   const partialTask = partialSheet ? tasks.find((t) => t.id === partialSheet) : null;
 
   const activeTask = tasks.find((t) => t.status === 'in_progress');
-  const pendingTasks = tasks.filter((t) => t.status === 'todo' || t.status === 'partial_done' || t.status === 'recovery_pending');
+  const pendingTasks = tasks.filter((t) => t.status === 'todo');
   // Hero 우선순위: ① 사용자가 선택(promote)한 카드 ② 진행 중 카드 ③ 첫 대기 카드.
   // 사용자가 row 를 클릭해 다른 카드를 보고 싶다는 의사를 명시했으면 그것이 최우선.
   const heroTask =
@@ -565,8 +567,7 @@ export function MergedTodayScreen({ tasks: allTasks, onOpen, onMarkDone, onParti
 
   // C안: 히어로 아래 나머지 일은 카드 더미가 아니라 시간축으로 읽힌다.
   // 시간 있는 항목만 먼저 오름차순, 미정 항목은 서버가 준 상대 순서를 유지한다.
-  const timelineTasks = tasks
-    .filter((t) => t.id !== heroTask?.id)
+  const sortedTimelineTasks = tasks
     .map((task, index) => ({ task, index, meta: metaFor(task) }))
     .sort((a, b) => {
       const at = a.meta.time ?? a.task.time;
@@ -576,6 +577,15 @@ export function MergedTodayScreen({ tasks: allTasks, onOpen, onMarkDone, onParti
       if (bt) return 1;
       return a.index - b.index;
     });
+  const timelineTasks = sortedTimelineTasks.filter(({ task }) =>
+    task.id !== heroTask?.id && (task.status === 'todo' || task.status === 'in_progress'),
+  );
+  const executionHistory = sortedTimelineTasks.filter(({ task }) =>
+    task.status === 'done'
+    || task.status === 'failed'
+    || task.status === 'partial_done'
+    || task.status === 'recovery_pending',
+  );
 
   // 히어로 카드가 화면 밖으로 나가면 상단 스트립을 띄운다(#214). 스트립이 가리키는 카드는
   // 항상 heroTask 그 자체다 — 선정 로직을 복제하면 언젠가 조용히 어긋난다.
@@ -709,27 +719,39 @@ export function MergedTodayScreen({ tasks: allTasks, onOpen, onMarkDone, onParti
           <>
             {/* Hero — 지금 할 일. row 에서 promote 한 카드 또는 진행 중 카드.
                 ref 는 상단 스트립 노출 판정(IntersectionObserver)용. */}
-            <div ref={heroRef}>
-            <HeroTaskCard
-              task={heroTask}
-              done={doneTasks.length}
-              total={tasks.length}
-              {...(heroTask ? metaFor(heroTask) : {})}
-              onComplete={() => heroTask && (onMarkDone(heroTask.id), showToast('완료!'))}
-              onPartial={() => heroTask && setPartialSheet(heroTask.id)}
-              onFail={() => heroTask && (setFailSheet(heroTask.id), setFailTags([]), setFailMemo(''))}
-              onStart={(id) => onOpen(id)}
-              startDisabled={heroStartsLater}
-              startLabel={heroStartsLater ? futureStartLabel : undefined}
-              onDetail={() => heroTask && setDetailTask(heroTask)}
-            />
-            </div>
+            {heroTask && (
+              <div ref={heroRef}>
+                <HeroTaskCard
+                  task={heroTask}
+                  done={doneTasks.length}
+                  total={tasks.length}
+                  {...metaFor(heroTask)}
+                  onComplete={() => (onMarkDone(heroTask.id), showToast('완료!'))}
+                  onPartial={() => setPartialSheet(heroTask.id)}
+                  onFail={() => (setFailSheet(heroTask.id), setFailTags([]), setFailMemo(''))}
+                  onStart={(id) => onOpen(id)}
+                  startDisabled={heroStartsLater}
+                  startLabel={heroStartsLater ? futureStartLabel : undefined}
+                  onDetail={() => setDetailTask(heroTask)}
+                />
+              </div>
+            )}
 
             {/* C안 — 나머지 할 일을 예정 시각 기준의 하루 타임라인으로 보여준다. */}
             <TodayTimeline
               items={timelineTasks.map(({ task, meta }) => ({ task, ...meta }))}
               title={usingWeeklyFallback ? '이번 주 남은 일정' : '오늘의 타임라인'}
               orderLabel={usingWeeklyFallback ? '예정순' : '시간순'}
+              interactive={!usingWeeklyFallback}
+              onSelect={setSelectedTaskId}
+              onFailedRecover={onFail}
+              onPartialRecover={onOpenRecovery}
+            />
+
+            <TodayTimeline
+              items={executionHistory.map(({ task, meta }) => ({ task, ...meta }))}
+              title="오늘 실행 기록"
+              orderLabel={`${executionHistory.length}건`}
               interactive={!usingWeeklyFallback}
               onSelect={setSelectedTaskId}
               onFailedRecover={onFail}


### PR DESCRIPTION
## Summary
- split actionable timeline items from a dedicated 오늘 실행 기록 section
- show explicit 완료, 일부 완료, 실패, 회복 대기 labels instead of relying on color and icons
- map backend over_done outcomes to completed in the Today UI
- avoid rendering an empty hero when every task is already terminal
- give each timeline section a unique accessible heading id

## Validation
- TypeScript check
- production build
- git diff --check