### PR TITLE
[ux] 자료 찾기 화면·복수 목표 안내·첫 사용 가이드 개선

### DIFF
--- a/src/components/UsageGuideModal.tsx
+++ b/src/components/UsageGuideModal.tsx
@@ -1,0 +1,47 @@
+import { Check, X } from '@phosphor-icons/react';
+
+interface UsageGuideModalProps {
+  title: string;
+  description: string;
+  steps: string[];
+  onClose: () => void;
+}
+
+export function UsageGuideModal({ title, description, steps, onClose }: UsageGuideModalProps) {
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="usage-guide-title"
+      onClick={onClose}
+      style={{ position: 'fixed', inset: 0, zIndex: 100, background: 'rgba(43, 36, 30, 0.48)', backdropFilter: 'blur(2px)', display: 'flex', alignItems: 'flex-end', justifyContent: 'center', padding: 16 }}
+    >
+      <section
+        onClick={(event) => event.stopPropagation()}
+        style={{ width: 'min(100%, 520px)', borderRadius: 22, background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', boxShadow: 'var(--shadow-lg, 0 16px 42px rgba(0,0,0,.18))', padding: 20, paddingBottom: 'max(20px, env(safe-area-inset-bottom, 20px))' }}
+      >
+        <div style={{ display: 'flex', alignItems: 'flex-start', gap: 12 }}>
+          <div style={{ flex: 1 }}>
+            <div style={{ color: 'var(--brand-ink)', fontSize: 11, fontWeight: 800, marginBottom: 5 }}>처음이신가요?</div>
+            <h2 id="usage-guide-title" style={{ margin: 0, fontSize: 20, lineHeight: 1.3 }}>{title}</h2>
+          </div>
+          <button aria-label="안내 닫기" onClick={onClose} style={{ width: 44, height: 44, margin: -8, border: 0, borderRadius: 9999, background: 'var(--sand-100)', color: 'var(--text-2)', display: 'grid', placeItems: 'center', cursor: 'pointer' }}>
+            <X size={18} />
+          </button>
+        </div>
+        <p style={{ margin: '10px 0 16px', color: 'var(--text-2)', fontSize: 13, lineHeight: 1.6 }}>{description}</p>
+        <ol style={{ listStyle: 'none', margin: 0, padding: 0, display: 'flex', flexDirection: 'column', gap: 9 }}>
+          {steps.map((step, index) => (
+            <li key={step} style={{ display: 'flex', gap: 10, alignItems: 'flex-start', padding: '10px 12px', borderRadius: 12, background: 'var(--surface-ground)', border: '1px solid var(--sand-200)', color: 'var(--text-1)', fontSize: 13, lineHeight: 1.5 }}>
+              <span className="tnum" aria-hidden style={{ width: 22, height: 22, flexShrink: 0, borderRadius: 9999, background: 'var(--brand-soft)', color: 'var(--brand-ink)', display: 'grid', placeItems: 'center', fontSize: 11, fontWeight: 800 }}>{index + 1}</span>
+              {step}
+            </li>
+          ))}
+        </ol>
+        <button onClick={onClose} autoFocus style={{ marginTop: 16, width: '100%', minHeight: 48, border: 0, borderRadius: 12, background: 'var(--brand-surface)', color: '#FFFCF6', fontFamily: 'inherit', fontSize: 15, fontWeight: 700, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 7, cursor: 'pointer' }}>
+          <Check size={17} weight="bold" /> 알겠어요
+        </button>
+      </section>
+    </div>
+  );
+}

--- a/src/design-system.ts
+++ b/src/design-system.ts
@@ -25,6 +25,7 @@ export { AiDraftCard } from './components/AiDraftCard';
 export { BlockEditSheet } from './components/BlockEditSheet';
 export { ProgressSheet } from './components/ProgressSheet';
 export { ResourceViewerSheet } from './components/ResourceViewerSheet';
+export { UsageGuideModal } from './components/UsageGuideModal';
 
 // ── 상태 표현 ────────────────────────────────────────────────
 export { EmptyState } from './components/EmptyState';

--- a/src/screens/GoalClassificationScreen.tsx
+++ b/src/screens/GoalClassificationScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { Sparkle, Check } from '@phosphor-icons/react';
+import { Sparkle, Check, Info } from '@phosphor-icons/react';
 import { GOAL_STATUS_META } from '../data';
 import { friendlyError, goalsApi } from '../lib/api';
 import type { ApiGoal, GoalCandidate, GoalsByTier, InterviewOutcome } from '../types/api';
@@ -9,6 +9,7 @@ import { AiDraftCard } from '../components/AiDraftCard';
 import { ErrorBanner } from '../components/ErrorBanner';
 import { SkeletonBlock } from '../components/SkeletonBlock';
 import { isPersistedGoalId } from '../lib/goalIdentity';
+import { UsageGuideModal } from '../components/UsageGuideModal';
 
 interface GoalClassificationScreenProps {
   onNext: () => void;
@@ -57,6 +58,7 @@ export function GoalClassificationScreen({ onNext, outcome }: GoalClassification
   const [error, setError] = useState<string | null>(null);
   // goals 가 실데이터(비어있어도)인지 — outcome 이든 goalsApi.list 든 성공하면 true.
   const [usingReal, setUsingReal] = useState(false);
+  const [showGuide, setShowGuide] = useState(false);
 
   // outcome.coreGoals 가 있으면 그걸 쓰고(정상 경로), 없을 때만 GET /goals 로 fallback한다
   // (예: 인터뷰를 거치지 않고 이 화면에 직접 진입한 dev/force-nav 케이스).
@@ -128,10 +130,14 @@ export function GoalClassificationScreen({ onNext, outcome }: GoalClassification
         <SetupProgress current={2} total={4} label="분류" />
         <div>
           <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: '-0.01em', color: 'var(--brand-ink)', marginBottom: 4 }}>목표 분류</div>
-          <div style={{ fontWeight: 800, fontSize: 24, letterSpacing: '-0.02em', lineHeight: 1.15, marginBottom: 4 }}>무엇에 집중할까요?</div>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10 }}>
+            <div style={{ fontWeight: 800, fontSize: 24, letterSpacing: '-0.02em', lineHeight: 1.15, marginBottom: 4 }}>무엇에 집중할까요?</div>
+            <button onClick={() => setShowGuide(true)} aria-label="목표 분류 사용법" style={{ width: 44, height: 44, flexShrink: 0, borderRadius: 9999, border: '1px solid var(--sand-200)', background: 'var(--surface-raised)', color: 'var(--text-2)', display: 'grid', placeItems: 'center', cursor: 'pointer' }}><Info size={17} /></button>
+          </div>
           <p style={{ fontSize: 12, color: 'var(--text-2)', margin: 0 }}>
             {isLoading ? '대화에서 파악한 목표를 불러오는 중…' : '대화에서 파악한 목표들이에요. 분류를 조정할 수 있어요.'}
           </p>
