### PR TITLE
[ux] 주요 계획 화면에서 튜토리얼을 다시 여는 도움말 버튼

### DIFF
--- a/src/components/UsageGuideModal.tsx
+++ b/src/components/UsageGuideModal.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { Check, X } from '@phosphor-icons/react';
 
 interface UsageGuideModalProps {
@@ -8,6 +9,12 @@ interface UsageGuideModalProps {
 }
 
 export function UsageGuideModal({ title, description, steps, onClose }: UsageGuideModalProps) {
+  useEffect(() => {
+    const closeOnEscape = (event: KeyboardEvent) => { if (event.key === 'Escape') onClose(); };
+    window.addEventListener('keydown', closeOnEscape);
+    return () => window.removeEventListener('keydown', closeOnEscape);
+  }, [onClose]);
+
   return (
     <div
       role="dialog"

--- a/src/screens/MilestoneConfirmScreen.tsx
+++ b/src/screens/MilestoneConfirmScreen.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
-import { CaretLeft, Plus, X, Sparkle, ArrowRight, Path } from '@phosphor-icons/react';
+import { CaretLeft, Plus, X, Sparkle, ArrowRight, Path, Info } from '@phosphor-icons/react';
 import { ApiError, plansApi } from '../lib/api';
+import { UsageGuideModal } from '../components/UsageGuideModal';
 import { useNavigation } from '../contexts/NavigationContext';
 import type { MilestoneDraft } from '../types/api';
 
@@ -22,6 +23,7 @@ export function MilestoneConfirmScreen() {
   const [loading, setLoading] = useState(true);
   const [failed, setFailed] = useState(false);
   const [drag, setDrag] = useState<Drag | null>(null);
+  const [showGuide, setShowGuide] = useState(false);
   const listRef = useRef<HTMLDivElement>(null);
   const uidRef = useRef(0);
   const withUid = (m: MilestoneDraft): Row => ({ ...m, uid: uidRef.current++ });
@@ -205,6 +207,9 @@ export function MilestoneConfirmScreen() {
             <Path size={20} weight="fill" color="var(--brand)" />
             <h1 style={{ fontWeight: 800, fontSize: 22, letterSpacing: '-0.02em', margin: 0 }}>계획의 큰 그림</h1>
           </div>
+          <button onClick={() => setShowGuide(true)} aria-label="마일스톤 사용법" style={{ marginLeft: 'auto', width: 44, height: 44, flexShrink: 0, borderRadius: 9999, border: '1px solid var(--sand-200)', background: 'var(--surface-raised)', color: 'var(--text-2)', display: 'grid', placeItems: 'center', cursor: 'pointer' }}>
+            <Info size={17} />
+          </button>
         </div>
 
         <p style={{ fontSize: 13, color: 'var(--text-2)', lineHeight: 1.6, margin: 0 }}>
@@ -321,6 +326,14 @@ export function MilestoneConfirmScreen() {
             그냥 자동으로 세워줘 (마일스톤 없이)
           </button>
         </div>
+      )}
+      {showGuide && (
+        <UsageGuideModal
+          title="마일스톤 순서를 직접 정할 수 있어요"
+          description="계획을 만들기 전에 중간 목표의 내용과 우선순위를 확인하는 단계입니다."
+          steps={['카드의 제목과 설명을 원하는 표현으로 고치세요.', '카드 전체를 길게 눌러 끌거나 번호에 초점을 두고 방향키를 눌러 순서를 바꾸세요.', '필요한 단계를 추가하거나 지운 뒤 이대로 계획 세우기를 누르세요.']}
+          onClose={() => setShowGuide(false)}
+        />
       )}
     </div>
   );

--- a/src/screens/WeeklyCalendarScreen.tsx
+++ b/src/screens/WeeklyCalendarScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Plus, CalendarPlus, ChatCircleDots } from '@phosphor-icons/react';
+import { Plus, CalendarPlus, ChatCircleDots, Info } from '@phosphor-icons/react';
 import { DEFAULT_GOAL_CATEGORY, goalColor } from '../data';
 import { ApiError, goalsApi, plansApi } from '../lib/api';
 import { localDateStr } from '../lib/dates';
@@ -9,6 +9,7 @@ import { WeekGrid, scrollColIntoView, type WeekGridBlock } from '../components/W
 import { EmptyState } from '../components/EmptyState';
 import { Toast } from '../components/Toast';
 import { ReinterviewSheet } from '../components/ReinterviewSheet';
+import { UsageGuideModal } from '../components/UsageGuideModal';
 import { useNavigation } from '../contexts/NavigationContext';
 import type { Block } from '../types';
 import type { WeeklyPlanResponse, BlockEditRequest, ApiGoal } from '../types/api';
@@ -99,6 +100,7 @@ export function WeeklyCalendarScreenV2() {
   // '+' 토글 메뉴와 재인터뷰 확인 시트.
   const [menuOpen, setMenuOpen] = useState(false);
   const [confirmReinterview, setConfirmReinterview] = useState(false);
+  const [showGuide, setShowGuide] = useState(false);
   const isThisWeek = weekOffset === 0;
 
   // 토글 메뉴는 Esc 로도 닫힌다 — 바깥을 누르는 것 말고 빠져나갈 길이 하나는 있어야 한다.
@@ -588,6 +590,9 @@ export function WeeklyCalendarScreenV2() {
             style={{ width: 28, height: 28, borderRadius: 8, border: '1px solid var(--sand-200)', background: 'var(--surface-raised)', color: 'var(--text-1)', cursor: 'pointer', fontFamily: 'inherit', fontSize: 14 }}
             aria-label="다음 주"
           >›</button>
+          <button onClick={() => setShowGuide(true)} aria-label="주간 시간표 사용법" style={{ width: 44, height: 44, flexShrink: 0, borderRadius: 9999, border: '1px solid var(--sand-200)', background: 'var(--surface-raised)', color: 'var(--text-2)', display: 'grid', placeItems: 'center', cursor: 'pointer' }}>
+            <Info size={17} />
+          </button>
           {/* 오늘 버튼은 항상 같은 자리에 둔다. 이번 주를 보고 있을 때는 선택된 컨트롤로
               표시해 다른 세그먼트·필터와 활성 상태 표현을 통일한다. */}
           <div style={{ width: 41, flexShrink: 0, display: 'flex', justifyContent: 'flex-end' }}>
@@ -736,6 +741,15 @@ export function WeeklyCalendarScreenV2() {
           setScreen('goal-intake');
         }}
       />
+
+      {showGuide && (
+        <UsageGuideModal
+          title="주간 계획을 확인하고 조정하세요"
+          description="시간표에서는 일정 확인, 이동, 추가를 직접 할 수 있습니다."
+          steps={['일정을 짧게 누르면 제목·시간·소요 시간을 수정할 수 있어요.', '모바일에서는 일정을 길게 누른 뒤 끌어야 이동하며, 일반 스와이프는 화면 스크롤로 동작해요.', '같은 시간 일정은 나란히 표시됩니다. 충돌 안내가 보이면 각 일정을 눌러 시간을 조정하세요.']}
+          onClose={() => setShowGuide(false)}
+        />
+      )}
 
       {toast && (
         <Toast

--- a/src/screens/WeeklyPlanGenerationScreen.tsx
+++ b/src/screens/WeeklyPlanGenerationScreen.tsx
@@ -1,11 +1,12 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { Clock, Lightbulb, DotsThreeOutline } from '@phosphor-icons/react';
+import { Clock, Lightbulb, DotsThreeOutline, Info } from '@phosphor-icons/react';
 import { DEFAULT_GOAL_CATEGORY, categoryLabel, goalColor } from '../data';
 import { SetupProgress } from '../components/SetupProgress';
 import { AiDraftCard } from '../components/AiDraftCard';
 import { DemoNotice } from '../components/DemoNotice';
 import { BlockEditSheet } from '../components/BlockEditSheet';
 import { PlanOptionsSheet } from '../components/PlanOptionsSheet';
+import { UsageGuideModal } from '../components/UsageGuideModal';
 import { WeekGrid, scrollColIntoView, type WeekGridBlock } from '../components/WeekGrid';
 import { ApiError, plansApi } from '../lib/api';
 import { localDateStr } from '../lib/dates';
@@ -127,6 +128,7 @@ interface WeeklyPlanGenerationScreenProps {
 }
 
 export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationScreenProps) {
+  const [showGuide, setShowGuide] = useState(false);
   const [blocks, setBlocks] = useState<Block[]>([]);
   const [editing, setEditing] = useState<Block | null>(null);
   const [generating, setGenerating] = useState(true);
@@ -507,6 +509,9 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
           <span className="tnum" style={{ flexShrink: 0, height: 'var(--ctrl-xs)', padding: '0 9px', background: 'var(--brand-soft)', border: '1px solid var(--coral-200)', borderRadius: 9999, fontSize: 12, fontWeight: 700, color: 'var(--brand-ink)', display: 'inline-flex', alignItems: 'center' }}>
             이번 주 {weekBlocks.length}개
           </span>
+          <button onClick={() => setShowGuide(true)} aria-label="생성된 계획 사용법" style={{ width: 44, height: 44, flexShrink: 0, borderRadius: 9999, border: '1px solid var(--sand-200)', background: 'var(--surface-raised)', color: 'var(--text-2)', display: 'grid', placeItems: 'center', cursor: 'pointer' }}>
+            <Info size={17} />
+          </button>
         </div>
         <p style={{ fontSize: 11.5, color: 'var(--text-3)', margin: '0 0 8px', lineHeight: 1.45 }}>
           탭하면 수정 · 끌면 15분 단위로 이동{overflowsX ? ' · 옆으로 밀면 나머지 요일' : ''}
@@ -682,6 +687,14 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
           onSave={handleSave}
           onDelete={handleDelete}
           onClose={() => setEditing(null)}
+        />
+      )}
+      {showGuide && (
+        <UsageGuideModal
+          title="AI 계획은 확인한 뒤 적용돼요"
+          description="생성된 일정은 아직 초안이며 사용자가 수락하기 전에는 확정되지 않습니다."
+          steps={['일정을 눌러 내용을 수정하고, 모바일에서는 길게 눌러 원하는 시간으로 옮기세요.', '블록 추가나 재생성으로 계획을 더 맞출 수 있어요.', '시간표를 모두 확인한 뒤 이대로 시작을 눌러 확정하세요.']}
+          onClose={() => setShowGuide(false)}
         />
       )}
     </div>


### PR DESCRIPTION
Closes #288

- 마일스톤·생성 계획·메인 주간 시간표에 44px 도움말 버튼
- 기존 목표 분류·관련 자료 화면과 동일한 안내 모달 사용
- 닫기 버튼, 배경 탭, Escape 키로 언제든 닫기
- 화면별 실제 조작법을 3단계로 안내

검증: npm run build