### PR TITLE
fix: 모바일 캘린더 드래그 센서 안정화

### DIFF
--- a/src/components/WeekGrid.tsx
+++ b/src/components/WeekGrid.tsx
@@ -19,6 +19,8 @@ export interface WeekGridBlock {
   muted?: boolean;
   /** 드래그 중 — 점선 + 그림자로 들린 느낌을 준다. */
   dragging?: boolean;
+  /** 현재 가리키는 위치에 놓을 수 없는 드래그 고스트. */
+  invalidDrop?: boolean;
   /** 고정 일정(수업·알바 등). 옮길 수 없으니 grab 커서를 주지 않는다. */
   fixed?: boolean;
 }
@@ -47,6 +49,7 @@ export interface WeekGridProps {
   loading?: boolean;
   /** 블록을 누르거나 끌기 시작할 때. 드래그/탭 분기는 호출한 쪽에서 판단한다. */
   onBlockPointerDown?: (e: React.PointerEvent, block: WeekGridBlock) => void;
+  onBlockTouchStart?: (e: React.TouchEvent, block: WeekGridBlock) => void;
   /** 키보드로 블록을 실행할 때. 포인터 탭과 같은 편집 화면을 연다. */
   onBlockActivate?: (block: WeekGridBlock) => void;
   /**
@@ -202,6 +205,7 @@ export function WeekGrid({
   timeWidth = 30,
   loading = false,
   onBlockPointerDown,
+  onBlockTouchStart,
   onBlockActivate,
   visibleCols,
   scrollRef,
@@ -245,8 +249,8 @@ export function WeekGrid({
       top: stackTop + 1 + lane * (stackHeight + stackGap),
       width: colWidth - 4,
       height: stackHeight,
-      background: c.bg,
-      border: `1.5px ${dashed ? 'dashed' : 'solid'} ${c.bd}`,
+      background: b.invalidDrop ? '#FFF1EC' : c.bg,
+      border: `1.5px ${dashed ? 'dashed' : 'solid'} ${b.invalidDrop ? 'var(--danger)' : c.bd}`,
       borderRadius: radius,
       padding: '3px 4px',
       overflow: 'hidden',
@@ -281,7 +285,7 @@ export function WeekGrid({
             className="tnum"
             style={{ fontSize: wide ? 10 : 8, color: c.fg, opacity: 0.7, marginTop: 1 }}
           >
-            {b.subLabel}
+          {b.invalidDrop ? '놓을 수 없음 · ' : ''}{b.subLabel}
           </div>
         )}
       </>
@@ -299,6 +303,7 @@ export function WeekGrid({
       <button
         key={b.id + (seg.tail ? '-tail' : '')}
         onPointerDown={(e) => onBlockPointerDown?.(e, b)}
+        onTouchStart={(e) => onBlockTouchStart?.(e, b)}
         onClick={(e) => {
           // 이동 가능한 블록의 포인터 탭은 호출부의 pointerup 이 처리한다. 하지만
           // 고정 일정은 드래그 핸들러가 즉시 반환하므로 일반 클릭 경로에서 열어야 한다.
@@ -312,7 +317,7 @@ export function WeekGrid({
           textAlign: 'left',
           fontFamily: 'inherit',
           opacity: b.dragging ? 0.85 : 1,
-          boxShadow: b.dragging ? 'var(--shadow-lg)' : 'none',
+          boxShadow: b.invalidDrop ? '0 0 0 2px rgba(190, 67, 50, .2)' : b.dragging ? 'var(--shadow-lg)' : 'none',
           zIndex: b.dragging ? 10 : 1,
           // 터치는 화면 스크롤이 기본이다. 호출부가 길게 누르기를 확인한 뒤에만
           // 드래그를 활성화하므로, 여기서 브라우저 제스처를 선제적으로 막지 않는다.

--- a/src/components/WeekGrid.tsx
+++ b/src/components/WeekGrid.tsx
@@ -295,9 +295,10 @@ export function WeekGrid({
         key={b.id + (seg.tail ? '-tail' : '')}
         onPointerDown={(e) => onBlockPointerDown?.(e, b)}
         onClick={(e) => {
-          // 포인터 탭은 호출부의 pointerup 이 처리한다. 키보드/보조기술이 만든
-          // detail=0 클릭만 별도 경로로 열어 중복 실행을 피한다.
-          if (e.detail === 0) onBlockActivate?.(b);
+          // 이동 가능한 블록의 포인터 탭은 호출부의 pointerup 이 처리한다. 하지만
+          // 고정 일정은 드래그 핸들러가 즉시 반환하므로 일반 클릭 경로에서 열어야 한다.
+          // 키보드/보조기술이 만든 detail=0 클릭도 이 경로를 함께 사용한다.
+          if (b.fixed || e.detail === 0) onBlockActivate?.(b);
         }}
         aria-label={`${b.title}${b.subLabel ? `, ${b.subLabel}` : ''}${laneCount > 1 ? `, 같은 시간대 일정 ${laneCount}개` : ''}. 탭하면 수정, 모바일에서는 길게 눌러 끌면 이동`}
         style={{

--- a/src/components/WeekGrid.tsx
+++ b/src/components/WeekGrid.tsx
@@ -25,6 +25,8 @@ export interface WeekGridBlock {
 
 export interface WeekGridProps {
   blocks: WeekGridBlock[];
+  /** 드래그 중 카드 재배치 전의 배치 기준. 스택의 나머지 카드가 갑자기 늘어나지 않게 한다. */
+  layoutBlocks?: WeekGridBlock[];
   /** 뒤에 흐리게 깔리는 층. 클릭 불가 — 비교용 잔상이다. */
   backdrop?: WeekGridBlock[];
   /** 요일 아래 날짜 숫자(길이 7). 없으면 요일 글자만 나온다. */
@@ -188,6 +190,7 @@ export function scrollColIntoView(
  */
 export function WeekGrid({
   blocks,
+  layoutBlocks,
   backdrop = [],
   dayNumbers,
   todayCol = null,
@@ -209,7 +212,7 @@ export function WeekGrid({
   const hours = Array.from({ length: endHour - startHour }, (_, i) => startHour + i);
   const toY = (m: number) => ((m - startHour * 60) * hourPx) / 60;
   const bodyWidth = colWidth * cols.length;
-  const blockLayouts = overlapLayouts(blocks);
+  const blockLayouts = overlapLayouts(layoutBlocks ?? blocks);
 
   const renderSegment = (b: WeekGridBlock, seg: Segment, interactive: boolean) => {
     const slot = slotOf(seg.col);
@@ -223,7 +226,9 @@ export function WeekGrid({
     const split = b.startMin + b.durMin > DAY_MIN;
     const radius = !split ? 6 : seg.tail ? '0 0 6px 6px' : '6px 6px 0 0';
     const layoutKey = `${b.id}:${seg.tail ? 'tail' : 'head'}`;
-    const layout = interactive ? blockLayouts.get(layoutKey) : undefined;
+    // 끌고 있는 카드는 원래 스택 칸에 가두지 않고 실제 시간 위치에 온전한 크기로 띄운다.
+    // 나머지 카드는 layoutBlocks의 원래 배치를 유지해 드래그 도중 요동치지 않는다.
+    const layout = interactive && !b.dragging ? blockLayouts.get(layoutKey) : undefined;
     const laneCount = layout?.laneCount ?? 1;
     const lane = layout?.lane ?? 0;
     const stackGap = laneCount > 1 ? 1 : 0;

--- a/src/screens/WeeklyCalendarScreen.tsx
+++ b/src/screens/WeeklyCalendarScreen.tsx
@@ -284,8 +284,8 @@ export function WeeklyCalendarScreenV2() {
   };
 
   // 화면 Block → WeekGrid 가 받는 모양. 드래그 중이면 고스트 위치로 미리 옮겨 그린다.
-  const toGridBlock = (b: BlockWithStatus): WeekGridBlock => {
-    const dragging = dragGhost?.id === b.id;
+  const toGridBlock = (b: BlockWithStatus, applyGhost = true): WeekGridBlock => {
+    const dragging = applyGhost && dragGhost?.id === b.id;
     const tMin = dragging ? dragGhost!.minute : parseMin(b.time);
     return {
       id: b.id,
@@ -632,7 +632,8 @@ export function WeeklyCalendarScreenV2() {
 
       <WeekGrid
         scrollRef={gridRef}
-        blocks={blocks.map(toGridBlock)}
+        blocks={blocks.map((block) => toGridBlock(block))}
+        layoutBlocks={blocks.map((block) => toGridBlock(block, false))}
         dayNumbers={dayNumbers}
         todayCol={isThisWeek ? TODAY : null}
         nowMin={nowMin}

--- a/src/screens/WeeklyCalendarScreen.tsx
+++ b/src/screens/WeeklyCalendarScreen.tsx
@@ -297,6 +297,7 @@ export function WeeklyCalendarScreenV2() {
       subLabel: `${dragging ? formatHHMM(tMin) : b.time}·${b.dur}분`,
       colors: blockStyle(b),
       dragging,
+      invalidDrop: dragging && !!dragGhost?.invalidReason,
       fixed: b.fixed,
     };
   };
@@ -306,7 +307,7 @@ export function WeeklyCalendarScreenV2() {
   // 그리드 root ref — pointermove 시 root 기준 상대 좌표 계산.
   const gridRef = useRef<HTMLDivElement>(null);
   // 현재 드래그 중인 블록의 임시 위치 (커밋 전). 드래그 끝나면 null.
-  const [dragGhost, setDragGhost] = useState<{ id: string; day: number; minute: number } | null>(null);
+  const [dragGhost, setDragGhost] = useState<{ id: string; day: number; minute: number; invalidReason?: string } | null>(null);
   // 더블탭/터치 보정용 — 단순 클릭과 드래그 시작을 구분.
   const dragMovedRef = useRef(false);
 
@@ -411,37 +412,29 @@ export function WeeklyCalendarScreenV2() {
   // pointerdown 핸들러 — 블록에 등록.
   const handleBlockPointerDown = (e: React.PointerEvent, block: BlockWithStatus) => {
     if (block.fixed) return; // 고정 블록은 드래그 불가.
+    // 터치는 아래 TouchSensor 경로가 맡는다. Pointer Events와 동시에 처리하면
+    // 브라우저 스크롤의 pointercancel과 두 상태 머신이 서로 경합한다.
+    if (e.pointerType === 'touch') return;
     e.stopPropagation();
     if (e.pointerType === 'mouse' && e.button !== 0) return;
-    const isTouch = e.pointerType === 'touch';
-    if (!isTouch) e.preventDefault();
+    e.preventDefault();
     const startX = e.clientX;
     const startY = e.clientY;
     const startDay = block.day;
     const startMinute = parseMin(block.time);
     dragMovedRef.current = false;
     const targetEl = e.currentTarget as HTMLElement;
-    let dragEnabled = !isTouch;
+    const dragEnabled = true;
     let cancelled = false;
-    let timer: number | null = isTouch ? window.setTimeout(() => {
-      if (cancelled) return;
-      dragEnabled = true;
-      timer = null;
-      targetEl.setPointerCapture(e.pointerId);
-      showToast('이제 끌어서 시간을 옮길 수 있어요');
-    }, 300) : null;
-
-    const blockScrollWhileDragging = (ev: TouchEvent) => {
-      if (dragEnabled && !cancelled) ev.preventDefault();
-    };
+    // 마우스·펜은 버튼의 좁은 경계를 벗어나도 move/up을 계속 받아야 한다.
+    targetEl.setPointerCapture(e.pointerId);
 
     const cleanup = () => {
       cancelled = true;
-      if (timer != null) window.clearTimeout(timer);
       targetEl.removeEventListener('pointermove', onMove);
       targetEl.removeEventListener('pointerup', onUp);
       targetEl.removeEventListener('pointercancel', onCancel);
-      window.removeEventListener('touchmove', blockScrollWhileDragging);
+      if (targetEl.hasPointerCapture(e.pointerId)) targetEl.releasePointerCapture(e.pointerId);
     };
 
     const onMove = (ev: PointerEvent) => {
@@ -456,11 +449,13 @@ export function WeeklyCalendarScreenV2() {
         dragMovedRef.current = true;
       }
       if (!dragMovedRef.current) return;
+      ev.preventDefault();
       // 픽셀 → 분 변환. 15분 snap.
       const minDelta = Math.round((dy / HOUR_PX) * 60 / SNAP_MIN) * SNAP_MIN;
       const newDay = dayFromDx(startDay, dx);
       const newMinute = clampStart(startMinute + minDelta);
-      setDragGhost({ id: block.id, day: newDay, minute: newMinute });
+      const validation = localValidate(block.id, newDay, newMinute, block.dur);
+      setDragGhost({ id: block.id, day: newDay, minute: newMinute, invalidReason: validation.ok ? undefined : validation.message });
     };
 
     const onUp = (ev: PointerEvent) => {
@@ -490,7 +485,84 @@ export function WeeklyCalendarScreenV2() {
     targetEl.addEventListener('pointermove', onMove);
     targetEl.addEventListener('pointerup', onUp);
     targetEl.addEventListener('pointercancel', onCancel);
-    window.addEventListener('touchmove', blockScrollWhileDragging, { passive: false });
+  };
+
+  // dnd-kit TouchSensor와 같은 방식: 250ms long-press + 5px tolerance.
+  // Pointer Events는 touch-action:manipulation에서 스크롤이 시작되면 pointercancel되므로,
+  // 터치만 별도 non-passive touchmove로 받아 활성화 이후 스크롤을 확실히 막는다.
+  const handleBlockTouchStart = (e: React.TouchEvent, block: BlockWithStatus) => {
+    if (block.fixed || e.touches.length !== 1) return;
+    e.stopPropagation();
+    const touch = e.touches[0];
+    const touchId = touch.identifier;
+    const startX = touch.clientX;
+    const startY = touch.clientY;
+    const startDay = block.day;
+    const startMinute = parseMin(block.time);
+    let activated = false;
+    let moved = false;
+    let cancelled = false;
+    let lastX = startX;
+    let lastY = startY;
+
+    const timer = window.setTimeout(() => {
+      if (cancelled) return;
+      activated = true;
+      showToast('일정을 잡았어요. 끌어서 옮기세요');
+    }, 250);
+
+    const point = (event: TouchEvent, changed = false) => {
+      const list = changed ? event.changedTouches : event.touches;
+      return Array.from(list).find((item) => item.identifier === touchId);
+    };
+    const cleanup = () => {
+      if (cancelled) return;
+      cancelled = true;
+      window.clearTimeout(timer);
+      window.removeEventListener('touchmove', onMove);
+      window.removeEventListener('touchend', onEnd);
+      window.removeEventListener('touchcancel', onCancel);
+    };
+    const calculate = (x: number, y: number) => {
+      const dx = x - startX;
+      const dy = y - startY;
+      return {
+        day: dayFromDx(startDay, dx),
+        minute: clampStart(startMinute + Math.round((dy / HOUR_PX) * 60 / SNAP_MIN) * SNAP_MIN),
+      };
+    };
+    const onMove = (event: TouchEvent) => {
+      const current = point(event);
+      if (!current) return;
+      lastX = current.clientX;
+      lastY = current.clientY;
+      const distance = Math.hypot(lastX - startX, lastY - startY);
+      if (!activated) {
+        if (distance > 5) cleanup(); // long-press 전 움직임은 캘린더 스크롤.
+        return;
+      }
+      event.preventDefault();
+      if (distance <= 5) return;
+      moved = true;
+      const next = calculate(lastX, lastY);
+      const validation = localValidate(block.id, next.day, next.minute, block.dur);
+      setDragGhost({ id: block.id, day: next.day, minute: next.minute, invalidReason: validation.ok ? undefined : validation.message });
+    };
+    const onEnd = (event: TouchEvent) => {
+      const ended = point(event, true);
+      if (ended) { lastX = ended.clientX; lastY = ended.clientY; }
+      cleanup();
+      setDragGhost(null);
+      if (!activated || !moved) { setEditing(block); return; }
+      const next = calculate(lastX, lastY);
+      if (next.day === startDay && next.minute === startMinute) return;
+      commitMove(block, next.day, next.minute);
+    };
+    const onCancel = () => { cleanup(); setDragGhost(null); };
+
+    window.addEventListener('touchmove', onMove, { passive: false });
+    window.addEventListener('touchend', onEnd);
+    window.addEventListener('touchcancel', onCancel);
   };
 
   // 조작법은 상시 배너 대신 최초 1회만 알려준다.
@@ -628,6 +700,11 @@ export function WeeklyCalendarScreenV2() {
             같은 시간대 일정 {conflictIds.size}개를 위아래로 나눠 표시했어요. 일정을 눌러 시간을 조정할 수 있어요.
           </div>
         )}
+        {dragGhost && (
+          <div role="status" aria-live="polite" style={{ marginTop: 8, padding: '8px 10px', borderRadius: 10, background: dragGhost.invalidReason ? '#FFF1EC' : 'var(--brand-soft)', border: `1px solid ${dragGhost.invalidReason ? 'var(--coral-200)' : 'var(--sand-200)'}`, color: dragGhost.invalidReason ? 'var(--danger)' : 'var(--text-2)', fontSize: 11.5, fontWeight: 700 }}>
+            {formatHHMM(dragGhost.minute)} · {dragGhost.invalidReason ?? '여기에 놓으면 이동해요'}
+          </div>
+        )}
       </div>
 
       <WeekGrid
@@ -647,6 +724,10 @@ export function WeeklyCalendarScreenV2() {
         onBlockPointerDown={(e, gb) => {
           const b = blocks.find((x) => x.id === gb.id);
           if (b) handleBlockPointerDown(e, b);
+        }}
+        onBlockTouchStart={(e, gb) => {
+          const b = blocks.find((x) => x.id === gb.id);
+          if (b) handleBlockTouchStart(e, b);
         }}
         onBlockActivate={(gb) => {
           const b = blocks.find((x) => x.id === gb.id);

--- a/src/screens/WeeklyPlanGenerationScreen.tsx
+++ b/src/screens/WeeklyPlanGenerationScreen.tsx
@@ -435,6 +435,7 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
     const targetEl = e.currentTarget as HTMLElement;
     let dragEnabled = !isTouch;
     let cancelled = false;
+    if (!isTouch) targetEl.setPointerCapture(e.pointerId);
     let timer: number | null = isTouch ? window.setTimeout(() => {
       if (cancelled) return;
       dragEnabled = true;
@@ -451,6 +452,7 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
       targetEl.removeEventListener('pointerup', onUp);
       targetEl.removeEventListener('pointercancel', onCancel);
       window.removeEventListener('touchmove', blockScrollWhileDragging);
+      if (targetEl.hasPointerCapture(e.pointerId)) targetEl.releasePointerCapture(e.pointerId);
     };
     const calc = (ev: PointerEvent) => {
       const minDelta = Math.round(((ev.clientY - startY) / HOUR_PX) * 60 / SNAP_MIN) * SNAP_MIN;
@@ -466,6 +468,7 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
       }
       if (!dragMovedRef.current && distance > 5) dragMovedRef.current = true;
       if (!dragMovedRef.current) return;
+      ev.preventDefault();
       const { newDay, newMinute } = calc(ev);
       setDragGhost({ id: block.id, day: newDay, minute: newMinute });
     };

--- a/src/screens/WeeklyPlanGenerationScreen.tsx
+++ b/src/screens/WeeklyPlanGenerationScreen.tsx
@@ -372,8 +372,8 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
   }, [generating, firstCol, COL_W, TIME_W, genWeekOffset]);
 
   // 화면 Block → WeekGrid 가 받는 모양. backdrop(기존 계획)은 muted 로 넘겨 뒤에 흐리게 깔린다.
-  const toGridBlock = (b: Block, col: number, muted = false): WeekGridBlock => {
-    const dragging = dragGhost?.id === b.id;
+  const toGridBlock = (b: Block, col: number, muted = false, applyGhost = true): WeekGridBlock => {
+    const dragging = applyGhost && dragGhost?.id === b.id;
     return {
       id: b.id,
       col: dragging ? dragGhost!.day : col,
@@ -588,6 +588,7 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
       <WeekGrid
         scrollRef={gridRef}
         blocks={weekBlocks.map(({ b, col }) => toGridBlock(b, col))}
+        layoutBlocks={weekBlocks.map(({ b, col }) => toGridBlock(b, col, false, false))}
         backdrop={weekExisting.map(({ b, col }) => toGridBlock(b, col, true))}
         dayNumbers={dayNumbers}
         todayCol={TODAY >= 0 ? TODAY : null}


### PR DESCRIPTION
## 조사
- MDN Pointer Events: 브라우저가 터치 스크롤을 시작하면 `pointercancel`이 발생하며 `touch-action` 결정은 제스처 시작 시점에 이뤄짐
- dnd-kit TouchSensor: 터치는 250ms delay + 5px tolerance 및 non-passive touchmove 권장
- FullCalendar: 모바일 일정 이동은 long-press 활성화 후 drag 권장

## 실제 재현
390px Chromium 터치 환경에 13:00~15:00 일정 3개를 주입했습니다. 기존 구현은 가운데 카드를 길게 눌러 내릴 때 캘린더 스크롤도 함께 움직였고, 충돌 위치에서는 이유가 불명확한 채 복귀했습니다.

## 변경
- 터치를 Pointer Events와 분리한 전용 TouchSensor 경로 추가
- 250ms long-press + 5px 이동 허용 오차
- 활성화 이후 non-passive touchmove로 스크롤/드래그 경합 차단
- 마우스·펜은 pointerdown 즉시 pointer capture
- 드래그 중 목표 시각을 상시 표시
- 충돌 위치는 붉은 점선과 `놓을 수 없음`, 구체적 충돌 사유로 놓기 전에 안내

별도 라이브러리는 추가하지 않았습니다. dnd-kit 도입 시 기존 시간 좌표·15분 스냅·서버 검증을 전부 어댑터로 다시 작성해야 하는 반면, 문제의 핵심인 센서 패턴은 공식 TouchSensor 방식으로 작은 범위에 적용할 수 있었습니다.

## 검증
- npm run build
- npm run check:api
- npm run check:fields
- git diff --check