### PR TITLE
[weekly-plan] 모바일 일정 드래그와 스크롤 충돌 방지

### DIFF
--- a/src/components/WeekGrid.tsx
+++ b/src/components/WeekGrid.tsx
@@ -45,6 +45,8 @@ export interface WeekGridProps {
   loading?: boolean;
   /** 블록을 누르거나 끌기 시작할 때. 드래그/탭 분기는 호출한 쪽에서 판단한다. */
   onBlockPointerDown?: (e: React.PointerEvent, block: WeekGridBlock) => void;
+  /** 키보드로 블록을 실행할 때. 포인터 탭과 같은 편집 화면을 연다. */
+  onBlockActivate?: (block: WeekGridBlock) => void;
   /**
    * 보여줄 요일 칸(0=월 … 6=일). 없으면 7일 전부. 여기 없는 칸의 블록은 렌더하지 않는다.
    * 지금 두 화면 모두 7일 전부를 넘긴다 — 좁아서 제목이 깨지던 문제는 칸을 줄이거나
@@ -146,6 +148,7 @@ export function WeekGrid({
   timeWidth = 30,
   loading = false,
   onBlockPointerDown,
+  onBlockActivate,
   visibleCols,
   scrollRef,
 }: WeekGridProps) {
@@ -227,6 +230,12 @@ export function WeekGrid({
       <button
         key={b.id + (seg.tail ? '-tail' : '')}
         onPointerDown={(e) => onBlockPointerDown?.(e, b)}
+        onClick={(e) => {
+          // 포인터 탭은 호출부의 pointerup 이 처리한다. 키보드/보조기술이 만든
+          // detail=0 클릭만 별도 경로로 열어 중복 실행을 피한다.
+          if (e.detail === 0) onBlockActivate?.(b);
+        }}
+        aria-label={`${b.title}${b.subLabel ? `, ${b.subLabel}` : ''}. 탭하면 수정, 모바일에서는 길게 눌러 끌면 이동`}
         style={{
           ...common,
           cursor: b.fixed ? 'pointer' : b.dragging ? 'grabbing' : 'grab',
@@ -235,8 +244,9 @@ export function WeekGrid({
           opacity: b.dragging ? 0.85 : 1,
           boxShadow: b.dragging ? 'var(--shadow-lg)' : 'none',
           zIndex: b.dragging ? 10 : 1,
-          // 모바일에서 세로 스크롤과 드래그가 싸우지 않게 한다.
-          touchAction: 'none',
+          // 터치는 화면 스크롤이 기본이다. 호출부가 길게 누르기를 확인한 뒤에만
+          // 드래그를 활성화하므로, 여기서 브라우저 제스처를 선제적으로 막지 않는다.
+          touchAction: 'manipulation',
           transition: b.dragging ? 'none' : 'box-shadow 120ms',
         }}
       >

--- a/src/screens/WeeklyCalendarScreen.tsx
+++ b/src/screens/WeeklyCalendarScreen.tsx
@@ -388,19 +388,47 @@ export function WeeklyCalendarScreenV2() {
   // pointerdown 핸들러 — 블록에 등록.
   const handleBlockPointerDown = (e: React.PointerEvent, block: BlockWithStatus) => {
     if (block.fixed) return; // 고정 블록은 드래그 불가.
-    e.preventDefault();
     e.stopPropagation();
+    if (e.pointerType === 'mouse' && e.button !== 0) return;
+    const isTouch = e.pointerType === 'touch';
+    if (!isTouch) e.preventDefault();
     const startX = e.clientX;
     const startY = e.clientY;
     const startDay = block.day;
     const startMinute = parseMin(block.time);
     dragMovedRef.current = false;
     const targetEl = e.currentTarget as HTMLElement;
-    targetEl.setPointerCapture(e.pointerId);
+    let dragEnabled = !isTouch;
+    let cancelled = false;
+    let timer: number | null = isTouch ? window.setTimeout(() => {
+      if (cancelled) return;
+      dragEnabled = true;
+      timer = null;
+      targetEl.setPointerCapture(e.pointerId);
+      showToast('이제 끌어서 시간을 옮길 수 있어요');
+    }, 300) : null;
+
+    const blockScrollWhileDragging = (ev: TouchEvent) => {
+      if (dragEnabled && !cancelled) ev.preventDefault();
+    };
+
+    const cleanup = () => {
+      cancelled = true;
+      if (timer != null) window.clearTimeout(timer);
+      targetEl.removeEventListener('pointermove', onMove);
+      targetEl.removeEventListener('pointerup', onUp);
+      targetEl.removeEventListener('pointercancel', onCancel);
+      window.removeEventListener('touchmove', blockScrollWhileDragging);
+    };
 
     const onMove = (ev: PointerEvent) => {
       const dx = ev.clientX - startX;
       const dy = ev.clientY - startY;
+      if (!dragEnabled) {
+        // 길게 누르기 전에 손가락이 움직이면 드래그 후보를 버리고 스크롤에 양보한다.
+        if (Math.hypot(dx, dy) > 8) cleanup();
+        return;
+      }
       if (!dragMovedRef.current && Math.hypot(dx, dy) > 5) {
         dragMovedRef.current = true;
       }
@@ -413,9 +441,7 @@ export function WeeklyCalendarScreenV2() {
     };
 
     const onUp = (ev: PointerEvent) => {
-      targetEl.removeEventListener('pointermove', onMove);
-      targetEl.removeEventListener('pointerup', onUp);
-      targetEl.removeEventListener('pointercancel', onUp);
+      cleanup();
       // 움직임 없었으면 = 클릭 → 편집 sheet.
       if (!dragMovedRef.current) {
         setEditing(block);
@@ -433,9 +459,15 @@ export function WeeklyCalendarScreenV2() {
       commitMove(block, newDay, newMinute);
     };
 
+    const onCancel = () => {
+      cleanup();
+      setDragGhost(null);
+    };
+
     targetEl.addEventListener('pointermove', onMove);
     targetEl.addEventListener('pointerup', onUp);
-    targetEl.addEventListener('pointercancel', onUp);
+    targetEl.addEventListener('pointercancel', onCancel);
+    window.addEventListener('touchmove', blockScrollWhileDragging, { passive: false });
   };
 
   // 조작법은 상시 배너 대신 최초 1회만 알려준다.
@@ -446,7 +478,7 @@ export function WeeklyCalendarScreenV2() {
       if (localStorage.getItem(HINT_KEY)) return;
       localStorage.setItem(HINT_KEY, '1');
     } catch { return; /* 프라이빗 모드 등 — 힌트를 건너뛴다 */ }
