### PR TITLE
feat: 도움말을 화면 핵심 기능 중심으로 간소화

### DIFF
--- a/src/app/ReActionMerged.tsx
+++ b/src/app/ReActionMerged.tsx
@@ -110,7 +110,19 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
   const [tasks, setTasks] = useState<Task[]>([]);
   const rootRef = useRef<HTMLDivElement>(null);
   const [tourOpen, setTourOpen] = useState(false);
+  const [tourFirstRun, setTourFirstRun] = useState(false);
   useEffect(() => setTourOpen(false), [screen]);
+  useEffect(() => {
+    if (!TAB_SCREENS.includes(screen) || typeof window === 'undefined') return;
+    if (window.localStorage.getItem('reaction.guidedTour.core.v1') === 'done') return;
+    setTourFirstRun(true);
+    setTourOpen(true);
+  }, [screen]);
+  const closeTour = () => {
+    if (tourFirstRun && typeof window !== 'undefined') window.localStorage.setItem('reaction.guidedTour.core.v1', 'done');
+    setTourOpen(false);
+    setTourFirstRun(false);
+  };
   // 방금 끝난 목표 파악 인터뷰의 outcome — 목표 분류(S03) 화면이 GET /goals
   // (이 시점엔 항상 빈 테이블) 대신 이 값을 렌더한다(#75).
   const [interviewOutcome, setInterviewOutcome] = useState<InterviewOutcome | null>(null);
@@ -253,8 +265,8 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
       overflow: 'hidden', background: 'var(--surface-ground)',
       display: 'flex', flexDirection: 'column',
     }}>
