### PR TITLE
fix: 겹친 일정 드래그 상태를 명확히 표시

### DIFF
--- a/src/components/WeekGrid.tsx
+++ b/src/components/WeekGrid.tsx
@@ -295,9 +295,10 @@ export function WeekGrid({
         key={b.id + (seg.tail ? '-tail' : '')}
         onPointerDown={(e) => onBlockPointerDown?.(e, b)}
         onClick={(e) => {
-          // 포인터 탭은 호출부의 pointerup 이 처리한다. 키보드/보조기술이 만든
-          // detail=0 클릭만 별도 경로로 열어 중복 실행을 피한다.
-          if (e.detail === 0) onBlockActivate?.(b);
+          // 이동 가능한 블록의 포인터 탭은 호출부의 pointerup 이 처리한다. 하지만
+          // 고정 일정은 드래그 핸들러가 즉시 반환하므로 일반 클릭 경로에서 열어야 한다.
+          // 키보드/보조기술이 만든 detail=0 클릭도 이 경로를 함께 사용한다.
+          if (b.fixed || e.detail === 0) onBlockActivate?.(b);
         }}
         aria-label={`${b.title}${b.subLabel ? `, ${b.subLabel}` : ''}${laneCount > 1 ? `, 같은 시간대 일정 ${laneCount}개` : ''}. 탭하면 수정, 모바일에서는 길게 눌러 끌면 이동`}
         style={{

--- a/src/components/WeekGrid.tsx
+++ b/src/components/WeekGrid.tsx
@@ -25,6 +25,8 @@ export interface WeekGridBlock {
 
 export interface WeekGridProps {
   blocks: WeekGridBlock[];
+  /** 드래그 중 카드 재배치 전의 배치 기준. 스택의 나머지 카드가 갑자기 늘어나지 않게 한다. */
+  layoutBlocks?: WeekGridBlock[];
   /** 뒤에 흐리게 깔리는 층. 클릭 불가 — 비교용 잔상이다. */
   backdrop?: WeekGridBlock[];
   /** 요일 아래 날짜 숫자(길이 7). 없으면 요일 글자만 나온다. */
@@ -188,6 +190,7 @@ export function scrollColIntoView(
  */
 export function WeekGrid({
   blocks,
+  layoutBlocks,
   backdrop = [],
   dayNumbers,
   todayCol = null,
@@ -209,7 +212,7 @@ export function WeekGrid({
   const hours = Array.from({ length: endHour - startHour }, (_, i) => startHour + i);
   const toY = (m: number) => ((m - startHour * 60) * hourPx) / 60;
   const bodyWidth = colWidth * cols.length;
-  const blockLayouts = overlapLayouts(blocks);
+  const blockLayouts = overlapLayouts(layoutBlocks ?? blocks);
 
   const renderSegment = (b: WeekGridBlock, seg: Segment, interactive: boolean) => {
     const slot = slotOf(seg.col);
@@ -223,7 +226,9 @@ export function WeekGrid({
     const split = b.startMin + b.durMin > DAY_MIN;
     const radius = !split ? 6 : seg.tail ? '0 0 6px 6px' : '6px 6px 0 0';
     const layoutKey = `${b.id}:${seg.tail ? 'tail' : 'head'}`;
-    const layout = interactive ? blockLayouts.get(layoutKey) : undefined;
+    // 끌고 있는 카드는 원래 스택 칸에 가두지 않고 실제 시간 위치에 온전한 크기로 띄운다.
+    // 나머지 카드는 layoutBlocks의 원래 배치를 유지해 드래그 도중 요동치지 않는다.
+    const layout = interactive && !b.dragging ? blockLayouts.get(layoutKey) : undefined;
     const laneCount = layout?.laneCount ?? 1;
     const lane = layout?.lane ?? 0;
     const stackGap = laneCount > 1 ? 1 : 0;

--- a/src/screens/WeeklyCalendarScreen.tsx
+++ b/src/screens/WeeklyCalendarScreen.tsx
@@ -284,8 +284,8 @@ export function WeeklyCalendarScreenV2() {
   };
 
   // 화면 Block → WeekGrid 가 받는 모양. 드래그 중이면 고스트 위치로 미리 옮겨 그린다.
-  const toGridBlock = (b: BlockWithStatus): WeekGridBlock => {
-    const dragging = dragGhost?.id === b.id;
+  const toGridBlock = (b: BlockWithStatus, applyGhost = true): WeekGridBlock => {
+    const dragging = applyGhost && dragGhost?.id === b.id;
     const tMin = dragging ? dragGhost!.minute : parseMin(b.time);
     return {
       id: b.id,
@@ -632,7 +632,8 @@ export function WeeklyCalendarScreenV2() {
 
       <WeekGrid
         scrollRef={gridRef}
-        blocks={blocks.map(toGridBlock)}
+        blocks={blocks.map((block) => toGridBlock(block))}
+        layoutBlocks={blocks.map((block) => toGridBlock(block, false))}
         dayNumbers={dayNumbers}
         todayCol={isThisWeek ? TODAY : null}
         nowMin={nowMin}

--- a/src/screens/WeeklyPlanGenerationScreen.tsx
+++ b/src/screens/WeeklyPlanGenerationScreen.tsx
@@ -372,8 +372,8 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
   }, [generating, firstCol, COL_W, TIME_W, genWeekOffset]);
 
   // 화면 Block → WeekGrid 가 받는 모양. backdrop(기존 계획)은 muted 로 넘겨 뒤에 흐리게 깔린다.
-  const toGridBlock = (b: Block, col: number, muted = false): WeekGridBlock => {
-    const dragging = dragGhost?.id === b.id;
+  const toGridBlock = (b: Block, col: number, muted = false, applyGhost = true): WeekGridBlock => {
+    const dragging = applyGhost && dragGhost?.id === b.id;
     return {
       id: b.id,
       col: dragging ? dragGhost!.day : col,
@@ -588,6 +588,7 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
       <WeekGrid
         scrollRef={gridRef}
         blocks={weekBlocks.map(({ b, col }) => toGridBlock(b, col))}
+        layoutBlocks={weekBlocks.map(({ b, col }) => toGridBlock(b, col, false, false))}
         backdrop={weekExisting.map(({ b, col }) => toGridBlock(b, col, true))}
         dayNumbers={dayNumbers}
         todayCol={TODAY >= 0 ? TODAY : null}


### PR DESCRIPTION
## 실제 브라우저 QA 결과
- 13:00~15:00 일정 3개를 동일 요일에 주입해 가운데 카드를 단계별 포인터 이벤트로 드래그했습니다.
- 기존에는 이동 중 겹침 묶음이 매 프레임 재계산되어 나머지 카드 크기·위치가 요동하고, 어떤 카드를 옮기는지 알아보기 어려웠습니다.

## 변경
- 드래그 시작 전 스택 배치를 별도 기준으로 유지해 나머지 카드가 움직이지 않게 했습니다.
- 끌고 있는 카드만 원래 소요시간 높이로 위에 띄웁니다.
- 카드 내부에 목표 시각이 실시간 표시됩니다.
- 메인 주간 캘린더와 계획 생성 시간표에 동일 적용했습니다.

## 검증
- 실제 Chromium에서 3개 세로 스택 위치 측정 및 가운데 카드 드래그
- 드래그 중 A/C 위치·높이 유지, B만 z-index 10과 목표 시각으로 이동 확인
- npm run build
- npm run check:api
- npm run check:fields
- git diff --check