### PR TITLE
[interview] 재인터뷰도 계획 체인으로 잇는다 (#441)

### DIFF
--- a/src/app/ReActionMerged.tsx
+++ b/src/app/ReActionMerged.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { CaretLeft, Question } from '@phosphor-icons/react';
 import { MergedTabBar } from '../components/TabBar';
 import { SystemIntroScreen } from '../screens/SystemIntroScreen';
+import { afterInterviewDone, afterPlanChain, backFromInterviewChain } from '../lib/interviewNav';
 import { GoalIntakeScreen } from '../screens/GoalIntakeScreen';
 import { GoalClassificationScreen } from '../screens/GoalClassificationScreen';
 import { SetupScreen } from '../screens/SetupScreen';
@@ -240,25 +241,35 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
   };
 
   // 탭으로 주간 계획에 들어오면 항상 이번 주부터 (다음 주는 리뷰 버튼으로만 진입).
-  const handleTabChange = (id: TabId) => { if (id === 'weekly') setWeekOffset(0); setTab(id); setScreen(id); };
+  const handleTabChange = (id: TabId) => {
+    // 체인을 탭으로 벗어나면 복귀 표시를 버린다 — 남겨두면 나중에 엉뚱한 화면으로 보낸다.
+    if (interviewReturnTo) setInterviewReturnTo(null);
+    if (id === 'weekly') setWeekOffset(0);
+    setTab(id);
+    setScreen(id);
+  };
 