-    showToast('블록을 탭하면 수정, 끌면 15분 단위로 이동돼요');
+    showToast('블록을 탭하면 수정, 모바일에서는 길게 눌러 끌면 이동돼요');
   }, [planLoading, blocks.length]);
 
   const handleSave = async (updated: Block) => {
@@ -586,6 +618,10 @@ export function WeeklyCalendarScreenV2() {
         onBlockPointerDown={(e, gb) => {
           const b = blocks.find((x) => x.id === gb.id);
           if (b) handleBlockPointerDown(e, b);
+        }}
+        onBlockActivate={(gb) => {
+          const b = blocks.find((x) => x.id === gb.id);
+          if (b) setEditing(b);
         }}
       />
 

--- a/src/screens/WeeklyPlanGenerationScreen.tsx
+++ b/src/screens/WeeklyPlanGenerationScreen.tsx
@@ -424,14 +424,34 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
   // draft 라 API 는 없고 로컬 state 만 갱신(승인 전이므로). 안 움직이면 탭=편집.
   const handleBlockPointerDown = (e: React.PointerEvent, block: Block, col: number) => {
     if (block.fixed) return; // 고정 블록은 이동 불가.
-    e.preventDefault();
     e.stopPropagation();
+    if (e.pointerType === 'mouse' && e.button !== 0) return;
+    const isTouch = e.pointerType === 'touch';
+    if (!isTouch) e.preventDefault();
     const startX = e.clientX;
     const startY = e.clientY;
     const startMinute = parseMin(block.time);
     dragMovedRef.current = false;
     const targetEl = e.currentTarget as HTMLElement;
-    targetEl.setPointerCapture(e.pointerId);
+    let dragEnabled = !isTouch;
+    let cancelled = false;
+    let timer: number | null = isTouch ? window.setTimeout(() => {
+      if (cancelled) return;
+      dragEnabled = true;
+      timer = null;
+      targetEl.setPointerCapture(e.pointerId);
+    }, 300) : null;
+    const blockScrollWhileDragging = (ev: TouchEvent) => {
+      if (dragEnabled && !cancelled) ev.preventDefault();
+    };
+    const cleanup = () => {
+      cancelled = true;
+      if (timer != null) window.clearTimeout(timer);
+      targetEl.removeEventListener('pointermove', onMove);
+      targetEl.removeEventListener('pointerup', onUp);
+      targetEl.removeEventListener('pointercancel', onCancel);
+      window.removeEventListener('touchmove', blockScrollWhileDragging);
+    };
     const calc = (ev: PointerEvent) => {
       const minDelta = Math.round(((ev.clientY - startY) / HOUR_PX) * 60 / SNAP_MIN) * SNAP_MIN;
       const newDay = dayFromDx(col, ev.clientX - startX);
@@ -439,15 +459,18 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
       return { newDay, newMinute };
     };
     const onMove = (ev: PointerEvent) => {
-      if (!dragMovedRef.current && Math.hypot(ev.clientX - startX, ev.clientY - startY) > 5) dragMovedRef.current = true;
+      const distance = Math.hypot(ev.clientX - startX, ev.clientY - startY);
+      if (!dragEnabled) {
+        if (distance > 8) cleanup(); // 터치 스크롤에 양보.
+        return;
+      }
+      if (!dragMovedRef.current && distance > 5) dragMovedRef.current = true;
       if (!dragMovedRef.current) return;
       const { newDay, newMinute } = calc(ev);
       setDragGhost({ id: block.id, day: newDay, minute: newMinute });
     };
     const onUp = (ev: PointerEvent) => {
-      targetEl.removeEventListener('pointermove', onMove);
-      targetEl.removeEventListener('pointerup', onUp);
-      targetEl.removeEventListener('pointercancel', onUp);
+      cleanup();
       if (!dragMovedRef.current) { setEditing({ ...block, day: col }); setDragGhost(null); return; } // 탭=편집
       const { newDay, newMinute } = calc(ev);
       setDragGhost(null);
@@ -458,9 +481,14 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
       const time = `${String(Math.floor(newMinute / 60)).padStart(2, '0')}:${String(newMinute % 60).padStart(2, '0')}`;
       setBlocks((bs) => bs.map((x) => x.id === block.id ? { ...x, day: newDay, time, dateStr: localDateStr(d) } : x));
     };
+    const onCancel = () => {
+      cleanup();
+      setDragGhost(null);
+    };
     targetEl.addEventListener('pointermove', onMove);
     targetEl.addEventListener('pointerup', onUp);
-    targetEl.addEventListener('pointercancel', onUp);
+    targetEl.addEventListener('pointercancel', onCancel);
+    window.addEventListener('touchmove', blockScrollWhileDragging, { passive: false });
   };
 
   if (generating) return <PlanGeneratingView />;
@@ -572,6 +600,10 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
         onBlockPointerDown={(e, gb) => {
           const hit = weekBlocks.find((x) => x.b.id === gb.id);
           if (hit) handleBlockPointerDown(e, hit.b, hit.col);
+        }}
+        onBlockActivate={(gb) => {
+          const hit = weekBlocks.find((x) => x.b.id === gb.id);
+          if (hit) setEditing({ ...hit.b, day: hit.col });
         }}
       />
 


### PR DESCRIPTION
Closes #282

- 모바일 300ms long-press 후에만 일정 드래그
- 이동 slop 이전에는 스크롤에 양보
- 실제 드래그 중에만 touchmove 차단
- 탭·키보드·보조기술 상세 열기 유지
- 마일스톤은 기존 전체 카드 long-press/방향키 재정렬 확인

검증: build, check:api, check:fields, diff-check