### PR TITLE
fix: 겹친 고정 일정 상세보기 클릭 복구

### DIFF
--- a/src/components/WeekGrid.tsx
+++ b/src/components/WeekGrid.tsx
@@ -295,9 +295,10 @@ export function WeekGrid({
         key={b.id + (seg.tail ? '-tail' : '')}
         onPointerDown={(e) => onBlockPointerDown?.(e, b)}
         onClick={(e) => {
-          // 포인터 탭은 호출부의 pointerup 이 처리한다. 키보드/보조기술이 만든
-          // detail=0 클릭만 별도 경로로 열어 중복 실행을 피한다.
-          if (e.detail === 0) onBlockActivate?.(b);
+          // 이동 가능한 블록의 포인터 탭은 호출부의 pointerup 이 처리한다. 하지만
+          // 고정 일정은 드래그 핸들러가 즉시 반환하므로 일반 클릭 경로에서 열어야 한다.
+          // 키보드/보조기술이 만든 detail=0 클릭도 이 경로를 함께 사용한다.
+          if (b.fixed || e.detail === 0) onBlockActivate?.(b);
         }}
         aria-label={`${b.title}${b.subLabel ? `, ${b.subLabel}` : ''}${laneCount > 1 ? `, 같은 시간대 일정 ${laneCount}개` : ''}. 탭하면 수정, 모바일에서는 길게 눌러 끌면 이동`}
         style={{


### PR DESCRIPTION
## 원인
고정 일정은 드래그 핸들러가 즉시 반환하지만 일반 포인터 클릭도 무시되어, 세로 스택의 보라색 카드가 상세보기를 열 수 없었습니다.

## 변경
- 고정 일정은 마우스·터치 클릭 시 `onBlockActivate`로 상세보기 연결
- 이동 가능한 일정의 탭/길게 누르기 드래그 동작은 기존대로 유지
- 키보드 접근성 경로 유지

## 검증
- npm run build
- npm run check:api
- npm run check:fields
- git diff --check