### PR TITLE
feat(intake): 참고 자료를 파일로도 넣는다

### DIFF
--- a/src/screens/GoalIntakeScreen.tsx
+++ b/src/screens/GoalIntakeScreen.tsx
@@ -318,6 +318,40 @@ export function GoalIntakeScreen({ onDone, onOutcome }: GoalIntakeScreenProps) {
   // ── answerType 전용 입력(#217) ──
   // 백엔드가 "이건 날짜다 / 이건 시간 범위다" 를 이미 알려주는데도 맨 텍스트 입력으로
   // 떨어뜨려, 마감일과 선호 시간대를 사용자가 형식까지 맞춰 타이핑하고 있었다.
+  // 자료를 파일로도 받는다.
+  //
+  // 백엔드엔 업로드 경로가 없다(multipart 를 받는 엔드포인트가 하나도 없다).
+  // 그래서 파일을 서버로 보내지 않고 **브라우저에서 텍스트만 읽어** 이 칸을 채운다.
+  // 사용자가 하려던 일("파일 내용을 자료로 주기")은 그대로 되고, BE 변경도 필요 없다.
+  //
+  // 텍스트로 읽히는 형식만 받는다. PDF·DOCX 는 파서를 실어야 하고(번들이 커진다)
+  // 서버 업로드가 생기면 그쪽에서 처리하는 게 맞아서, 지금은 받지 않고 그 사실을 말한다.
+  const MATERIAL_CHAR_CAP = 20000;
+  const TEXT_LIKE = /\.(txt|md|markdown|csv|tsv|json|ya?ml|log)$/i;
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [fileNote, setFileNote] = useState<string | null>(null);
+
+  const readMaterialFile = async (file: File) => {
+    if (!TEXT_LIKE.test(file.name) && !file.type.startsWith('text/')) {
+      setFileNote(`${file.name} 은 아직 못 읽어요. txt·md·csv 처럼 글자로 된 파일만 됩니다.`);
+      return;
+    }
+    try {
+      const raw = await file.text();
+      const body = raw.length > MATERIAL_CHAR_CAP ? raw.slice(0, MATERIAL_CHAR_CAP) : raw;
+      // 어디서 온 내용인지 남긴다 — 여러 개를 붙이면 구분이 안 된다.
+      const block = `[${file.name}]\n${body.trim()}`;
+      setInputText((prev) => (prev.trim() ? `${prev.trim()}\n\n${block}` : block));
+      setFileNote(
+        raw.length > MATERIAL_CHAR_CAP
+          ? `${file.name} 을 불러왔어요. 너무 길어서 앞부분 ${MATERIAL_CHAR_CAP.toLocaleString()}자만 가져왔어요.`
+          : `${file.name} 을 불러왔어요.`,
+      );
+    } catch {
+      setFileNote(`${file.name} 을 읽지 못했어요. 내용을 직접 붙여넣어 주세요.`);
+    }
+  };
+
   // 자료 붙여넣기 슬롯은 기존 textarea 특례를 그대로 둔다.
   const typedKind: 'date' | 'range' | null =
     currentQuestion && currentQuestion.slotKey !== 'goals.materials'
@@ -563,27 +597,57 @@ export function GoalIntakeScreen({ onDone, onOutcome }: GoalIntakeScreenProps) {
             <div style={{ display: 'flex', gap: 8, marginTop: showQuickReplies ? 4 : 0, alignItems: 'flex-end' }}>
               {useTypedField ? null : currentQuestion.slotKey === 'goals.materials' ? (
                 // 자료 원문 붙여넣기 — 여러 줄 붙여넣기가 편하도록 textarea (Enter=줄바꿈, 전송은 버튼).
-                <textarea
-                  value={inputText}
-                  onChange={(e) => setInputText(e.target.value)}
-                  placeholder={placeholderFor(currentQuestion)}
-                  disabled={isTyping}
-                  rows={5}
-                  style={{
-                    flex: 1,
-                    padding: '11px 14px',
-                    borderRadius: 12,
-                    border: '1.5px solid var(--sand-200)',
-                    background: 'var(--surface-raised)',
-                    color: 'var(--text-1)',
-                    fontSize: 13,
-                    fontFamily: 'inherit',
-                    outline: 'none',
-                    resize: 'vertical',
-                    minHeight: 96,
-                    lineHeight: 1.5,
-                  }}
-                />
+                <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 6 }}>
+                  <textarea
+                    value={inputText}
+                    onChange={(e) => setInputText(e.target.value)}
+                    placeholder={placeholderFor(currentQuestion)}
+                    disabled={isTyping}
+                    rows={5}
+                    style={{
+                      width: '100%',
+                      boxSizing: 'border-box',
+                      padding: '11px 14px',
+                      borderRadius: 12,
+                      border: '1.5px solid var(--sand-200)',
+                      background: 'var(--surface-raised)',
+                      color: 'var(--text-1)',
+                      fontSize: 13,
+                      fontFamily: 'inherit',
+                      outline: 'none',
+                      resize: 'vertical',
+                      minHeight: 96,
+                      lineHeight: 1.5,
+                    }}
+                  />
+                  {/* 붙여넣기만 되던 자리에 파일로 넣는 길을 더한다. 파일은 서버로
+                      보내지 않고 브라우저에서 글자만 읽어 위 칸에 채운다. */}
+                  <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept=".txt,.md,.markdown,.csv,.tsv,.json,.yml,.yaml,.log,text/*"
+                    hidden
+                    onChange={(e) => {
+                      const f = e.target.files?.[0];
+                      if (f) void readMaterialFile(f);
+                      e.target.value = ''; // 같은 파일을 다시 골라도 onChange 가 뜨게
+                    }}
+                  />
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+                    <button
+                      type="button"
+                      onClick={() => fileInputRef.current?.click()}
+                      disabled={isTyping}
+                      data-tour-help="자료를 파일로 넣어요. txt·md·csv 처럼 글자로 된 파일을 고르면 내용이 위 칸에 들어와요."
+                      style={{ height: 'var(--ctrl-sm)', padding: '0 12px', borderRadius: 9999, border: '1px solid var(--sand-200)', background: 'var(--surface-raised)', color: 'var(--text-2)', fontSize: 12, fontWeight: 600, fontFamily: 'inherit', cursor: isTyping ? 'wait' : 'pointer' }}
+                    >
+                      파일에서 불러오기
+                    </button>
+                    <span style={{ fontSize: 11, color: 'var(--text-3)', minWidth: 0 }}>
+                      {fileNote ?? 'txt · md · csv 처럼 글자로 된 파일'}
+                    </span>
+                  </div>
+                </div>
               ) : (
                 <input
                   ref={textInputRef}


### PR DESCRIPTION
자료 슬롯이 **붙여넣기만** 받았습니다. 강의 계획서·요구사항 문서를 파일로 갖고 있어도 열어서 전부 복사해 붙여야 했습니다.

## 서버로 보내지 않습니다

백엔드에 업로드 경로가 없습니다 — 스펙에서 `multipart/form-data` 를 받는 엔드포인트가 **0개**입니다.

그래서 파일을 전송하지 않고 **브라우저에서 텍스트만 읽어** 기존 자료 칸을 채웁니다. 하려던 일("파일 내용을 자료로 주기")은 그대로 되고 BE 변경도 필요 없습니다.

- 읽은 내용 앞에 `[파일명]` 을 붙입니다 — 여러 개를 넣으면 어디서 온 내용인지 구분이 안 됩니다
- 기존에 적어둔 내용은 지우지 않고 **아래에 잇습니다**

## 못 읽는 형식은 못 읽는다고 말합니다

PDF·DOCX 는 파서를 번들에 실어야 하고(용량이 커집니다), 서버 업로드가 생기면 그쪽에서 처리하는 게 맞습니다. 지금은 **조용히 실패하지 않고 사유를 알립니다.**

20,000자를 넘으면 앞부분만 가져오고 **잘랐다는 사실을 함께** 알립니다 — 분해 프롬프트가 어차피 자료를 잘라 씁니다.

## 실측

```
md 파일      "[sample-syllabus.md]\n1주차: 자료구조 개요…" 로 칸이 채워짐
안내         "sample-syllabus.md 을 불러왔어요."
pdf 파일     "sample-bad.pdf 은 아직 못 읽어요. txt·md·csv 처럼 글자로 된 파일만 됩니다."
거절 후에도  기존 내용 그대로 유지
```

- pageErrors 0 · `tsc` 0 errors · `check:api` PASS · `check:fields` PASS(strict) · vitest 14케이스 통과 · `build` 성공

## 남는 것

**진짜 파일 업로드(PDF·DOCX·이미지)는 백엔드가 받아야 합니다.** 필요하시면 BE 이슈로 올리겠습니다 — 앞서 올린 [BE #226(웹에서 자료 받아오기)](https://github.com/hanium-reaction/reaction-backend/issues/226) 과 같은 "자료 공급" 문제라 함께 다루는 게 자연스럽습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)