-  // 딥 인터뷰를 마치고(또는 중간에 나가서) 돌아갈 곳(#216).
-  // 앱 사용 중 재인터뷰로 들어온 경우엔 온보딩 체인이 아니라 들어온 화면으로 돌려보낸다.
-  const leaveInterview = (fallback: ScreenId) => {
-    const back = interviewReturnTo;
+  // 계획 체인의 종착. 재인터뷰로 들어왔으면 그 화면으로, 온보딩이면 오늘 화면으로.
+  //
+  // ⚠️ 예전엔 **인터뷰가 끝나는 순간** 들어온 화면으로 돌려보내 계획 체인을 통째로
+  // 건너뛰었다 — 재인터뷰 시트는 "몇 가지만 다시 묻고 **계획을 새로 세울게요**" 라고
+  // 말하는데 계획을 안 세웠다(#441). 복귀 표시는 체인 **끝**에서 소비한다.
+  const finishPlanChain = () => {
+    const to = afterPlanChain(interviewReturnTo);
     setInterviewReturnTo(null);
-    setScreen(back ?? fallback);
+    if (to === 'today') setTab('today');
+    setScreen(to);
   };
 
   const goBack = () => {
-    // 재인터뷰 중 뒤로가기가 NAV_META 의 온보딩 체인을 따르면 사용자를 intro 로 떨어뜨린다.
-    if (screen === 'goal-intake' && interviewReturnTo) {
-      leaveInterview('today');
-      return;
-    }
-    const meta = NAV_META[screen];
-    if (meta?.back) setScreen(meta.back);
-    else setScreen('today');
+    // 규칙은 `lib/interviewNav` 의 순수 함수가 갖는다 — 화면을 렌더하지 않고 테스트한다.
+    const { to, abandonInterview: drop } = backFromInterviewChain(
+      screen,
+      NAV_META[screen]?.back ?? null,
+      interviewReturnTo,
+    );
+    if (drop) setInterviewReturnTo(null);
+    setScreen(to);
   };
 
   const handleFocusComplete = () => {
@@ -281,7 +292,7 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
           <SystemIntroScreen onDone={() => setScreen('goal-intake')} />
         )}
         {screen === 'goal-intake' && (
-          <GoalIntakeScreen onDone={() => leaveInterview('goal-classify')} onOutcome={setInterviewOutcome} />
+          <GoalIntakeScreen onDone={() => setScreen(afterInterviewDone())} onOutcome={setInterviewOutcome} />
         )}
         {screen === 'goal-classify' && (
           <GoalClassificationScreen onNext={() => setScreen('setup')} outcome={interviewOutcome} />
@@ -292,7 +303,7 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
         {screen === 'milestone-confirm' && <MilestoneConfirmScreen />}
         {screen === 'materials-search' && <MaterialsSearchScreen />}
         {screen === 'weekly-plan' && (
-          <WeeklyPlanGenerationScreen onContinue={() => { setTab('today'); setScreen('today'); }} />
+          <WeeklyPlanGenerationScreen onContinue={finishPlanChain} />
         )}
         {screen === 'today' && (
           <MergedTodayScreen

--- a/src/lib/interviewNav.test.ts
+++ b/src/lib/interviewNav.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { afterInterviewDone, afterPlanChain, backFromInterviewChain } from './interviewNav';
+
+/**
+ * 재인터뷰가 **계획으로 이어지는가** (#441).
+ *
+ * 회귀 배경: 재인터뷰 시트는 "몇 가지만 다시 묻고 **계획을 새로 세울게요**" 라고 말하는데
+ * 인터뷰가 끝나는 순간 들어온 화면으로 돌려보내 **계획 체인을 통째로 건너뛰었다.**
+ * 백엔드는 새 목표를 `proposed` 로 저장하고 이전 잠정 목표를 supersede 까지 했으므로,
+ * 사용자는 **이전 미계획 목표가 정리된 채 새 계획도 없는** 상태를 받았다.
+ */
+
+describe('인터뷰 완료 → 계획 체인', () => {
+  it('온보딩이든 재인터뷰든 **항상** 계획 체인으로 들어간다', () => {
+    // 진입 경로에 따라 갈리면 안 된다 — 갈렸던 것이 #441 의 원인이다.
+    expect(afterInterviewDone()).toBe('goal-classify');
+  });
+});
+
+describe('계획 체인 종착', () => {
+  it('온보딩이면 오늘 화면으로', () => {
+    expect(afterPlanChain(null)).toBe('today');
+  });
+
+  it('목표 관리에서 재인터뷰했으면 목표 관리로 — 방금 세운 계획이 반영된 걸 본다', () => {
+    expect(afterPlanChain('goals')).toBe('goals');
+  });
+
+  it('주간 계획에서 재인터뷰했으면 주간 계획으로', () => {
+    expect(afterPlanChain('weekly')).toBe('weekly');
+  });
+});
+
+describe('뒤로가기', () => {
+  it('인터뷰 화면에서 뒤로 = 재인터뷰를 그만둔다 — 들어온 화면으로', () => {
+    expect(backFromInterviewChain('goal-intake', 'intro', 'goals')).toEqual({
+      to: 'goals',
+      abandonInterview: true,
+    });
+  });
+
+  it('재인터뷰 중에는 온보딩 시작(intro)으로 떨어지지 않는다', () => {
+    // 재인터뷰로 들어온 사용자는 이미 온보딩을 마쳤다.
+    expect(backFromInterviewChain('goal-classify', 'goal-intake', 'goals').to).not.toBe('intro');
+    expect(backFromInterviewChain('goal-intake', 'intro', 'weekly')).toEqual({
+      to: 'weekly',
+      abandonInterview: true,
+    });
+  });
+
+  it('온보딩 중에는 평소대로 체인을 거슬러 올라간다', () => {
+    expect(backFromInterviewChain('goal-intake', 'intro', null)).toEqual({
+      to: 'intro',
+      abandonInterview: false,
+    });
+    expect(backFromInterviewChain('setup', 'goal-classify', null)).toEqual({
+      to: 'goal-classify',
+      abandonInterview: false,
+    });
+  });
+
+  it('back 이 없는 화면은 오늘로', () => {
+    expect(backFromInterviewChain('today', null, null)).toEqual({
+      to: 'today',
+      abandonInterview: false,
+    });
+  });
+
+  it('복귀 표시는 **그만둘 때만** 지운다 — 체인 중간의 평범한 뒤로가기는 유지', () => {
+    // 여기서 지워버리면 체인 끝에서 들어온 화면으로 못 돌아간다.
+    const step = backFromInterviewChain('milestone-confirm', 'setup', 'goals');
+    expect(step).toEqual({ to: 'setup', abandonInterview: false });
+  });
+});

--- a/src/lib/interviewNav.ts
+++ b/src/lib/interviewNav.ts
@@ -1,0 +1,62 @@
+import type { ScreenId } from '../types';
+
+/**
+ * 딥 인터뷰로 들어왔다 나갈 때의 화면 이동 규칙 (#216 · #441).
+ *
+ * 화면 컴포넌트 밖 **순수 함수**로 두는 이유: 이 규칙이 조용히 틀리면 사용자가
+ * "계획을 새로 세울게요" 라는 약속을 못 받거나(#441) 온보딩 시작 화면으로 떨어진다.
+ * `ReActionMerged` 를 통째로 렌더하지 않고 규칙만 테스트할 수 있어야 한다.
+ */
+
+/**
+ * 인터뷰를 **끝까지 마친 뒤** 갈 곳 — 언제나 계획 체인의 시작이다.
+ *
+ * ⚠️ 예전엔 재인터뷰(`returnTo` 가 있는 경우)를 여기서 곧장 들어온 화면으로 돌려보냈다.
+ * 그래서 계획 체인을 통째로 건너뛰었고, 재인터뷰 시트가 한 약속이 깨졌다:
+ *
+ * > 몇 가지만 다시 묻고 **계획을 새로 세울게요.**
+ *
+ * 백엔드는 제 할 일을 다 한다 — 새 목표를 `proposed` 로 저장하고 이전 잠정 목표를
+ * supersede 한다. **그 다음 단계(계획 생성)가 호출되지 않았을 뿐이다.**
+ * 그래서 재인터뷰만 하고 나가면 이전 미계획 목표가 정리된 채 새 계획도 없는 상태가 됐다.
+ */
+export function afterInterviewDone(): ScreenId {
+  return 'goal-classify';
+}
+
+/**
+ * 계획 체인의 **종착** — 여기서 비로소 복귀 표시를 소비한다.
+ *
+ * 재인터뷰로 들어왔으면 들어온 화면으로(그 화면에서 방금 세운 계획이 반영된 걸 본다),
+ * 온보딩이면 오늘 화면으로.
+ */
+export function afterPlanChain(returnTo: ScreenId | null): ScreenId {
+  return returnTo ?? 'today';
+}
+
+/**
+ * 뒤로가기 — 재인터뷰 중이면 온보딩 체인을 거슬러 올라가지 않는다.
+ *
+ * 재인터뷰로 들어온 사용자는 **이미 온보딩을 마쳤다.** 계획 체인의 `back` 을 따라가면
+ * `goal-intake → intro`(온보딩 시작)로 떨어진다. 그 전에 들어온 화면으로 되돌린다.
+ *
+ * @param screen   지금 화면
+ * @param metaBack `NAV_META[screen].back`
+ * @param returnTo 재인터뷰로 들어왔다면 그 화면, 아니면 null
+ * @returns `{ to, abandonInterview }` — `abandonInterview` 면 호출부가 복귀 표시를 지운다.
+ */
+export function backFromInterviewChain(
+  screen: ScreenId,
+  metaBack: ScreenId | null,
+  returnTo: ScreenId | null,
+): { to: ScreenId; abandonInterview: boolean } {
+  // 인터뷰 화면에서의 뒤로가기 = 재인터뷰를 그만두는 것.
+  if (screen === 'goal-intake' && returnTo) {
+    return { to: returnTo, abandonInterview: true };
+  }
+  // 계획 체인을 거슬러 올라가다 온보딩 시작으로 떨어지려는 순간.
+  if (metaBack === 'intro' && returnTo) {
+    return { to: returnTo, abandonInterview: true };
+  }
+  return { to: metaBack ?? 'today', abandonInterview: false };
+}


### PR DESCRIPTION
fix(interview): 재인터뷰도 계획 체인으로 잇는다 (#441)

재인터뷰 시트는 이렇게 말한다:

> 목표의 결이 바뀌었나요?
> 몇 가지만 다시 묻고 **계획을 새로 세울게요.**

그런데 **계획을 안 세우고** 원래 화면으로 돌려보냈다.

## 원인 — 복귀 표시를 인터뷰 끝에서 소비했다

    const leaveInterview = (fallback) => {
      const back = interviewReturnTo;
      setInterviewReturnTo(null);
      setScreen(back ?? fallback);       // ← 재인터뷰면 계획 체인을 건너뛴다
    };
    <GoalIntakeScreen onDone={() => leaveInterview('goal-classify')} ... />

| 진입 | `interviewReturnTo` | 도착 | 계획 |
|---|---|---|---|
| 온보딩 | `null` | `goal-classify → setup → milestone-confirm → weekly-plan` | ✅ |
| 재인터뷰(목표 관리) | `'goals'` | **`goals` 로 복귀** | ❌ |
| 재인터뷰(주간 계획) | `'weekly'` | **`weekly` 로 복귀** | ❌ |

**백엔드는 제 할 일을 다 한다** — 새 목표를 `proposed` 로 저장하고 이전 잠정 목표를
supersede 한다. 그 다음 단계가 호출되지 않았을 뿐이다. 그래서 재인터뷰만 하고 나가면
**이전 미계획 목표가 정리된 채 새 계획도 없는** 상태가 됐다.

## 고친 방법 — 복귀 표시를 체인 **끝**에서 소비한다

    인터뷰 완료  → 항상 `goal-classify` (진입 경로와 무관)
    체인 종착    → 재인터뷰면 들어온 화면, 온보딩이면 today

들어온 화면으로 돌려보내는 것이 `interviewReturnTo` 의 원래 의도이고, 사용자는 거기서
**방금 세운 계획이 반영된 것**을 본다.

## 함께 막은 두 가지

- **온보딩 시작으로 떨어지는 것**: 재인터뷰 사용자가 계획 체인을 거슬러 올라가면
  `goal-intake → intro` 로 간다. 재인터뷰로 들어온 사람은 **이미 온보딩을 마쳤다** —
  그 전에 들어온 화면으로 되돌린다. (지금까지는 재인터뷰가 체인에 진입하지 않아
  노출되지 않던 경로다.)
- **표시가 남아 도는 것**: 탭으로 체인을 벗어나면 복귀 표시를 버린다. 안 그러면 나중에
  엉뚱한 화면으로 보낸다.

⚠️ 체인 **중간**의 평범한 뒤로가기는 표시를 **유지**한다 — 거기서 지우면 끝에서
들어온 화면으로 못 돌아간다.

## 규칙을 순수 함수로 뺐다

`src/lib/interviewNav.ts` — `ReActionMerged` 를 통째로 렌더하지 않고 규칙만 테스트한다.
이 규칙이 조용히 틀리면 사용자가 약속받은 계획을 못 받거나 온보딩 시작으로 떨어진다.

## 검증

`npx vitest` 를 **로컬에서 못 돌렸다** — `vitest`·`@testing-library` 가 node_modules 에
없고 네트워크가 차단돼 `npm install` 이 안 된다. CI(`npm ci && npm test`)가 검증한다.

대신 순수 함수의 **로직은 node 로 직접 확인**했다(타입만 제거해 실행):

    ok  인터뷰 완료 → 항상 계획 체인
    ok  온보딩 종착 = today
    ok  목표관리/주간계획 재인터뷰 → 각각 복귀
    ok  인터뷰에서 뒤로 = 그만두기 (두 진입 모두)
    ok  온보딩은 평소대로 / 체인 유지
    ok  체인 중간 뒤로가기는 표시 유지
    ok  back 없으면 today
    → 10/10

    npx tsc --noEmit   오류 11건 → 11건 (변경 전후 동일)
                       전부 vitest/@testing-library 미설치 계열, 내 변경 관련 0
