### PR TITLE
fix: 겹친 모든 일정의 드래그 허용

### DIFF
--- a/src/components/WeekGrid.tsx
+++ b/src/components/WeekGrid.tsx
@@ -305,15 +305,14 @@ export function WeekGrid({
         onPointerDown={(e) => onBlockPointerDown?.(e, b)}
         onTouchStart={(e) => onBlockTouchStart?.(e, b)}
         onClick={(e) => {
-          // 이동 가능한 블록의 포인터 탭은 호출부의 pointerup 이 처리한다. 하지만
-          // 고정 일정은 드래그 핸들러가 즉시 반환하므로 일반 클릭 경로에서 열어야 한다.
-          // 키보드/보조기술이 만든 detail=0 클릭도 이 경로를 함께 사용한다.
-          if (b.fixed || e.detail === 0) onBlockActivate?.(b);
+          // 포인터 탭은 호출부의 pointerup/touchend가 처리한다. 키보드/보조기술이
+          // 만든 detail=0 클릭만 별도 경로로 열어 중복 실행을 피한다.
+          if (e.detail === 0) onBlockActivate?.(b);
         }}
         aria-label={`${b.title}${b.subLabel ? `, ${b.subLabel}` : ''}${laneCount > 1 ? `, 같은 시간대 일정 ${laneCount}개` : ''}. 탭하면 수정, 모바일에서는 길게 눌러 끌면 이동`}
         style={{
           ...common,
-          cursor: b.fixed ? 'pointer' : b.dragging ? 'grabbing' : 'grab',
+          cursor: b.dragging ? 'grabbing' : 'grab',
           textAlign: 'left',
           fontFamily: 'inherit',
           opacity: b.dragging ? 0.85 : 1,

--- a/src/screens/WeeklyCalendarScreen.tsx
+++ b/src/screens/WeeklyCalendarScreen.tsx
@@ -411,7 +411,6 @@ export function WeeklyCalendarScreenV2() {
 
   // pointerdown 핸들러 — 블록에 등록.
   const handleBlockPointerDown = (e: React.PointerEvent, block: BlockWithStatus) => {
-    if (block.fixed) return; // 고정 블록은 드래그 불가.
     // 터치는 아래 TouchSensor 경로가 맡는다. Pointer Events와 동시에 처리하면
     // 브라우저 스크롤의 pointercancel과 두 상태 머신이 서로 경합한다.
     if (e.pointerType === 'touch') return;
@@ -491,7 +490,7 @@ export function WeeklyCalendarScreenV2() {
   // Pointer Events는 touch-action:manipulation에서 스크롤이 시작되면 pointercancel되므로,
   // 터치만 별도 non-passive touchmove로 받아 활성화 이후 스크롤을 확실히 막는다.
   const handleBlockTouchStart = (e: React.TouchEvent, block: BlockWithStatus) => {
-    if (block.fixed || e.touches.length !== 1) return;
+    if (e.touches.length !== 1) return;
     e.stopPropagation();
     const touch = e.touches[0];
     const touchId = touch.identifier;

--- a/src/screens/WeeklyPlanGenerationScreen.tsx
+++ b/src/screens/WeeklyPlanGenerationScreen.tsx
@@ -423,7 +423,6 @@ export function WeeklyPlanGenerationScreen({ onContinue }: WeeklyPlanGenerationS
   // 블록 드래그 이동 — 메인 캘린더(S14)와 동일 조작을 온보딩 draft 에 이식.
   // draft 라 API 는 없고 로컬 state 만 갱신(승인 전이므로). 안 움직이면 탭=편집.
   const handleBlockPointerDown = (e: React.PointerEvent, block: Block, col: number) => {
-    if (block.fixed) return; // 고정 블록은 이동 불가.
     e.stopPropagation();
     if (e.pointerType === 'mouse' && e.button !== 0) return;
     const isTouch = e.pointerType === 'touch';


### PR DESCRIPTION
## 원인
세로 스택 계산 문제가 아니라 `source === fixed` 카드의 포인터·터치 드래그를 프론트에서 명시적으로 반환하고 있었습니다. 그래서 같은 시간대 세 카드 중 일반 계획 하나만 이동하고 나머지는 상세보기만 열렸습니다.

## 변경
- fixed/source 구분 없이 모든 일정 카드에 포인터·터치 드래그 적용
- 모든 카드에 grab/grabbing 커서 적용
- fixed 카드 전용 클릭 예외 제거로 상세보기 중복 실행 방지
- 메인 주간 캘린더와 계획 생성 시간표에 동일 적용

## 백엔드 확인
PATCH `/plans/{planId}/blocks/{blockId}`는 source 제한 없이 블록 이동을 허용하며, 이동 성공 시 source를 `user_edit`로 전환합니다.

## 검증
- npm run build
- npm run check:api
- npm run check:fields
- git diff --check