-      <MergedTopNav screen={screen} onBack={goBack} onHelp={() => setTourOpen(true)} />
-      {screen === 'intro' && <button data-tour-ignore aria-label="현재 화면 도움말 열기" onClick={() => setTourOpen(true)} style={{ position: 'fixed', zIndex: 30, top: 10, right: 14, width: 44, height: 44, borderRadius: 9999, border: '1px solid var(--sand-200)', background: 'var(--surface-raised)', display: 'grid', placeItems: 'center' }}><Question size={18} /></button>}
+      <MergedTopNav screen={screen} onBack={goBack} onHelp={() => { setTourFirstRun(false); setTourOpen(true); }} />
+      {screen === 'intro' && <button data-tour-ignore aria-label="현재 화면 도움말 열기" onClick={() => { setTourFirstRun(false); setTourOpen(true); }} style={{ position: 'fixed', zIndex: 30, top: 10, right: 14, width: 44, height: 44, borderRadius: 9999, border: '1px solid var(--sand-200)', background: 'var(--surface-raised)', display: 'grid', placeItems: 'center' }}><Question size={18} /></button>}
 
       <div style={{ flex: 1, position: 'relative', minHeight: 0, display: 'flex', flexDirection: 'column' }}>
         {screen === 'intro' && (
@@ -366,7 +378,7 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
         {screen === 'settings' && <SettingsScreen />}
         {screen === 'my-info' && <MyInfoScreen />}
       </div>
-      <GuidedTourOverlay root={rootRef.current} open={tourOpen} screenLabel={NAV_META[screen].label} onClose={() => setTourOpen(false)} />
+      <GuidedTourOverlay root={rootRef.current} open={tourOpen} screenLabel={NAV_META[screen].label} firstRun={tourFirstRun} onClose={closeTour} />
 
       {showTabs && (
         <MergedTabBar

--- a/src/components/GuidedTourOverlay.tsx
+++ b/src/components/GuidedTourOverlay.tsx
@@ -1,101 +1,45 @@
 import { useEffect, useMemo, useState } from 'react';
 import { X } from '@phosphor-icons/react';
 
-type TourTarget = { element: HTMLElement; label: string; kind: string };
+type TourTarget = { element: HTMLElement; label: string; kind: string; persistent: boolean; score: number };
 type Rect = { top: number; left: number; right: number; bottom: number; width: number; height: number };
+const SELECTOR = '[role="tablist"], [aria-label="주요 화면"], button:not([disabled]), a[href], input:not([disabled]):not([type="hidden"]), textarea:not([disabled]), select:not([disabled]), [role="button"]:not([aria-disabled="true"])';
+const SUMMARIES: Record<string, string> = {
+  'RE:ACTION': '계획을 실행하고 다시 회복하도록 돕는 방식을 소개하는 시작 화면이에요.', '목표 파악': '대화를 통해 목표와 사용할 수 있는 시간을 구체화해요.', '목표 분류': '목표를 집중·유지·보류로 나눠 우선순위를 정해요.',
+  '마무리 확인': '계획 생성 전에 시간과 알림 조건을 확인해요.', '계획의 큰 그림': '중간 목표를 편집하고 순서를 정해 계획의 뼈대를 만들어요.', '참고 자료 찾기': '자료를 검색·검토한 뒤 계획에 반영할 내용을 선택해요.',
+  '주간 계획 생성': 'AI 시간표를 수정하고 확인한 뒤 실제 계획으로 확정해요.', '모닝 브리프': '오늘 가장 먼저 실행할 일과 조정 사항을 확인해요.', '오늘의 실행': '오늘 할 일의 상태를 확인하고 실행·완료·회복을 진행해요.',
+  '집중 모드': '한 가지 일정에 집중하며 시간과 진행 상태를 기록해요.', '복구 코치': '실패하거나 미룬 이유를 돌아보고 현실적인 회복안을 골라요.', '회복 완료': '선택한 회복안을 확인하고 다음 실행으로 돌아가요.',
+  '저녁 체크인': '오늘 실행 결과를 돌아보고 다음 계획에 반영해요.', '주간 계획': '이번 주 일정을 확인하고 상세보기·추가·시간 이동을 할 수 있어요.', 'LIFE INBOX': '생각과 할 일을 모으고 조언을 확인해 계획으로 연결해요.',
+  '주간 리뷰': '한 주의 실행 결과와 실패 패턴을 확인하고 다음 주를 조정해요.', '목표 관리': '진행 중인 목표와 우선순위를 한곳에서 관리해요.', '궁극적 목표': '장기적으로 이루고 싶은 방향을 대화로 구체화해요.',
+  '만다라트 초안': '궁극적 목표를 하위 영역으로 나눈 초안을 검토하고 승인해요.', '만다라트': '장기 목표와 세부 실천 영역을 구조적으로 확인해요.', '설정': '알림과 계정 등 앱 사용 환경을 관리해요.', '내 정보': '프로필과 계정 정보를 확인하고 관리해요.',
+};
 
-const SELECTOR = 'button:not([disabled]), a[href], input:not([disabled]):not([type="hidden"]), textarea:not([disabled]), select:not([disabled]), [role="button"]:not([aria-disabled="true"])';
+function visible(el: HTMLElement) { const r = el.getBoundingClientRect(); const s = getComputedStyle(el); return r.width > 0 && r.height > 0 && s.display !== 'none' && s.visibility !== 'hidden' && el.getAttribute('aria-hidden') !== 'true'; }
+function labelOf(el: HTMLElement) { return el.dataset.tourLabel || el.getAttribute('aria-label') || el.getAttribute('title') || ((el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) ? el.placeholder : '') || el.innerText.trim().replace(/\s+/g, ' ').slice(0, 60) || '이 조작 영역'; }
+function score(el: HTMLElement, label: string) { if (el.dataset.tourCore != null) return 100; if (el.matches('[role="tablist"], [aria-label="주요 화면"]')) return 95; if (['INPUT', 'TEXTAREA', 'SELECT'].includes(el.tagName)) return 85; if (/시작|확정|완료|저장|추가|검색|계속|실행|수정|생성|승인|회복/.test(label)) return 80; if (/뒤로|이전 주|다음 주|도움말/.test(label)) return 10; return el.tagName === 'BUTTON' ? 55 : 45; }
+function keyOf(t: TourTarget) { if (t.persistent) return `persistent:${t.label}`; if (/탭하면 수정|같은 시간대 일정/.test(t.label)) return 'calendar-card'; return `${t.kind}:${t.label.replace(/\d+/g, '#').slice(0, 40)}`; }
+function description(t: TourTarget) { if (t.element.getAttribute('aria-label') === '주요 화면') return '오늘 실행·주간 계획·인박스로 이동하는 고정 메뉴예요.'; if (t.element.getAttribute('role') === 'tablist') return '이 화면의 주요 보기 사이를 전환하는 메뉴예요.'; if (['INPUT', 'TEXTAREA', 'SELECT'].includes(t.kind)) return '내용을 입력하거나 선택하는 핵심 영역이에요.'; if (t.kind === 'A') return '연결된 화면이나 자료로 이동해요.'; return '이 화면에서 자주 사용하는 핵심 기능이에요.'; }
 
-function visible(element: HTMLElement) {
-  const rect = element.getBoundingClientRect();
-  const style = window.getComputedStyle(element);
-  return rect.width > 0 && rect.height > 0 && style.display !== 'none' && style.visibility !== 'hidden' && element.getAttribute('aria-hidden') !== 'true';
-}
-
-function labelOf(element: HTMLElement) {
-  return element.dataset.tourLabel || element.getAttribute('aria-label') || element.getAttribute('title') ||
-    (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement ? element.placeholder : '') ||
-    element.innerText.trim().replace(/\s+/g, ' ').slice(0, 60) || '이 조작 영역';
-}
-
-function descriptionOf(target: TourTarget) {
-  if (target.kind === 'INPUT' || target.kind === 'TEXTAREA' || target.kind === 'SELECT') return '내용을 입력하거나 선택하는 영역이에요.';
-  if (target.kind === 'A') return '누르면 연결된 화면이나 자료로 이동해요.';
-  return '누르면 이 기능을 실행할 수 있어요.';
-}
-
-export function GuidedTourOverlay({ root, open, screenLabel, onClose }: { root: HTMLElement | null; open: boolean; screenLabel: string; onClose: () => void }) {
-  const [targets, setTargets] = useState<TourTarget[]>([]);
-  const [index, setIndex] = useState(0);
-  const [rect, setRect] = useState<Rect | null>(null);
-
+export function GuidedTourOverlay({ root, open, screenLabel, firstRun = false, onClose }: { root: HTMLElement | null; open: boolean; screenLabel: string; firstRun?: boolean; onClose: () => void }) {
+  const [targets, setTargets] = useState<TourTarget[]>([]); const [index, setIndex] = useState(0); const [rect, setRect] = useState<Rect | null>(null);
   useEffect(() => {
     if (!open || !root) return;
-    const found = Array.from(root.querySelectorAll<HTMLElement>(SELECTOR))
-      .filter((el) => !el.closest('[data-tour-overlay]') && !el.closest('[data-tour-ignore]') && visible(el))
-      .map((element) => ({ element, label: labelOf(element), kind: element.tagName }));
-    setTargets(found);
-    setIndex(0);
-  }, [open, root, screenLabel]);
-
-  const current = targets[index];
-  useEffect(() => {
-    if (!open || !current) { setRect(null); return; }
-    current.element.scrollIntoView({ block: 'center', inline: 'center' });
-    const update = () => {
-      const r = current.element.getBoundingClientRect();
-      const gap = 6;
-      setRect({ top: Math.max(4, r.top - gap), left: Math.max(4, r.left - gap), right: Math.min(innerWidth - 4, r.right + gap), bottom: Math.min(innerHeight - 4, r.bottom + gap), width: r.width + gap * 2, height: r.height + gap * 2 });
-    };
-    const frame = requestAnimationFrame(() => requestAnimationFrame(update));
-    window.addEventListener('resize', update);
-    window.addEventListener('scroll', update, true);
-    return () => { cancelAnimationFrame(frame); window.removeEventListener('resize', update); window.removeEventListener('scroll', update, true); };
-  }, [open, current]);
-
-  useEffect(() => {
-    if (!open) return;
-    const key = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') onClose();
-      if (event.key === 'ArrowRight') setIndex((i) => Math.min(targets.length - 1, i + 1));
-      if (event.key === 'ArrowLeft') setIndex((i) => Math.max(0, i - 1));
-    };
-    window.addEventListener('keydown', key);
-    return () => window.removeEventListener('keydown', key);
-  }, [open, onClose, targets.length]);
-
-  const cardStyle = useMemo(() => {
-    if (!rect) return { top: '50%', left: 16, right: 16, transform: 'translateY(-50%)' };
-    const cardHeight = 180;
-    const below = rect.bottom + 14;
-    return below + cardHeight < innerHeight
-      ? { top: below, left: Math.max(16, Math.min(rect.left, innerWidth - 336)) }
-      : { bottom: Math.max(16, innerHeight - rect.top + 14), left: Math.max(16, Math.min(rect.left, innerWidth - 336)) };
-  }, [rect]);
-
-  if (!open) return null;
-  const shade = 'rgba(31, 27, 23, .68)';
-  return (
-    <div data-tour-overlay role="dialog" aria-modal="true" aria-label={`${screenLabel} 화면 사용법`} style={{ position: 'fixed', inset: 0, zIndex: 1000 }}>
-      {rect ? <>
-        <div style={{ position: 'fixed', inset: `0 0 ${innerHeight - rect.top}px 0`, background: shade }} />
-        <div style={{ position: 'fixed', top: rect.top, left: 0, width: rect.left, height: rect.height, background: shade }} />
-        <div style={{ position: 'fixed', top: rect.top, left: rect.right, right: 0, height: rect.height, background: shade }} />
-        <div style={{ position: 'fixed', inset: `${rect.bottom}px 0 0 0`, background: shade }} />
-        <div aria-hidden style={{ position: 'fixed', top: rect.top, left: rect.left, width: rect.width, height: rect.height, border: '3px solid var(--brand)', borderRadius: 12, boxShadow: '0 0 0 3px rgba(255,252,246,.9)', pointerEvents: 'auto' }} />
-      </> : <div style={{ position: 'fixed', inset: 0, background: shade }} />}
-      <section style={{ position: 'fixed', ...cardStyle, width: 'min(320px, calc(100vw - 32px))', boxSizing: 'border-box', borderRadius: 18, padding: 18, background: 'var(--surface-raised)', color: 'var(--text-1)', boxShadow: '0 18px 48px rgba(0,0,0,.3)' }}>
-        <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12, alignItems: 'center' }}>
-          <span style={{ color: 'var(--brand)', fontSize: 12, fontWeight: 800 }}>{screenLabel} · {targets.length ? `${index + 1}/${targets.length}` : '안내'}</span>
-          <button data-tour-ignore onClick={onClose} aria-label="도움말 닫기" style={{ width: 44, height: 44, border: 0, borderRadius: 999, background: 'var(--sand-100)', display: 'grid', placeItems: 'center', cursor: 'pointer' }}><X size={18} /></button>
-        </div>
-        <h2 style={{ margin: '4px 0 6px', fontSize: 18 }}>{current?.label || '이 화면에는 조작할 버튼이 없어요'}</h2>
-        <p style={{ margin: 0, color: 'var(--text-2)', fontSize: 14, lineHeight: 1.55 }}>{current ? descriptionOf(current) : '화면의 내용을 확인한 뒤 도움말을 닫아 주세요.'}</p>
-        <div style={{ display: 'flex', gap: 8, marginTop: 16 }}>
-          <button onClick={() => setIndex((i) => Math.max(0, i - 1))} disabled={index === 0 || !targets.length} style={{ minHeight: 44, flex: 1, borderRadius: 12, border: '1px solid var(--sand-200)', background: 'var(--surface-raised)', fontFamily: 'inherit' }}>이전</button>
-          <button onClick={() => index >= targets.length - 1 ? onClose() : setIndex((i) => i + 1)} style={{ minHeight: 44, flex: 1, borderRadius: 12, border: 0, background: 'var(--brand)', color: '#fff', fontWeight: 800, fontFamily: 'inherit' }}>{!targets.length || index >= targets.length - 1 ? '완료' : '다음'}</button>
-        </div>
-      </section>
-    </div>
-  );
+    const found = Array.from(root.querySelectorAll<HTMLElement>(SELECTOR)).filter((el) => !el.closest('[data-tour-overlay]') && !el.closest('[data-tour-ignore]') && visible(el)).filter((el) => el.matches('[role="tablist"], [aria-label="주요 화면"]') || !el.closest('[role="tablist"], [aria-label="주요 화면"]')).map((element) => { const label = labelOf(element); const persistent = element.matches('[role="tablist"], [aria-label="주요 화면"]'); return { element, label, kind: element.tagName, persistent, score: score(element, label) }; });
+    const unique = new Map<string, TourTarget>(); for (const target of found.sort((a, b) => b.score - a.score)) if (!unique.has(keyOf(target))) unique.set(keyOf(target), target);
+    const values = [...unique.values()]; const persistent = values.filter((t) => t.persistent); const core = values.filter((t) => !t.persistent).slice(0, firstRun ? 3 : 4);
+    setTargets(firstRun ? [...persistent, ...core].slice(0, 5) : core); setIndex(0);
+  }, [open, root, screenLabel, firstRun]);
+  const current = index === 0 ? undefined : targets[index - 1];
+  useEffect(() => { if (!open || !current) { setRect(null); return; } current.element.scrollIntoView({ block: 'center', inline: 'center' }); const update = () => { const r = current.element.getBoundingClientRect(); const g = 6; setRect({ top: Math.max(4, r.top - g), left: Math.max(4, r.left - g), right: Math.min(innerWidth - 4, r.right + g), bottom: Math.min(innerHeight - 4, r.bottom + g), width: r.width + g * 2, height: r.height + g * 2 }); }; const frame = requestAnimationFrame(() => requestAnimationFrame(update)); addEventListener('resize', update); addEventListener('scroll', update, true); return () => { cancelAnimationFrame(frame); removeEventListener('resize', update); removeEventListener('scroll', update, true); }; }, [open, current]);
+  useEffect(() => { if (!open) return; const key = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); if (e.key === 'ArrowRight') setIndex((i) => Math.min(targets.length, i + 1)); if (e.key === 'ArrowLeft') setIndex((i) => Math.max(0, i - 1)); }; addEventListener('keydown', key); return () => removeEventListener('keydown', key); }, [open, onClose, targets.length]);
+  const cardStyle = useMemo(() => { if (!rect) return { top: '50%', left: 16, right: 16, transform: 'translateY(-50%)' }; const below = rect.bottom + 14; return below + 180 < innerHeight ? { top: below, left: Math.max(16, Math.min(rect.left, innerWidth - 336)) } : { bottom: Math.max(16, innerHeight - rect.top + 14), left: Math.max(16, Math.min(rect.left, innerWidth - 336)) }; }, [rect]);
+  if (!open) return null; const shade = 'rgba(31, 27, 23, .68)';
+  return <div data-tour-overlay role="dialog" aria-modal="true" aria-label={`${screenLabel} 화면 사용법`} style={{ position: 'fixed', inset: 0, zIndex: 1000 }}>
+    {rect ? <><div style={{ position: 'fixed', inset: `0 0 ${innerHeight - rect.top}px 0`, background: shade }} /><div style={{ position: 'fixed', top: rect.top, left: 0, width: rect.left, height: rect.height, background: shade }} /><div style={{ position: 'fixed', top: rect.top, left: rect.right, right: 0, height: rect.height, background: shade }} /><div style={{ position: 'fixed', inset: `${rect.bottom}px 0 0`, background: shade }} /><div aria-hidden style={{ position: 'fixed', top: rect.top, left: rect.left, width: rect.width, height: rect.height, border: '3px solid var(--brand)', borderRadius: 12, boxShadow: '0 0 0 3px rgba(255,252,246,.9)', pointerEvents: 'auto' }} /></> : <div style={{ position: 'fixed', inset: 0, background: shade }} />}
+    <section style={{ position: 'fixed', ...cardStyle, width: 'min(320px, calc(100vw - 32px))', boxSizing: 'border-box', borderRadius: 18, padding: 18, background: 'var(--surface-raised)', color: 'var(--text-1)', boxShadow: '0 18px 48px rgba(0,0,0,.3)' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}><span style={{ color: 'var(--brand)', fontSize: 12, fontWeight: 800 }}>{screenLabel} · {index + 1}/{targets.length + 1}</span><button data-tour-ignore onClick={onClose} aria-label="도움말 닫기" style={{ width: 44, height: 44, border: 0, borderRadius: 999, background: 'var(--sand-100)', display: 'grid', placeItems: 'center' }}><X size={18} /></button></div>
+      <h2 style={{ margin: '4px 0 6px', fontSize: 18 }}>{current?.label || `${screenLabel} 한눈에 보기`}</h2><p style={{ margin: 0, color: 'var(--text-2)', fontSize: 14, lineHeight: 1.55 }}>{current ? description(current) : (SUMMARIES[screenLabel] ?? '이 화면의 핵심 기능을 순서대로 확인해 보세요.')}</p>
+      <div style={{ display: 'flex', gap: 8, marginTop: 16 }}><button onClick={() => setIndex((i) => Math.max(0, i - 1))} disabled={index === 0} style={{ minHeight: 44, flex: 1, borderRadius: 12, border: '1px solid var(--sand-200)', background: 'var(--surface-raised)' }}>이전</button><button onClick={() => index >= targets.length ? onClose() : setIndex((i) => i + 1)} style={{ minHeight: 44, flex: 1, borderRadius: 12, border: 0, background: 'var(--brand)', color: '#fff', fontWeight: 800 }}>{index >= targets.length ? '완료' : '다음'}</button></div>
+    </section>
+  </div>;
 }


### PR DESCRIPTION
## 변경
- 모든 화면 도움말 첫 단계에 페이지 목적 한 문장 요약
- 반복 버튼·일정 카드를 의미 기준으로 중복 제거
- 수동 도움말은 핵심 기능 최대 4개만 spotlight
- 중요 입력·시작·확정·저장·추가 기능 우선 선별
- 첫 실행 시 도움말 자동 표시
- 첫 실행에만 하단 주요 화면과 계획/리뷰 등 고정 메뉴를 반드시 포함
- 첫 안내 완료 여부를 localStorage에 저장해 반복 자동 노출 방지

## 검증
- npm run build
- npm run check:api
- npm run check:fields
- git diff --check