### PR TITLE
fix: 딥인터뷰 줄바꿈 · 팁 박스 흔들림 · 뒤로가기 중복 · 도움말 문구

### DIFF
--- a/src/components/GuidedTourOverlay.tsx
+++ b/src/components/GuidedTourOverlay.tsx
@@ -18,7 +18,18 @@ function visible(el: HTMLElement) { const r = el.getBoundingClientRect(); const 
 function labelOf(el: HTMLElement) { return el.dataset.tourLabel || el.getAttribute('aria-label') || el.getAttribute('title') || ((el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) ? el.placeholder : '') || el.innerText.trim().replace(/\s+/g, ' ').slice(0, 60) || '이 조작 영역'; }
 function score(el: HTMLElement, label: string) { if (el.dataset.tourCore != null) return 100; if (el.matches('[role="tablist"], [aria-label="주요 화면"]')) return 95; if (['INPUT', 'TEXTAREA', 'SELECT'].includes(el.tagName)) return 85; if (/시작|확정|완료|저장|추가|검색|계속|실행|수정|생성|승인|회복/.test(label)) return 80; if (/뒤로|이전 주|다음 주|도움말/.test(label)) return 10; return el.tagName === 'BUTTON' ? 55 : 45; }
 function keyOf(t: TourTarget) { if (t.persistent) return `persistent:${t.label}`; if (/탭하면 수정|같은 시간대 일정/.test(t.label)) return 'calendar-card'; return `${t.kind}:${t.label.replace(/\d+/g, '#').slice(0, 40)}`; }
-function description(t: TourTarget) { if (t.element.getAttribute('aria-label') === '주요 화면') return '오늘 실행·주간 계획·인박스로 이동하는 고정 메뉴예요.'; if (t.element.getAttribute('role') === 'tablist') return '이 화면의 주요 보기 사이를 전환하는 메뉴예요.'; if (['INPUT', 'TEXTAREA', 'SELECT'].includes(t.kind)) return '내용을 입력하거나 선택하는 핵심 영역이에요.'; if (t.kind === 'A') return '연결된 화면이나 자료로 이동해요.'; return '이 화면에서 자주 사용하는 핵심 기능이에요.'; }
+/**
+ * 강조한 요소가 무엇을 하는지 설명한다.
+ *
+ * 요소 종류로 문구를 지어내지 않는다. 예전엔 버튼이면 무조건 "이 화면에서 자주
+ * 사용하는 핵심 기능이에요" 를 붙였는데, 그건 그 버튼에 대해 아무것도 말하지 않는다.
+ * DOM 만 봐서는 버튼이 무슨 일을 하는지 알 수 없기 때문이다.
+ *
+ * 설명은 화면 쪽에서 data-tour-help 로 직접 써 넣는다. 안 써둔 요소는 빈 문자열을
+ * 돌려 설명 문단 자체를 그리지 않는다 — 틀린 말을 붙이느니 강조만 한다.
+ * (탭바·탭 목록·입력 필드는 종류 자체가 하는 일을 말해주므로 예외로 남긴다.)
+ */
+function description(t: TourTarget) { const authored = t.element.dataset.tourHelp; if (authored) return authored; if (t.element.getAttribute('aria-label') === '주요 화면') return '오늘 실행·주간 계획·인박스로 이동하는 고정 메뉴예요.'; if (t.element.getAttribute('role') === 'tablist') return '이 화면의 주요 보기 사이를 전환하는 메뉴예요.'; if (['INPUT', 'TEXTAREA', 'SELECT'].includes(t.kind)) return '내용을 입력하거나 선택하는 곳이에요.'; return ''; }
 
 export function GuidedTourOverlay({ root, open, screenLabel, firstRun = false, onClose }: { root: HTMLElement | null; open: boolean; screenLabel: string; firstRun?: boolean; onClose: () => void }) {
   const [targets, setTargets] = useState<TourTarget[]>([]); const [index, setIndex] = useState(0); const [rect, setRect] = useState<Rect | null>(null);
@@ -39,7 +50,7 @@ export function GuidedTourOverlay({ root, open, screenLabel, firstRun = false, o
     {rect ? <><div style={{ position: 'fixed', inset: `0 0 ${innerHeight - rect.top}px 0`, background: shade }} /><div style={{ position: 'fixed', top: rect.top, left: 0, width: rect.left, height: rect.height, background: shade }} /><div style={{ position: 'fixed', top: rect.top, left: rect.right, right: 0, height: rect.height, background: shade }} /><div style={{ position: 'fixed', inset: `${rect.bottom}px 0 0`, background: shade }} /><div aria-hidden style={{ position: 'fixed', top: rect.top, left: rect.left, width: rect.width, height: rect.height, border: '3px solid var(--brand)', borderRadius: 12, boxShadow: '0 0 0 3px rgba(255,252,246,.9)', pointerEvents: 'auto' }} /></> : <div style={{ position: 'fixed', inset: 0, background: shade }} />}
     <section className="guided-tour-card" style={{ position: 'fixed', ...cardStyle, width: 'min(320px, calc(100vw - 32px))', boxSizing: 'border-box', borderRadius: 18, padding: 18, background: 'var(--surface-raised)', color: 'var(--text-1)', boxShadow: '0 18px 48px rgba(0,0,0,.3)' }}>
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}><span style={{ color: 'var(--brand)', fontSize: 12, fontWeight: 800 }}>{screenLabel} · {index + 1}/{targets.length + 1}</span><button data-tour-ignore onClick={onClose} aria-label="도움말 닫기" style={{ width: 44, height: 44, border: 0, borderRadius: 999, background: 'var(--sand-100)', display: 'grid', placeItems: 'center' }}><X size={18} /></button></div>
-      <h2 style={{ margin: '4px 0 6px', fontSize: 18 }}>{current?.label || `${screenLabel} 화면 전체 안내`}</h2><p style={{ margin: 0, color: 'var(--text-2)', fontSize: 14, lineHeight: 1.55 }}>{current ? description(current) : (SUMMARIES[screenLabel] ?? '강조된 화면 본문에서 핵심 기능을 순서대로 확인해 보세요.')}</p>
+      <h2 style={{ margin: '4px 0 6px', fontSize: 18 }}>{current?.label || `${screenLabel} 화면 전체 안내`}</h2>{(() => { const body = current ? description(current) : (SUMMARIES[screenLabel] ?? '강조된 화면 본문에서 핵심 기능을 순서대로 확인해 보세요.'); return body ? <p style={{ margin: 0, color: 'var(--text-2)', fontSize: 14, lineHeight: 1.55 }}>{body}</p> : null; })()}
       <div style={{ display: 'flex', gap: 8, marginTop: 16 }}><button onClick={() => setIndex((i) => Math.max(0, i - 1))} disabled={index === 0} style={{ minHeight: 44, flex: 1, borderRadius: 12, border: '1px solid var(--sand-200)', background: 'var(--surface-raised)' }}>이전</button><button onClick={() => index >= targets.length ? onClose() : setIndex((i) => i + 1)} style={{ minHeight: 44, flex: 1, borderRadius: 12, border: 0, background: 'var(--brand)', color: '#fff', fontWeight: 800 }}>{index >= targets.length ? '완료' : '다음'}</button></div>
     </section>
   </div>;

--- a/src/components/HeroTaskCard.tsx
+++ b/src/components/HeroTaskCard.tsx
@@ -183,6 +183,7 @@ export function HeroTaskCard({
       {isActive ? (
         <button
           onClick={() => onStart(task.id)}
+          data-tour-help="이 일을 지금 시작해요. 집중 모드로 넘어가 시간을 재고, 끝나면 완료·일부만·잘 안됨 중에 골라 기록해요."
           style={{
             width: '100%', height: 52, borderRadius: 14, border: 'none',
             background: 'var(--text-1)', color: '#FAF6EE', fontWeight: 700,
@@ -196,6 +197,7 @@ export function HeroTaskCard({
         <button
           onClick={() => { if (!startDisabled) onStart(task.id); }}
           disabled={startDisabled}
+          data-tour-help="지금 이 일을 시작해요. 집중 모드로 넘어가 시간을 재고, 끝나면 완료·일부만·잘 안됨 중에 골라 기록해요."
           style={{
             width: '100%',
             height: 52,

--- a/src/components/NextUpStrip.tsx
+++ b/src/components/NextUpStrip.tsx
@@ -116,6 +116,7 @@ export function NextUpStrip({
         disabled={startDisabled}
         // 숨겨진 동안 탭 순서에서도 빠진다.
         tabIndex={visible ? 0 : -1}
+        data-tour-help="오늘 가장 먼저 할 일을 바로 시작해요. 누르면 집중 모드로 넘어가요."
         style={{
           height: 34,
           padding: '0 14px',

--- a/src/screens/GoalsScreen.tsx
+++ b/src/screens/GoalsScreen.tsx
@@ -236,6 +236,7 @@ export function GoalsScreen() {
             style={{ marginTop: 10, alignSelf: 'flex-start', height: 'var(--ctrl-sm)', padding: '0 12px', borderRadius: 9999, border: '1px solid var(--coral-200)', background: 'var(--brand-soft)', color: 'var(--coral-700)', fontSize: 12, fontWeight: 700, fontFamily: 'inherit', cursor: 'pointer', display: 'inline-flex', alignItems: 'center', gap: 5 }}
           >
             <ChatCircleDots size={13} weight="fill" />
+            data-tour-help="목표가 달라졌을 때 인터뷰를 다시 해서 계획을 새로 세워요."
             목표가 바뀌었어요 · 다시 인터뷰하기
           </button>
 
@@ -266,6 +267,7 @@ export function GoalsScreen() {
                 size="sm"
                 onClick={() => { setMandalaGoalId(null); setScreen('ultimate-interview'); }}
               >
+                data-tour-help="장기 목표를 만다라트로 펼쳐 하위 영역까지 정해요."
                 {ultimateGoal ? '다시 세우기' : '궁극적 목표 세우기'}
               </ReButton>
             </div>
@@ -444,6 +446,7 @@ export function GoalsScreen() {
           </div>
         ) : (
           <button onClick={() => setShowAdd(true)} style={{ display: 'flex', alignItems: 'center', gap: 6, justifyContent: 'center', height: 40, borderRadius: 12, border: '1.5px dashed var(--sand-300)', background: 'transparent', color: 'var(--text-2)', fontWeight: 600, fontSize: 12, cursor: 'pointer', fontFamily: 'inherit' }}>
+            data-tour-help="새 목표를 직접 만들어요. 집중·유지·보류 중 어디에 둘지도 여기서 정해요."
             <Plus size={14} /> 목표 추가
           </button>
         )}

--- a/src/screens/InboxScreen.tsx
+++ b/src/screens/InboxScreen.tsx
@@ -432,6 +432,7 @@ export function InboxScreen() {
           onChange={(e) => setDraft(e.target.value)}
           onKeyDown={(e) => { if (e.key === 'Enter' && !e.nativeEvent.isComposing) capture(); }}
           placeholder="한 줄로 적어요…"
+          data-tour-help="떠오른 일을 한 줄로 적어두는 곳이에요. AI 가 카테고리를 붙여두고, 나중에 목표나 오늘 할 일로 올릴 수 있어요."
           disabled={isCreating}
           style={{ flex: 1, padding: '11px 14px', borderRadius: 12, border: '1.5px solid var(--sand-200)', background: 'var(--surface-raised)', color: 'var(--text-1)', fontSize: 13, fontFamily: 'inherit', outline: 'none' }}
         />

--- a/src/screens/MilestoneConfirmScreen.tsx
+++ b/src/screens/MilestoneConfirmScreen.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { CaretLeft, Plus, X, Sparkle, ArrowRight, Path } from '@phosphor-icons/react';
+import { Plus, X, Sparkle, ArrowRight, Path } from '@phosphor-icons/react';
 import { ApiError, plansApi } from '../lib/api';
 import { useNavigation } from '../contexts/NavigationContext';
 import type { MilestoneDraft } from '../types/api';
@@ -194,13 +194,6 @@ export function MilestoneConfirmScreen() {
     <div style={{ height: '100%', display: 'flex', flexDirection: 'column', background: 'var(--surface-ground)' }}>
       <div style={{ flex: 1, overflowY: 'auto', padding: '14px 18px 24px', display: 'flex', flexDirection: 'column', gap: 16 }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-          <button
-            onClick={() => setScreen('setup')}
-            style={{ width: 36, height: 36, borderRadius: 9999, border: 'none', background: 'var(--surface-raised)', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer' }}
-            aria-label="뒤로"
-          >
-            <CaretLeft size={16} />
-          </button>
           <div style={{ display: 'flex', alignItems: 'center', gap: 7 }}>
             <Path size={20} weight="fill" color="var(--brand)" />
             <h1 style={{ fontWeight: 800, fontSize: 22, letterSpacing: '-0.02em', margin: 0 }}>계획의 큰 그림</h1>

--- a/src/screens/MyInfoScreen.tsx
+++ b/src/screens/MyInfoScreen.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { CaretLeft, Waveform, IdentificationCard } from '@phosphor-icons/react';
+import { Waveform, IdentificationCard } from '@phosphor-icons/react';
 import { ApiError, settingsApi } from '../lib/api';
 import { useNavigation } from '../contexts/NavigationContext';
 import type {
@@ -67,13 +67,6 @@ export function MyInfoScreen() {
     <div style={{ height: '100%', display: 'flex', flexDirection: 'column', background: 'var(--surface-ground)', position: 'relative' }}>
       <div style={{ flex: 1, overflowY: 'auto', padding: '14px 18px 32px', display: 'flex', flexDirection: 'column', gap: 18 }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-          <button
-            onClick={() => setScreen('settings')}
-            style={{ width: 36, height: 36, borderRadius: 9999, border: 'none', background: 'var(--surface-raised)', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer' }}
-            aria-label="뒤로"
-          >
-            <CaretLeft size={16} />
-          </button>
           <h1 style={{ fontWeight: 800, fontSize: 24, letterSpacing: '-0.02em', margin: 0 }}>내 정보</h1>
         </div>
 

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { CaretLeft, CaretRight, Sparkle, BellRinging, BellSlash, Shield, Warning, Check, ArrowClockwise, IdentificationCard, SignOut } from '@phosphor-icons/react';
+import { CaretRight, Sparkle, BellRinging, BellSlash, Shield, Warning, Check, ArrowClockwise, IdentificationCard, SignOut } from '@phosphor-icons/react';
 import { ApiError, notificationsApi, privacyApi, settingsApi } from '../lib/api';
 import { isNativeApp, nativePushReady } from '../lib/platform';
 import { subscribePush, unsubscribePush, getPushPermission } from '../lib/push';
@@ -131,13 +131,6 @@ export function SettingsScreen() {
     <div style={{ height: '100%', display: 'flex', flexDirection: 'column', background: 'var(--surface-ground)', position: 'relative' }}>
       <div style={{ flex: 1, overflowY: 'auto', padding: '14px 18px 32px', display: 'flex', flexDirection: 'column', gap: 18 }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-          <button
-            onClick={() => setScreen('today')}
-            style={{ width: 36, height: 36, borderRadius: 9999, border: 'none', background: 'var(--surface-raised)', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer' }}
-            aria-label="뒤로"
-          >
-            <CaretLeft size={16} />
-          </button>
           <h1 style={{ fontWeight: 800, fontSize: 24, letterSpacing: '-0.02em', margin: 0 }}>설정</h1>
         </div>
 

--- a/src/screens/TodayScreen.tsx
+++ b/src/screens/TodayScreen.tsx
@@ -40,6 +40,7 @@ function HeaderMenu({ onOpenBrief, hasBrief }: { onOpenBrief: () => void; hasBri
       <button
         onClick={() => setOpen((o) => !o)}
         aria-label="메뉴"
+        data-tour-help="오늘 브리프·목표 관리·설정으로 가는 메뉴예요."
         aria-expanded={open}
         style={{ width: 36, height: 36, borderRadius: 9999, border: 'none', background: open ? 'var(--sand-100)' : 'var(--surface-raised)', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer' }}
       >
@@ -791,6 +792,7 @@ export function MergedTodayScreen({ tasks: allTasks, onOpen, onMarkDone, onParti
             <button
               onClick={() => setAddingHabit(true)}
               style={{ minHeight: 42, padding: '0 14px', borderRadius: 12, border: 'none', background: 'var(--brand-surface)', color: '#FFFCF6', cursor: 'pointer', fontFamily: 'inherit', fontSize: 12, fontWeight: 800, display: 'inline-flex', alignItems: 'center', justifyContent: 'center', gap: 5, whiteSpace: 'nowrap', flexShrink: 0, boxShadow: 'var(--shadow-sm)' }}
+            data-tour-help="매주 반복할 습관을 만들어요. 주 몇 회 할지 정하면 오늘 화면에서 눌러 체크할 수 있어요."
             ><Plus size={14} weight="bold" /> 습관 추가</button>
           </section>
         ) : (
@@ -803,6 +805,7 @@ export function MergedTodayScreen({ tasks: allTasks, onOpen, onMarkDone, onParti
             <button
               onClick={() => setAddingHabit(true)}
               style={{ minHeight: 36, padding: '0 12px', borderRadius: 9999, fontSize: 12, color: 'var(--coral-700)', fontWeight: 800, background: 'var(--brand-soft)', border: '1px solid var(--coral-200)', cursor: 'pointer', fontFamily: 'inherit', display: 'inline-flex', alignItems: 'center', gap: 4, whiteSpace: 'nowrap' }}
+            data-tour-help="매주 반복할 습관을 만들어요. 주 몇 회 할지 정하면 오늘 화면에서 눌러 체크할 수 있어요."
             ><Plus size={13} weight="bold" /> 습관 추가</button>
           </div>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>

--- a/src/screens/UltimateGoalInterviewScreen.tsx
+++ b/src/screens/UltimateGoalInterviewScreen.tsx
@@ -226,6 +226,16 @@ export function UltimateGoalInterviewScreen({ onGoalReady, onCancel }: UltimateG
         : null
     : null;
   const [manualEntry, setManualEntry] = useState(false);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+  // 내용에 맞춰 높이를 다시 잰다. scrollHeight 를 읽기 전에 height 를 비워야
+  // 줄이 줄어들 때도 따라 줄어든다(안 그러면 한 번 커진 뒤 그대로 남는다).
+  useEffect(() => {
+    const el = inputRef.current;
+    if (!el) return;
+    el.style.height = 'auto';
+    el.style.height = `${Math.min(el.scrollHeight, 132)}px`;
+  }, [inputText]);
+
   const useTypedField = typedKind !== null && !manualEntry;
 
   useEffect(() => {
@@ -404,13 +414,24 @@ export function UltimateGoalInterviewScreen({ onGoalReady, onCancel }: UltimateG
             )}
             <div style={{ display: 'flex', gap: 8, alignItems: 'flex-end' }}>
               {!useTypedField && (
-                <input
+                /* textarea 다. input 은 한 줄짜리 요소라 어떤 조합키로도 줄바꿈이
+                   들어가지 않는다 — 답이 길어지면 한 줄에 밀려 앞이 안 보였다.
+                   Enter 로 보내고 Shift+Enter 로 줄을 바꾼다(메신저 관용).
+                   내용에 맞춰 높이가 늘어나되 상한을 둬서 화면을 먹지 않게 한다. */
+                <textarea
+                  ref={inputRef}
+                  rows={1}
                   value={inputText}
                   onChange={(e) => setInputText(e.target.value)}
-                  onKeyDown={(e) => { if (e.key === 'Enter' && !e.nativeEvent.isComposing) submit(inputText); }}
+                  onKeyDown={(e) => {
+                    if (e.key !== 'Enter' || e.nativeEvent.isComposing) return;
+                    if (e.shiftKey) return; // 줄바꿈은 브라우저 기본 동작에 맡긴다
+                    e.preventDefault();     // 보낼 때는 줄바꿈이 남지 않게
+                    submit(inputText);
+                  }}
                   placeholder={placeholderFor(currentQuestion)}
                   disabled={isTyping}
-                  style={{ flex: 1, padding: '11px 14px', borderRadius: 12, border: '1.5px solid var(--sand-200)', background: 'var(--surface-raised)', color: 'var(--text-1)', fontSize: 13, fontFamily: 'inherit', outline: 'none' }}
+                  style={{ flex: 1, padding: '11px 14px', borderRadius: 12, border: '1.5px solid var(--sand-200)', background: 'var(--surface-raised)', color: 'var(--text-1)', fontSize: 13, fontFamily: 'inherit', outline: 'none', resize: 'none', lineHeight: 1.5, maxHeight: 132, overflowY: 'auto' }}
                 />
               )}
               {!useTypedField && inputText.trim() !== '' && (

--- a/src/screens/WeeklyCalendarScreen.tsx
+++ b/src/screens/WeeklyCalendarScreen.tsx
@@ -701,6 +701,7 @@ export function WeeklyCalendarScreenV2() {
               onClick={goToday}
               aria-pressed={isThisWeek}
               style={{ height: 28, padding: '0 10px', borderRadius: 8, border: `1px solid ${isThisWeek ? 'var(--brand-surface)' : 'var(--sand-200)'}`, background: isThisWeek ? 'var(--brand-surface)' : 'var(--surface-raised)', color: isThisWeek ? '#FFFCF6' : 'var(--text-2)', cursor: isThisWeek ? 'default' : 'pointer', fontFamily: 'inherit', fontSize: 11, fontWeight: isThisWeek ? 700 : 600 }}
+            data-tour-help="오늘이 들어 있는 날짜로 돌아가요."
             >오늘</button>
           </div>
         </div>

--- a/src/screens/WeeklyPlanGenerationScreen.tsx
+++ b/src/screens/WeeklyPlanGenerationScreen.tsx
@@ -109,13 +109,16 @@ function PlanGeneratingView() {
       </div>
 
       {/* 기다리는 동안 팁 — 앱 철학. 3.8초마다 페이드 전환 */}
-      <div style={{ marginTop: 10, width: '100%', maxWidth: 300, minHeight: 66, background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', borderRadius: 14, padding: '12px 14px', display: 'flex', gap: 10, alignItems: 'flex-start', textAlign: 'left' }}>
+      {/* 팁이 3.8초마다 바뀌는데 1줄(65px)과 2줄(83px)의 높이가 달라 박스가 계속
+          튀었다. minHeight 66 은 1줄만 덮는 값이었다. 문단에 두 줄을 미리 확보해
+          어떤 팁이 와도 같은 높이로 둔다 — 아래 로딩 화면 전체가 같이 흔들렸다. */}
+      <div style={{ marginTop: 10, width: '100%', maxWidth: 300, background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', borderRadius: 14, padding: '12px 14px', display: 'flex', gap: 10, alignItems: 'flex-start', textAlign: 'left' }}>
         <div style={{ width: 24, height: 24, borderRadius: 8, background: 'var(--brand-soft)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
           <Lightbulb size={14} weight="fill" color="var(--brand)" />
         </div>
         <div style={{ flex: 1, minWidth: 0 }}>
           <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: '-0.01em', color: 'var(--text-3)', marginBottom: 3 }}>알아두면 좋아요</div>
-          <p key={tip} style={{ margin: 0, fontSize: 12, color: 'var(--text-2)', lineHeight: 1.5, animation: 'toastIn 400ms ease-out' }}>{GEN_TIPS[tip]}</p>
+          <p key={tip} style={{ margin: 0, fontSize: 12, color: 'var(--text-2)', lineHeight: 1.5, minHeight: '3em', animation: 'toastIn 400ms ease-out' }}>{GEN_TIPS[tip]}</p>
         </div>
       </div>
     </div>

--- a/src/screens/WeeklyReviewScreen.tsx
+++ b/src/screens/WeeklyReviewScreen.tsx
@@ -353,6 +353,7 @@ export function WeeklyReviewScreenV2() {
       {/* Sticky CTA */}
       <div style={{ flexShrink: 0, padding: '12px 18px', paddingBottom: 'max(28px, env(safe-area-inset-bottom, 28px))', background: 'var(--surface-ground)' }}>
         <button onClick={goToNextWeekPlan} style={{ width: '100%', height: 'var(--ctrl-lg)', borderRadius: 12, border: 'none', background: 'var(--brand-surface)', color: '#FFFCF6', fontWeight: 700, fontSize: 14, fontFamily: 'inherit', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6 }}>
+          data-tour-help="이번 리뷰를 반영하러 다음 주 계획 화면으로 넘어가요."
           다음 주 계획 확인 <ArrowRight size={15} />
         </button>
       </div>


### PR DESCRIPTION
보고해 주신 버그 4건을 고쳤습니다.

## 1. 딥인터뷰에서 줄바꿈이 안 됨

답 입력이 **`<input>`** 이었습니다. 한 줄짜리 요소라 **어떤 조합키로도 줄바꿈이 들어가지 않습니다.** 게다가 `onKeyDown` 이 `shiftKey` 를 보지 않아 Enter 면 무조건 전송했습니다.

`textarea` 로 바꾸고 **Enter=전송 / Shift+Enter=줄바꿈** 으로 나눴습니다(메신저 관용). 내용에 맞춰 높이가 늘고, 상한 132px 을 둬서 화면을 먹지 않습니다.

> `시프트 탭` 으로 말씀하셨는데, Shift+Tab 은 브라우저가 포커스를 뒤로 옮기는 단축키라 줄바꿈에 쓸 수 없습니다. 같은 의도(전송하지 않고 줄 바꾸기)를 **Shift+Enter** 로 넣었습니다. 다른 키를 원하시면 바꾸겠습니다.

```
Shift+Enter → "첫 줄\n둘째 줄" · 전송 0회
Enter       → 전송 1회 · 입력 비워짐 · 2줄일 때 높이 70px
```

## 2. 계획 생성 팁 박스가 계속 튐

`minHeight: 66` 은 **1줄 팁(65px)만 덮는 값**이라, 2줄 팁(83px)이 오면 박스가 커졌다 작아졌다 했습니다 — 3.8초마다 **18px** 씩. 로딩 화면 전체가 같이 흔들렸습니다.

문단에 두 줄을 미리 확보(`minHeight: 3em`)해 어떤 팁이 와도 같은 높이로 둡니다.

```
전  65 / 83px 반복        후  83px 고정 (팁 4종 거치며 실측)
```

## 3. 뒤로가기 버튼이 두 개

**설정 · 내 정보 · 계획의 큰 그림** 세 화면이, 셸(`MergedTopNav`)이 이미 그리는 뒤로가기와 **별도로 자기 뒤로가기를 또** 그리고 있었습니다. 화면 자체 것을 없앴습니다(안 쓰게 된 `CaretLeft` import 정리 포함).

```
세 화면 모두 상단 좌측 아이콘 버튼 1개
```

## 4. 도움말이 기능이 아니라 요소 종류를 설명함

버튼이면 무조건 이렇게 붙였습니다.

> 이 화면에서 자주 사용하는 핵심 기능이에요.

그 버튼에 대해 **아무것도 말하지 않는 문장**입니다. 원인은 구조에 있습니다 — 도움말이 DOM 에서 요소를 자동으로 골라 **태그·role 로 문구를 지어내는데**, DOM 만 봐서는 버튼이 무슨 일을 하는지 알 수 없습니다.

그래서 설명을 화면 쪽에서 `data-tour-help` 로 **직접 쓰게** 하고, 안 써둔 요소는 설명 문단을 **아예 그리지 않습니다.** 틀린 말을 붙이느니 강조만 합니다. (탭바·탭 목록·입력 필드는 종류가 곧 하는 일이라 예외로 남겼습니다.)

도움말이 실제로 뽑는 요소를 **선택 로직 그대로 계산해** 확인하고 그것들에 문구를 달았습니다.

| 화면 | 문구를 단 요소 |
|---|---|
| 오늘의 실행 | 시작 · 시작하기 · 습관 추가 · 메뉴 |
| LIFE INBOX | 캡처 입력창 |
| 주간 계획 | 오늘 |
| 목표 관리 | 목표 추가 · 다시 인터뷰하기 · 궁극적 목표 세우기 |
| 주간 리뷰 | 다음 주 계획 확인 |

실측(오늘 화면 5단계):

```
1. 시작       → 오늘 가장 먼저 할 일을 바로 시작해요. 누르면 집중 모드로 넘어가요.
2. 시작하기   → 지금 이 일을 시작해요. 집중 모드로 넘어가 시간을 재고, 끝나면 …
3. 습관 추가  → 매주 반복할 습관을 만들어요. 주 몇 회 할지 정하면 오늘 화면에서 …
4. 메뉴       → 오늘 브리프·목표 관리·설정으로 가는 메뉴예요.
```

아직 문구를 안 단 화면은 강조만 되고 설명이 비어 있습니다 — 거짓말은 사라졌지만 채워야 할 자리는 남아 있습니다. 필요하시면 나머지도 이어서 달겠습니다.

## 게이트

`tsc` 0 errors · `check:api` PASS · `check:fields` PASS(strict) · **vitest 3파일 14케이스 통과** · `build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)