### PR TITLE
fix: 캘린더 드래그 단계를 시각적으로 구분

### DIFF
--- a/src/components/WeekGrid.tsx
+++ b/src/components/WeekGrid.tsx
@@ -19,6 +19,7 @@ export interface WeekGridBlock {
   muted?: boolean;
   /** 드래그 중 — 점선 + 그림자로 들린 느낌을 준다. */
   dragging?: boolean;
+  dragPhase?: 'pressing' | 'picked' | 'moving';
   /** 현재 가리키는 위치에 놓을 수 없는 드래그 고스트. */
   invalidDrop?: boolean;
   /** 고정 일정(수업·알바 등). 옮길 수 없으니 grab 커서를 주지 않는다. */
@@ -312,16 +313,17 @@ export function WeekGrid({
         aria-label={`${b.title}${b.subLabel ? `, ${b.subLabel}` : ''}${laneCount > 1 ? `, 같은 시간대 일정 ${laneCount}개` : ''}. 탭하면 수정, 모바일에서는 길게 눌러 끌면 이동`}
         style={{
           ...common,
-          cursor: b.dragging ? 'grabbing' : 'grab',
+          cursor: b.dragPhase === 'picked' || b.dragPhase === 'moving' ? 'grabbing' : 'grab',
           textAlign: 'left',
           fontFamily: 'inherit',
-          opacity: b.dragging ? 0.85 : 1,
-          boxShadow: b.invalidDrop ? '0 0 0 2px rgba(190, 67, 50, .2)' : b.dragging ? 'var(--shadow-lg)' : 'none',
-          zIndex: b.dragging ? 10 : 1,
+          opacity: b.dragPhase === 'pressing' ? 0.72 : b.dragging ? 0.92 : 1,
+          transform: b.dragPhase === 'pressing' ? 'scale(.97)' : b.dragPhase === 'picked' ? 'scale(1.025)' : 'none',
+          boxShadow: b.invalidDrop ? '0 0 0 2px rgba(190, 67, 50, .2)' : b.dragPhase === 'picked' || b.dragPhase === 'moving' ? 'var(--shadow-lg)' : 'none',
+          zIndex: b.dragPhase === 'picked' || b.dragPhase === 'moving' ? 10 : 1,
           // 터치는 화면 스크롤이 기본이다. 호출부가 길게 누르기를 확인한 뒤에만
           // 드래그를 활성화하므로, 여기서 브라우저 제스처를 선제적으로 막지 않는다.
           touchAction: 'manipulation',
-          transition: b.dragging ? 'none' : 'box-shadow 120ms',
+          transition: b.dragPhase === 'moving' ? 'none' : 'transform 120ms, opacity 120ms, box-shadow 120ms',
         }}
       >
         {label}

--- a/src/screens/WeeklyCalendarScreen.tsx
+++ b/src/screens/WeeklyCalendarScreen.tsx
@@ -285,19 +285,22 @@ export function WeeklyCalendarScreenV2() {
 
   // 화면 Block → WeekGrid 가 받는 모양. 드래그 중이면 고스트 위치로 미리 옮겨 그린다.
   const toGridBlock = (b: BlockWithStatus, applyGhost = true): WeekGridBlock => {
-    const dragging = applyGhost && dragGhost?.id === b.id;
-    const tMin = dragging ? dragGhost!.minute : parseMin(b.time);
+    const moving = applyGhost && dragGhost?.id === b.id;
+    const intentPhase = applyGhost && dragIntent?.id === b.id ? dragIntent.phase : undefined;
+    const dragging = moving || intentPhase === 'picked';
+    const tMin = moving ? dragGhost!.minute : parseMin(b.time);
     return {
       id: b.id,
-      col: dragging ? dragGhost!.day : b.day,
+      col: moving ? dragGhost!.day : b.day,
       startMin: tMin,
       durMin: b.dur,
       title: b.title,
       glyph: b.status === 'done' ? '✓ ' : b.status === 'failed' ? '✗ ' : b.carryover ? '↩ ' : undefined,
-      subLabel: `${dragging ? formatHHMM(tMin) : b.time}·${b.dur}분`,
+      subLabel: `${moving ? formatHHMM(tMin) : b.time}·${b.dur}분`,
       colors: blockStyle(b),
       dragging,
-      invalidDrop: dragging && !!dragGhost?.invalidReason,
+      dragPhase: moving ? 'moving' : intentPhase,
+      invalidDrop: moving && !!dragGhost?.invalidReason,
       fixed: b.fixed,
     };
   };
@@ -308,6 +311,7 @@ export function WeeklyCalendarScreenV2() {
   const gridRef = useRef<HTMLDivElement>(null);
   // 현재 드래그 중인 블록의 임시 위치 (커밋 전). 드래그 끝나면 null.
   const [dragGhost, setDragGhost] = useState<{ id: string; day: number; minute: number; invalidReason?: string } | null>(null);
+  const [dragIntent, setDragIntent] = useState<{ id: string; phase: 'pressing' | 'picked' } | null>(null);
   // 더블탭/터치 보정용 — 단순 클릭과 드래그 시작을 구분.
   const dragMovedRef = useRef(false);
 
@@ -422,6 +426,7 @@ export function WeeklyCalendarScreenV2() {
     const startDay = block.day;
     const startMinute = parseMin(block.time);
     dragMovedRef.current = false;
+    setDragIntent({ id: block.id, phase: 'pressing' });
     const targetEl = e.currentTarget as HTMLElement;
     const dragEnabled = true;
     let cancelled = false;
@@ -430,6 +435,7 @@ export function WeeklyCalendarScreenV2() {
 
     const cleanup = () => {
       cancelled = true;
+      setDragIntent((current) => current?.id === block.id ? null : current);
       targetEl.removeEventListener('pointermove', onMove);
       targetEl.removeEventListener('pointerup', onUp);
       targetEl.removeEventListener('pointercancel', onCancel);
@@ -446,6 +452,7 @@ export function WeeklyCalendarScreenV2() {
       }
       if (!dragMovedRef.current && Math.hypot(dx, dy) > 5) {
         dragMovedRef.current = true;
+        setDragIntent({ id: block.id, phase: 'picked' });
       }
       if (!dragMovedRef.current) return;
       ev.preventDefault();
@@ -503,10 +510,12 @@ export function WeeklyCalendarScreenV2() {
     let cancelled = false;
     let lastX = startX;
     let lastY = startY;
+    setDragIntent({ id: block.id, phase: 'pressing' });
 
     const timer = window.setTimeout(() => {
       if (cancelled) return;
       activated = true;
+      setDragIntent({ id: block.id, phase: 'picked' });
       showToast('일정을 잡았어요. 끌어서 옮기세요');
     }, 250);
 
@@ -517,6 +526,7 @@ export function WeeklyCalendarScreenV2() {
     const cleanup = () => {
       if (cancelled) return;
       cancelled = true;
+      setDragIntent((current) => current?.id === block.id ? null : current);
       window.clearTimeout(timer);
       window.removeEventListener('touchmove', onMove);
       window.removeEventListener('touchend', onEnd);
@@ -699,9 +709,13 @@ export function WeeklyCalendarScreenV2() {
             같은 시간대 일정 {conflictIds.size}개를 위아래로 나눠 표시했어요. 일정을 눌러 시간을 조정할 수 있어요.
           </div>
         )}
-        {dragGhost && (
-          <div role="status" aria-live="polite" style={{ marginTop: 8, padding: '8px 10px', borderRadius: 10, background: dragGhost.invalidReason ? '#FFF1EC' : 'var(--brand-soft)', border: `1px solid ${dragGhost.invalidReason ? 'var(--coral-200)' : 'var(--sand-200)'}`, color: dragGhost.invalidReason ? 'var(--danger)' : 'var(--text-2)', fontSize: 11.5, fontWeight: 700 }}>
-            {formatHHMM(dragGhost.minute)} · {dragGhost.invalidReason ?? '여기에 놓으면 이동해요'}
+        {(dragIntent || dragGhost) && (
+          <div role="status" aria-live="polite" style={{ marginTop: 8, padding: '8px 10px', borderRadius: 10, background: dragGhost?.invalidReason ? '#FFF1EC' : 'var(--brand-soft)', border: `1px solid ${dragGhost?.invalidReason ? 'var(--coral-200)' : 'var(--sand-200)'}`, color: dragGhost?.invalidReason ? 'var(--danger)' : 'var(--text-2)', fontSize: 11.5, fontWeight: 700 }}>
+            {dragGhost
+              ? `${formatHHMM(dragGhost.minute)} · ${dragGhost.invalidReason ?? '여기에 놓으면 이동해요'}`
+              : dragIntent?.phase === 'picked'
+                ? '일정을 잡았어요 · 끌어서 이동하세요'
+                : '계속 누르면 일정을 잡아요'}
           </div>
         )}
       </div>


### PR DESCRIPTION
## 원인
기존 로직은 이동 거리 5px로 클릭/드래그를 내부 판별했지만, `dragGhost`가 실제 좌표 이동 뒤에만 생성되었습니다. 따라서 길게 누르는 중과 long-press로 잡힌 상태가 화면에서 동일해 사용자가 언제 이동을 시작해야 하는지 알 수 없었습니다.

## 변경
- 드래그 상태를 `pressing → picked → moving` 3단계로 분리
- pressing: 카드 축소·반투명 + `계속 누르면 일정을 잡아요`
- picked: 카드 확대·그림자·grabbing + `일정을 잡았어요 · 끌어서 이동하세요`
- moving: 목표 시각 및 놓기 가능/충돌 상태 실시간 표시
- 탭/스크롤 취소/놓기/pointercancel에서 상태를 확실히 정리
- 마우스·펜도 누름과 5px 이상 이동을 구분

## 검증
- npm run build
- npm run check:api
- npm run check:fields
- git diff --check