### PR TITLE
fix: 집중 화면 이탈 시 자동 완료 처리 방지

### DIFF
--- a/src/app/ReActionMerged.tsx
+++ b/src/app/ReActionMerged.tsx
@@ -43,7 +43,9 @@ const NAV_META: Record<ScreenId, { label: string; back: ScreenId | null }> = {
   'materials-search':       { label: '참고 자료 찾기',  back: 'milestone-confirm' },
   'weekly-plan':            { label: '주간 계획 생성', back: 'milestone-confirm' },
   'today':                  { label: '오늘의 실행',    back: null },
-  'focus':                  { label: '집중 모드',      back: 'today' },
+  // 집중 화면의 이탈은 FocusScreen이 타이머를 일시정지·보존한 뒤 처리한다.
+  // 공용 헤더의 별도 뒤로가기를 노출하면 그 정리 경로를 우회하므로 숨긴다.
+  'focus':                  { label: '집중 모드',      back: null },
   'recovery':               { label: '복구 코치',      back: 'today' },
   'recovered':              { label: '회복 완료',      back: null },
   'evening':                { label: '저녁 체크인',    back: 'today' },

--- a/src/components/HeroTaskCard.tsx
+++ b/src/components/HeroTaskCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { CaretRight, Check } from '@phosphor-icons/react';
+import { CaretRight } from '@phosphor-icons/react';
 import type { Task } from '../types';
 import { EmptyState } from './EmptyState';
 
@@ -37,9 +37,8 @@ export interface HeroTaskCardProps {
  * 설계 의도: 목록을 훑게 하지 않고 "다음 한 개"로 시선을 좁힌다. 그래서
  * 화면에 이 카드가 하나뿐이고, 진행 전에는 CTA 도 [시작하기] 하나뿐이다.
  *
- * 진행 중으로 바뀌면 버튼이 셋으로 갈라진다 — 완료 / ◑ 일부만 / ✗ 잘 안됨.
- * 이 세 갈래가 앱 전체의 상태 어휘이고, 어느 쪽을 눌러도 실패로 끝나지 않고
- * 회복 흐름으로 이어진다.
+ * 진행 중으로 바뀌면 [이어서 하기]로 타이머에 복귀한다. 결과 판정은 실행 화면의
+ * 체크인이 서버에 저장된 뒤에만 이루어져, 단순 화면 이탈이 완료가 되는 일을 막는다.
  */
 export function HeroTaskCard({
   task,
@@ -49,9 +48,6 @@ export function HeroTaskCard({
   dur,
   goalLabel,
   goalColor,
-  onComplete,
-  onPartial,
-  onFail,
   onStart,
   startDisabled = false,
   startLabel = '시작하기',
@@ -185,63 +181,17 @@ export function HeroTaskCard({
       </div>
 
       {isActive ? (
-        <div style={{ display: 'flex', gap: 8 }}>
-          <button
-            onClick={onComplete}
-            style={{
-              flex: 2,
-              height: 52,
-              borderRadius: 14,
-              border: 'none',
-              background: 'var(--brand-surface)',
-              color: '#FFFCF6',
-              fontWeight: 700,
-              fontSize: 15,
-              fontFamily: 'inherit',
-              cursor: 'pointer',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              gap: 6,
-            }}
-          >
-            <Check size={16} weight="bold" /> 완료
-          </button>
-          <button
-            onClick={onPartial}
-            aria-label="일부만 함"
-            style={{
-              width: 52,
-              height: 52,
-              borderRadius: 14,
-              border: '1px solid var(--sand-200)',
-              background: 'var(--surface-ground)',
-              color: 'var(--text-2)',
-              fontSize: 16,
-              fontFamily: 'inherit',
-              cursor: 'pointer',
-            }}
-          >
-            ◑
-          </button>
-          <button
-            onClick={onFail}
-            aria-label="잘 안됨"
-            style={{
-              width: 52,
-              height: 52,
-              borderRadius: 14,
-              border: '1px solid var(--coral-200)',
-              background: '#FAE2D8',
-              color: 'var(--danger-ink)',
-              fontSize: 16,
-              fontFamily: 'inherit',
-              cursor: 'pointer',
-            }}
-          >
-            ✗
-          </button>
-        </div>
+        <button
+          onClick={() => onStart(task.id)}
+          style={{
+            width: '100%', height: 52, borderRadius: 14, border: 'none',
+            background: 'var(--text-1)', color: '#FAF6EE', fontWeight: 700,
+            fontSize: 15, fontFamily: 'inherit', cursor: 'pointer',
+            display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6,
+          }}
+        >
+          이어서 하기 <CaretRight size={14} />
+        </button>
       ) : (
         <button
           onClick={() => { if (!startDisabled) onStart(task.id); }}

--- a/src/screens/FocusScreen.test.tsx
+++ b/src/screens/FocusScreen.test.tsx
@@ -24,8 +24,8 @@ const api = todayApi as unknown as {
   checkIn: ReturnType<typeof vi.fn>;
 };
 
-function view(onComplete = vi.fn()) {
-  return render(<FocusScreen task={task} elapsedMin={0} totalMin={25} onPause={() => {}} onComplete={onComplete} onBack={() => {}} />);
+function view(onComplete = vi.fn(), onBack = vi.fn()) {
+  return render(<FocusScreen task={task} elapsedMin={0} totalMin={25} onPause={() => {}} onComplete={onComplete} onBack={onBack} />);
 }
 
 describe('FocusScreen execution contract', () => {
@@ -83,5 +83,23 @@ describe('FocusScreen execution contract', () => {
       'check-exec-1',
     );
     expect(sessionStorage.getItem('reaction.focus.task-1')).toBeNull();
+  });
+
+  it('pauses and preserves the session when leaving without completing', async () => {
+    const onComplete = vi.fn();
+    const onBack = vi.fn();
+    api.start.mockResolvedValue({ executionId: 'exec-1' });
+    api.pause.mockResolvedValue({});
+    view(onComplete, onBack);
+    await waitFor(() => expect(api.start).toHaveBeenCalledOnce());
+
+    fireEvent.click(screen.getByRole('button', { name: /Today/ }));
+
+    expect(onBack).toHaveBeenCalledOnce();
+    expect(onComplete).not.toHaveBeenCalled();
+    expect(api.checkIn).not.toHaveBeenCalled();
+    await waitFor(() => expect(api.pause).toHaveBeenCalledWith('exec-1'));
+    const saved = JSON.parse(sessionStorage.getItem('reaction.focus.task-1') ?? '{}');
+    expect(saved.running).toBe(false);
   });
 });

--- a/src/screens/FocusScreen.tsx
+++ b/src/screens/FocusScreen.tsx
@@ -270,8 +270,31 @@ export function FocusScreen({ task, elapsedMin, totalMin, onComplete, onBack, on
     }
   };
 
-  // 중단 — 기록 없이 오늘로 복귀(세션 정리). 나중에 다시 시작할 수 있다.
-  const handleAbort = () => { clearSession(); onBack(); };
+  // 뒤로가기/중단은 결과 판정이 아니다. 로컬·서버 타이머를 멈춘 뒤 세션을 남겨
+  // 오늘 화면에서 이어서 시작할 수 있게 한다. 완료는 handleComplete 성공 경로뿐이다.
+  const handleExit = () => {
+    if (running) {
+      pauseAtRef.current = Date.now();
+      setRunning(false);
+      runningRef.current = false;
+      queuedRunIntentRef.current = 'pause';
+      persist({ running: false, queuedIntent: 'pause' });
+
+      const executionId = executionIdRef.current;
+      if (executionId) {
+        void todayApi.pause(executionId).then(
+          () => {
+            queuedRunIntentRef.current = null;
+            persist({ running: false, queuedIntent: null });
+          },
+          (err) => logMutationFailure('pause-on-exit', err),
+        );
+      }
+    } else {
+      persist({ running: false });
+    }
+    onBack();
+  };
 
   const totalSec = Math.max(1, totalMin * 60);
   const pct = Math.min(elapsedSec / totalSec, 1);
@@ -285,7 +308,7 @@ export function FocusScreen({ task, elapsedMin, totalMin, onComplete, onBack, on
 
   return (
     <div style={{ padding: '12px 20px 110px', background: 'var(--surface-ground)', minHeight: '100%' }}>
-      <button onClick={onBack} style={{ background: 'transparent', border: 'none', display: 'flex', alignItems: 'center', gap: 4, color: 'var(--text-2)', padding: 0, marginBottom: 20, cursor: 'pointer', fontFamily: 'inherit', fontSize: 14 }}>
+      <button onClick={handleExit} style={{ background: 'transparent', border: 'none', display: 'flex', alignItems: 'center', gap: 4, color: 'var(--text-2)', padding: 0, marginBottom: 20, cursor: 'pointer', fontFamily: 'inherit', fontSize: 14 }}>
         <CaretLeft size={20} /> Today
       </button>
       <Chip tone={running ? 'amber' : 'neutral'} style={{ marginBottom: 12 }}>
@@ -329,7 +352,7 @@ export function FocusScreen({ task, elapsedMin, totalMin, onComplete, onBack, on
         <ReButton variant="ghost" size="lg" full onClick={toggleRun}>
           {running ? <><Pause size={16} /> 멈춤</> : <><Play size={16} weight="fill" /> 이어서</>}
         </ReButton>
-        <ReButton variant="ghost" size="lg" full onClick={handleAbort}>
+        <ReButton variant="ghost" size="lg" full onClick={handleExit}>
           <X size={16} /> 중단
         </ReButton>
         <ReButton variant="primary" size="lg" full onClick={() => void handleComplete()} disabled={completing || syncState === 'pending' || syncState === 'retrying'}>

--- a/src/screens/TodayScreen.tsx
+++ b/src/screens/TodayScreen.tsx
@@ -121,6 +121,7 @@ function thisMonday(): string {
 function actionStatusToTaskStatus(s: string): TaskStatus {
   switch (s) {
     case 'in_progress':
+      return 'in_progress';
     case 'done':
     case 'over_done':
       return 'done';


### PR DESCRIPTION
## 문제
타이머에서 뒤로가기 또는 중단 후 진행 중 상태가 완료로 잘못 표시됐습니다.

## 변경
- 진행 중 상태를 그대로 유지하고 실제 완료 상태만 완료로 매핑
- 뒤로가기·중단 시 로컬 및 서버 타이머를 일시정지하고 세션 보존
- 오늘 화면의 진행 중 카드는 이어서 하기만 제공해 체크인 없는 완료 차단
- 집중 화면 공용 헤더의 우회 뒤로가기 제거
- 이탈 시 pause 호출, check-in 미호출, 세션 보존 회귀 테스트 추가

## 검증
- npm run build
- FocusScreen 테스트 8개 통과
- npm run check:api
- npm run check:fields
- git diff --check