### PR TITLE
[ui] data-tour-help 이 버튼 안에 글자로 찍히고 있었다 (4곳)

### DIFF
--- a/src/screens/GoalsScreen.tsx
+++ b/src/screens/GoalsScreen.tsx
@@ -233,10 +233,10 @@ export function GoalsScreen() {
               누를지 말지는 사용자가 정하고, 무슨 일이 일어나는지는 시트에서 밝힌다. */}
           <button
             onClick={() => setConfirmReinterview(true)}
+            data-tour-help="목표가 달라졌을 때 인터뷰를 다시 해서 계획을 새로 세워요."
             style={{ marginTop: 10, alignSelf: 'flex-start', height: 'var(--ctrl-sm)', padding: '0 12px', borderRadius: 9999, border: '1px solid var(--coral-200)', background: 'var(--brand-soft)', color: 'var(--coral-700)', fontSize: 12, fontWeight: 700, fontFamily: 'inherit', cursor: 'pointer', display: 'inline-flex', alignItems: 'center', gap: 5 }}
           >
             <ChatCircleDots size={13} weight="fill" />
-            data-tour-help="목표가 달라졌을 때 인터뷰를 다시 해서 계획을 새로 세워요."
             목표가 바뀌었어요 · 다시 인터뷰하기
           </button>
 
@@ -266,8 +266,8 @@ export function GoalsScreen() {
                 variant={ultimateGoal ? 'ghost' : 'primary'}
                 size="sm"
                 onClick={() => { setMandalaGoalId(null); setScreen('ultimate-interview'); }}
-              >
                 data-tour-help="장기 목표를 만다라트로 펼쳐 하위 영역까지 정해요."
+              >
                 {ultimateGoal ? '다시 세우기' : '궁극적 목표 세우기'}
               </ReButton>
             </div>
@@ -445,8 +445,7 @@ export function GoalsScreen() {
             </div>
           </div>
         ) : (
-          <button onClick={() => setShowAdd(true)} style={{ display: 'flex', alignItems: 'center', gap: 6, justifyContent: 'center', height: 40, borderRadius: 12, border: '1.5px dashed var(--sand-300)', background: 'transparent', color: 'var(--text-2)', fontWeight: 600, fontSize: 12, cursor: 'pointer', fontFamily: 'inherit' }}>
-            data-tour-help="새 목표를 직접 만들어요. 집중·유지·보류 중 어디에 둘지도 여기서 정해요."
+          <button onClick={() => setShowAdd(true)} data-tour-help="새 목표를 직접 만들어요. 집중·유지·보류 중 어디에 둘지도 여기서 정해요." style={{ display: 'flex', alignItems: 'center', gap: 6, justifyContent: 'center', height: 40, borderRadius: 12, border: '1.5px dashed var(--sand-300)', background: 'transparent', color: 'var(--text-2)', fontWeight: 600, fontSize: 12, cursor: 'pointer', fontFamily: 'inherit' }}>
             <Plus size={14} /> 목표 추가
           </button>
         )}

--- a/src/screens/WeeklyReviewScreen.tsx
+++ b/src/screens/WeeklyReviewScreen.tsx
@@ -352,8 +352,7 @@ export function WeeklyReviewScreenV2() {
 
       {/* Sticky CTA */}
       <div style={{ flexShrink: 0, padding: '12px 18px', paddingBottom: 'max(28px, env(safe-area-inset-bottom, 28px))', background: 'var(--surface-ground)' }}>
-        <button onClick={goToNextWeekPlan} style={{ width: '100%', height: 'var(--ctrl-lg)', borderRadius: 12, border: 'none', background: 'var(--brand-surface)', color: '#FFFCF6', fontWeight: 700, fontSize: 14, fontFamily: 'inherit', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6 }}>
-          data-tour-help="이번 리뷰를 반영하러 다음 주 계획 화면으로 넘어가요."
+        <button onClick={goToNextWeekPlan} data-tour-help="이번 리뷰를 반영하러 다음 주 계획 화면으로 넘어가요." style={{ width: '100%', height: 'var(--ctrl-lg)', borderRadius: 12, border: 'none', background: 'var(--brand-surface)', color: '#FFFCF6', fontWeight: 700, fontSize: 14, fontFamily: 'inherit', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6 }}>
           다음 주 계획 확인 <ArrowRight size={15} />
         </button>
       </div>


### PR DESCRIPTION
fix(ui): data-tour-help 이 버튼 안에 **글자로 찍히고 있었다** (4곳)

로컬에서 목표 관리 화면을 직접 열어보다 발견했다. 버튼에 이렇게 나온다:

    data-tour-help="목표가 달라졌을 때 인터뷰를 다시 해서 계획을 새로 세워요." 목표가 바뀌었어요 · 다시 인터뷰하기
    data-tour-help="장기 목표를 만다라트로 펼쳐 하위 영역까지 정해요."궁극적 목표 세우기
    data-tour-help="새 목표를 직접 만들어요. 집중·유지·보류 중 어디에 둘지도 여기서 정해요." 목표 추가

## 원인

`data-tour-help` 가 **여는 태그 안의 속성이 아니라 JSX 자식**으로 들어가 있다.
JSX 에서 태그 밖의 문자열은 그냥 텍스트 노드다.

    <button onClick={...} style={...}>
      <ChatCircleDots size={13} weight="fill" />
      data-tour-help="..."          ← 자식. 화면에 그대로 찍힌다
      목표가 바뀌었어요 · 다시 인터뷰하기
    </button>

`HeroTaskCard.tsx:186` 은 올바르게 여는 태그 안에 두고 있다.

## 피해 둘

1. **설명 문구가 UI 에 노출된다** — 사용자가 보는 화면에 코드 조각이 찍힌다.
2. **가이드 투어가 그 설명을 못 읽는다** — 속성이 없으니 `GuidedTourOverlay` 가 빈 문자열을
   쓴다. 설명을 달아둔 의도가 통째로 죽어 있었다.

## 고친 곳 4개

    screens/GoalsScreen.tsx        3곳 (다시 인터뷰 · 궁극적 목표 · 목표 추가)
    screens/WeeklyReviewScreen.tsx 1곳 (다음 주 계획 확인)

지우지 않고 **여는 태그의 속성으로 옮겼다** — 지우면 투어 설명이 사라진다.

## 전수 확인

`src/**/*.tsx` 의 모든 `data-tour-help` 를 훑어 "단독 줄로 있고 직전 줄에서 태그가 이미
닫힌" 경우를 찾았다. 수정 후 **0곳**.

⚠️ 첫 판정은 오탐이 하나 있었다 — `<button ... data-tour-help="..." style=...>` 처럼
**같은 줄**에 있는 정상 속성을 직전 줄 `>` 만 보고 누출로 셌다. "그 줄이
`data-tour-help=` 로 **시작**하는가" 를 조건에 넣어 갈랐다.

## 검증

    npx tsc --noEmit   내 변경 관련 오류 0
    브라우저 실측       수정 전 4곳 노출 → 수정 후 0곳 (아래 PR 코멘트에 화면 텍스트)

⚠️ `vitest` 는 네트워크 차단으로 로컬 실행 불가 — CI 가 검증한다.