+          {!isLoading && goals.length > 1 && <p role="status" style={{ margin: '8px 0 0', padding: '9px 11px', borderRadius: 10, background: 'var(--brand-soft)', border: '1px solid var(--coral-200)', color: 'var(--coral-700)', fontSize: 11.5, lineHeight: 1.5 }}><b>{goals.length}개의 목표</b>를 함께 찾았어요. 각 카드를 눌러 집중·유지·보류를 따로 정할 수 있어요.</p>}
         </div>
 
         {error && (
@@ -254,6 +260,7 @@ export function GoalClassificationScreen({ onNext, outcome }: GoalClassification
           </div>
         </AiDraftCard>
       </div>
+      {showGuide && <UsageGuideModal title="여러 목표도 함께 정리할 수 있어요" description="인터뷰에서 파악된 목표마다 이번 계획에서의 역할을 정합니다." steps={['목표 카드를 눌러 분류 선택지를 여세요.', '집중은 최대 3개, 유지는 최대 5개까지 두고 나머지는 보류할 수 있어요.', '분류를 확인한 뒤 주간 계획 생성을 누르세요.']} onClose={() => setShowGuide(false)} />}
     </div>
   );
 }

--- a/src/screens/MaterialsSearchScreen.tsx
+++ b/src/screens/MaterialsSearchScreen.tsx
@@ -1,8 +1,14 @@
 import { useEffect, useState } from 'react';
-import { ArrowRight, Check, MagnifyingGlass, PencilSimple, SkipForward } from '@phosphor-icons/react';
+import { ArrowRight, Check, Info, MagnifyingGlass, PencilSimple, SkipForward, Sparkle } from '@phosphor-icons/react';
 import { ApiError, plansApi } from '../lib/api';
 import { useNavigation } from '../contexts/NavigationContext';
 import type { MaterialsSearchResponse } from '../types/api';
+import { ErrorBanner } from '../components/ErrorBanner';
+import { ReButton } from '../components/ReButton';
+import { SkeletonBlock } from '../components/SkeletonBlock';
+import { UsageGuideModal } from '../components/UsageGuideModal';
+
+const GUIDE_KEY = 'reaction.guide.materials.v1';
 
 const STATUS_MESSAGE: Record<Exclude<MaterialsSearchResponse['status'], 'found'>, string> = {
   not_found: '맞는 자료를 찾지 못했어요. 검색어를 조금 더 구체적으로 바꿔보세요.',
@@ -20,6 +26,12 @@ export function MaterialsSearchScreen() {
   const [loadingQuery, setLoadingQuery] = useState(true);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [showGuide, setShowGuide] = useState(() => typeof window !== 'undefined' && window.localStorage.getItem(GUIDE_KEY) !== 'done');
+
+  const closeGuide = () => {
+    if (typeof window !== 'undefined') window.localStorage.setItem(GUIDE_KEY, 'done');
+    setShowGuide(false);
+  };
 
   useEffect(() => {
     let cancelled = false;
@@ -53,34 +65,42 @@ export function MaterialsSearchScreen() {
 
   const found = result?.status === 'found';
   return (
-    <div style={{ height: '100%', overflowY: 'auto', padding: '18px 18px 32px', background: 'var(--surface-ground)' }}>
+    <div style={{ height: '100%', overflowY: 'auto', padding: '14px 18px 32px', background: 'var(--surface-ground)' }}>
       <div style={{ maxWidth: 640, margin: '0 auto', display: 'flex', flexDirection: 'column', gap: 16 }}>
-        <div><h1 style={{ margin: 0, fontSize: 22 }}>계획에 참고할 자료가 있나요?</h1>
-          <p style={{ color: 'var(--text-2)', fontSize: 13, lineHeight: 1.6 }}>검색어와 검색 결과를 직접 확인한 뒤에만 계획에 반영해요. 필요 없으면 건너뛰어도 됩니다.</p></div>
-
-        <section style={{ background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', borderRadius: 16, padding: 16 }}>
-          <div style={{ display: 'flex', gap: 7, alignItems: 'center', fontWeight: 800, marginBottom: 10 }}><MagnifyingGlass size={18} /> 1. 검색어 확인</div>
-          <div style={{ display: 'flex', gap: 8 }}>
-            <input aria-label="자료 검색어" value={query} disabled={loadingQuery || busy} onChange={(e) => { setQuery(e.target.value); setResult(null); }} maxLength={200}
-              placeholder={loadingQuery ? '검색어를 제안하는 중…' : '직접 검색어를 입력하세요'} style={{ flex: 1, minWidth: 0, border: '1px solid var(--sand-300)', borderRadius: 10, padding: '11px 12px', fontSize: 14 }} />
-            <button onClick={search} disabled={loadingQuery || busy || query.trim().length < 2} style={{ border: 0, borderRadius: 10, padding: '0 15px', background: 'var(--brand)', color: 'white', fontWeight: 800 }}>검색</button>
+        <div>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12, marginBottom: 5 }}>
+            <div style={{ color: 'var(--brand-ink)', fontSize: 12, fontWeight: 800 }}>계획 준비 · 선택 단계</div>
+            <button onClick={() => setShowGuide(true)} style={{ minHeight: 44, padding: '0 10px', borderRadius: 9999, border: '1px solid var(--sand-200)', background: 'var(--surface-raised)', color: 'var(--text-2)', fontFamily: 'inherit', fontSize: 12, fontWeight: 700, display: 'flex', alignItems: 'center', gap: 5, cursor: 'pointer' }}><Info size={15} /> 사용법</button>
           </div>
+          <h1 style={{ margin: 0, fontSize: 24, letterSpacing: '-0.02em', lineHeight: 1.25 }}>계획에 참고할 자료가 있나요?</h1>
+          <p style={{ color: 'var(--text-2)', fontSize: 13, lineHeight: 1.6, marginBottom: 0 }}>AI가 검색을 돕지만, 확인한 내용만 계획에 반영됩니다. 필요하지 않다면 바로 건너뛰어도 괜찮아요.</p>
+        </div>
+
+        <section style={{ background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', borderRadius: 16, padding: 16, boxShadow: 'var(--shadow-sm, 0 2px 10px rgba(0,0,0,.04))' }}>
+          <div style={{ display: 'flex', gap: 7, alignItems: 'center', fontWeight: 800, marginBottom: 10 }}><MagnifyingGlass size={18} /> 1. 검색어 확인</div>
+          {loadingQuery ? <SkeletonBlock count={1} height={44} radius={10} /> : <div style={{ display: 'flex', gap: 8, alignItems: 'stretch' }}>
+            <input aria-label="자료 검색어" value={query} disabled={loadingQuery || busy} onChange={(e) => { setQuery(e.target.value); setResult(null); }} maxLength={200}
+              placeholder="직접 검색어를 입력하세요" style={{ flex: 1, minWidth: 0, minHeight: 44, boxSizing: 'border-box', border: '1px solid var(--sand-300)', borderRadius: 10, padding: '11px 12px', background: 'var(--surface-ground)', color: 'var(--text-1)', fontFamily: 'inherit', fontSize: 14 }} />
+            <ReButton onClick={search} disabled={busy || query.trim().length < 2} style={{ padding: '0 16px' }}>{busy ? '찾는 중…' : '검색'}</ReButton>
+          </div>}
           {notice && <p style={{ color: 'var(--text-3)', fontSize: 12, lineHeight: 1.5, marginBottom: 0 }}>{notice}</p>}
         </section>
 
-        {result && result.status !== 'found' && <div role="status" style={{ padding: 14, borderRadius: 12, background: 'var(--surface-raised)', fontSize: 13, lineHeight: 1.6 }}>{STATUS_MESSAGE[result.status]}</div>}
+        {result && result.status !== 'found' && <div role="status" style={{ padding: 14, borderRadius: 12, background: 'var(--surface-raised)', border: '1px dashed var(--sand-300)', color: 'var(--text-2)', fontSize: 13, lineHeight: 1.6 }}>{STATUS_MESSAGE[result.status]}</div>}
         {found && <section style={{ background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', borderRadius: 16, padding: 16 }}>
-          <div style={{ display: 'flex', gap: 7, alignItems: 'center', fontWeight: 800, marginBottom: 6 }}><PencilSimple size={18} /> 2. 찾은 내용 확인·편집</div>
+          <div style={{ display: 'flex', gap: 7, alignItems: 'center', fontWeight: 800, marginBottom: 6 }}><PencilSimple size={18} color="var(--brand)" /> 2. 찾은 내용 확인·편집</div>
           <p style={{ color: 'var(--text-2)', fontSize: 12, lineHeight: 1.5 }}>내용이 다르면 고치거나 지워도 돼요. 아직 계획에는 저장되지 않았습니다.</p>
-          <textarea aria-label="확정할 자료 내용" value={text} onChange={(e) => setText(e.target.value)} maxLength={20000} rows={12} style={{ width: '100%', boxSizing: 'border-box', resize: 'vertical', border: '1px solid var(--sand-300)', borderRadius: 10, padding: 12, fontSize: 13, lineHeight: 1.6 }} />
+          <textarea aria-label="확정할 자료 내용" value={text} onChange={(e) => setText(e.target.value)} maxLength={20000} rows={12} style={{ width: '100%', boxSizing: 'border-box', resize: 'vertical', border: '1px solid var(--sand-300)', borderRadius: 10, padding: 12, background: 'var(--surface-ground)', color: 'var(--text-1)', fontFamily: 'inherit', fontSize: 13, lineHeight: 1.6 }} />
           <div style={{ textAlign: 'right', color: 'var(--text-3)', fontSize: 11 }}>{text.length.toLocaleString()} / 20,000자</div>
           {!!result.sources?.length && <div style={{ marginTop: 10, fontSize: 12 }}><b>참고 출처</b>{result.sources.map((s) => <div key={s.uri}><a href={s.uri} target="_blank" rel="noreferrer">{s.title || s.uri}</a></div>)}</div>}
-          <button onClick={confirm} disabled={busy || !text.trim()} style={{ marginTop: 14, width: '100%', border: 0, borderRadius: 11, padding: 13, background: 'var(--brand)', color: 'white', fontWeight: 800 }}><Check size={16} /> 3. 이 자료를 계획에 반영</button>
+          <ReButton onClick={confirm} disabled={busy || !text.trim()} full style={{ marginTop: 14 }}><Check size={16} /> 3. 이 자료를 계획에 반영</ReButton>
         </section>}
 
-        {error && <div role="alert" style={{ color: 'var(--coral-700)', fontSize: 13 }}>{error}</div>}
-        <button onClick={() => setScreen('weekly-plan')} disabled={busy} style={{ background: 'transparent', border: 0, color: 'var(--text-2)', padding: 10, cursor: 'pointer' }}><SkipForward size={16} /> 자료 없이 계획 계속하기 <ArrowRight size={14} /></button>
+        {error && <ErrorBanner>{error}</ErrorBanner>}
+        <div style={{ padding: '12px 14px', borderRadius: 14, background: 'var(--brand-soft)', border: '1px solid var(--coral-200)', display: 'flex', gap: 9 }}><Sparkle size={16} weight="fill" color="var(--brand)" style={{ flexShrink: 0, marginTop: 1 }} /><div style={{ color: 'var(--coral-700)', fontSize: 12, lineHeight: 1.55 }}><b>선택 단계예요.</b> 자료를 넣지 않아도 인터뷰와 마일스톤을 바탕으로 계획을 만들 수 있어요.</div></div>
+        <ReButton variant="ghost" onClick={() => setScreen('weekly-plan')} disabled={busy} full><SkipForward size={16} /> 자료 없이 계획 계속하기 <ArrowRight size={14} /></ReButton>
       </div>
+      {showGuide && <UsageGuideModal title="관련 자료는 이렇게 반영해요" description="AI가 제안한 검색어와 결과를 사용자가 직접 확인하는 단계입니다." steps={['검색어를 확인하거나 원하는 표현으로 고쳐 검색하세요.', '찾은 내용에서 계획에 필요하지 않은 부분은 편집하거나 지우세요.', '확정 버튼을 눌러야만 계획에 반영됩니다. 자료가 필요 없다면 건너뛰세요.']} onClose={closeGuide} />}
     </div>
   );
 }


### PR DESCRIPTION
Closes #286
Closes #288
Partially addresses #287

- 관련 자료 찾기 화면을 공용 디자인 시스템으로 정렬
- 최초 진입 반투명 사용법 모달과 다시 보기 제공
- 목표 분류에서 복수 목표 개수와 개별 분류 안내
- 로딩·오류·선택 상태 및 44px 터치 영역 개선

제한: 자료 API가 goalTitle 단수라 목표별 자료 연결은 계약 확장 필요

검증: build, check:api, check:fields, diff-check