### PR TITLE
feat(today): 습관 체크가 무엇에 쓰이는지 밝힌다

### DIFF
--- a/src/screens/TodayScreen.tsx
+++ b/src/screens/TodayScreen.tsx
@@ -808,6 +808,16 @@ export function MergedTodayScreen({ tasks: allTasks, onOpen, onMarkDone, onParti
             data-tour-help="매주 반복할 습관을 만들어요. 주 몇 회 할지 정하면 오늘 화면에서 눌러 체크할 수 있어요."
             ><Plus size={13} weight="bold" /> 습관 추가</button>
           </div>
+          {/* 체크가 무엇에 쓰이는지 밝힌다. 이유를 모르면 그냥 카운터를 올리는
+              버튼으로 보이고, 3주 뒤 주간 리뷰에 제안이 뜨는 것과 연결되지 않는다.
+              판정 기준은 BE orchestrator/habit_penalty.py — 목표의 절반 미만이
+              3주 연속이면 최근 3주 평균 횟수로 낮춰 제안한다. */}
+          {!habitsLoading && habits.length > 0 && (
+            <p style={{ margin: '0 0 10px', fontSize: 11.5, color: 'var(--text-3)', lineHeight: 1.5 }}>
+              한 번 할 때마다 체크해 주세요. 3주 연속 절반도 못 채우면 주간 리뷰가
+              <b style={{ color: 'var(--text-2)', fontWeight: 700 }}> 더 낮은 횟수</b>를 제안해요 — 못 했다고 다그치지 않아요.
+            </p>
+          )}
           <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
             {habitsLoading && <SkeletonBlock count={2} height={52} radius={14} gap={10} />}
             {habits.map(h => {
@@ -829,6 +839,7 @@ export function MergedTodayScreen({ tasks: allTasks, onOpen, onMarkDone, onParti
                   <button
                     onClick={() => checkHabit(h.id)}
                     disabled={done}
+                    data-tour-help="이번 주에 한 번 했다고 기록해요. 이 기록이 3주 쌓이면, 목표 횟수가 버거울 때 주간 리뷰가 더 낮은 횟수를 제안하는 근거가 돼요."
                     style={{ padding: '8px 14px', borderRadius: 9999, border: 'none', background: done ? '#E5EFE3' : '#EEEAF6', color: done ? 'var(--success-ink)' : '#7B68C8', fontSize: 13, fontWeight: 600, cursor: done ? 'default' : 'pointer', fontFamily: 'inherit', flexShrink: 0, transition: 'all 200ms' }}
                   >{done ? '완료' : '체크'}</button>
                   <button


### PR DESCRIPTION
"추적 습관 루틴에서 체크한 건 왜 만든 거지?" 라는 물음에서 시작했습니다. 화면에 이유가 없어서 **그냥 카운터를 올리는 버튼**으로 보였고, 3주 뒤 주간 리뷰에 제안이 뜨는 것과 연결되지 않았습니다.

## 체크는 빈도 재설계의 근거입니다

BE `orchestrator/habit_penalty.py` 의 판정이 이렇습니다.

> **3주 연속 미달**(`done_count < target_count * 0.5`) 시 빈도 재설계 제안 **(비난 아닌 재설계)**
> `suggested_frequency` = 최근 3주 평균 달성 횟수

즉 체크는 사용자를 채점하려는 게 아니라 **목표치가 현실과 안 맞는다는 걸 알아채려고** 세는 것입니다. 주 5회로 잡았는데 3주째 2회뿐이면, 앱이 먼저 "주 2회로 낮출까요?" 를 제안합니다.

경로는 양쪽 다 연결돼 있습니다 — 체크 → `done_count` → `GET /reviews/habit-penalty` → 주간 리뷰 화면(`WeeklyReviewScreen.tsx:106`). **그 사실을 화면이 말하지 않고 있었을 뿐**입니다.

## 한 것

습관 목록 위에 한 줄을 뒀습니다.

> 한 번 할 때마다 체크해 주세요. 3주 연속 절반도 못 채우면 주간 리뷰가 **더 낮은 횟수**를 제안해요 — 못 했다고 다그치지 않아요.

마지막 절을 붙인 건 이 문구가 자칫 **'못 채우면 벌점'** 으로 읽힐 수 있어서입니다. 실제 동작은 정반대입니다.

체크 버튼에도 `data-tour-help` 를 달아 도움말 투어에서 같은 설명이 나옵니다.

습관이 하나도 없으면 안내를 그리지 않습니다 — 체크할 게 없는데 체크 설명을 띄우면 자리만 먹습니다.

## 실측

```
안내 노출     "한 번 할 때마다 체크해 주세요. 3주 연속 절반도 못 채우면…"
체크 도움말   "이번 주에 한 번 했다고 기록해요. 이 기록이 3주 쌓이면…"
습관 0개      안내 안 뜸
```

- pageErrors 0 · `tsc` 0 errors · `check:api` PASS · `check:fields` PASS(strict) · vitest 14케이스 통과 · `build` 성공

## 참고 — 이 제안은 최근까지 한 번도 뜬 적이 없습니다

BE `scheduler/habit_instances.py` 주석이 남긴 기록입니다.

> 판정 로직·`apply_penalty`·`/reviews/habit-penalty` 가 전부 완성돼 있는데 **먹일 데이터가 없어 한 번도 발화하지 못했다.**

주간 인스턴스를 만드는 크론이 없어 **등록한 그 주 1행**만 생겼고, 판정은 연속 3주를 요구하니 `len < 3` 에서 영영 `None` 이었습니다. 지금은 그 크론이 들어와 있어 인스턴스가 매주 쌓이면 3주 뒤부터 실제로 뜨기 시작합니다. **스테이징에서 크론이 실제로 도는지는 아직 확인하지 않았습니다.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)