### PR TITLE
[goals] 미계획 카드에 [이 목표 계획 세우기] — 그 목표만 계획한다 (#442)

### DIFF
--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -60,6 +60,8 @@ export function AppShell() {
   const [interviewReturnTo, setInterviewReturnTo] = useState<ScreenId | null>(null);
   // 만다라트 화면이 볼 궁극목표 id(#220). 목표 화면에서 진입하면 채워지고, 직접 진입하면 null.
   const [mandalaGoalId, setMandalaGoalId] = useState<string | null>(null);
+  // 이 목표 하나만 계획하러 들어온 인터뷰의 대상(#442). 전체 인터뷰면 null.
+  const [interviewGoalId, setInterviewGoalId] = useState<string | null>(null);
   // 실제 로그인 화면(구글/데모)을 보여줘야 하는지 — stub 자동 로그인이 꺼졌거나(?login=1) 401 뒤 재로그인 필요할 때.
   const [needsLogin, setNeedsLogin] = useState(false);
   const [authBusy, setAuthBusy] = useState(false);
@@ -186,6 +188,7 @@ export function AppShell() {
     setPlannedMilestones(null);
     setInterviewReturnTo(null);
     setMandalaGoalId(null);
+    setInterviewGoalId(null);
     setWeekOffset(0);
     setAuthError(null);
     setBootError(null);
@@ -335,7 +338,7 @@ export function AppShell() {
 
   return (
     <NavigationContext.Provider
-      value={{ screen, tab, setScreen, setTab, user, onboardingState, isBootstrapping, weekOffset, setWeekOffset, interviewSessionId, setInterviewSessionId, plannedMilestones, setPlannedMilestones, interviewReturnTo, setInterviewReturnTo, mandalaGoalId, setMandalaGoalId, logout: handleLogout }}
+      value={{ screen, tab, setScreen, setTab, user, onboardingState, isBootstrapping, weekOffset, setWeekOffset, interviewSessionId, setInterviewSessionId, plannedMilestones, setPlannedMilestones, interviewReturnTo, setInterviewReturnTo, mandalaGoalId, setMandalaGoalId, interviewGoalId, setInterviewGoalId, logout: handleLogout }}
     >
       <ToastProvider>
         {/* 뷰포트에 맞는 트리 하나만 마운트(둘 다 마운트 후 CSS 로만 숨기면 데이터 페칭이 2배로 나감). */}

--- a/src/app/ReActionMerged.tsx
+++ b/src/app/ReActionMerged.tsx
@@ -105,7 +105,7 @@ interface ReActionMergedProps {
 }
 
 export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
-  const { screen, tab, setScreen, setTab, setWeekOffset, interviewReturnTo, setInterviewReturnTo, mandalaGoalId, setMandalaGoalId } = useNavigation();
+  const { screen, tab, setScreen, setTab, setWeekOffset, interviewReturnTo, setInterviewReturnTo, mandalaGoalId, setMandalaGoalId, setInterviewGoalId } = useNavigation();
 
   // 초기값 비움 → /today/agenda 로딩 중엔 TodayScreen 의 스켈레톤이 대신 표시된다.
   // 실패 시에도 더미로 가리지 않고 빈 목록 + 정직 배너를 보여준다.
@@ -244,6 +244,7 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
   const handleTabChange = (id: TabId) => {
     // 체인을 탭으로 벗어나면 복귀 표시를 버린다 — 남겨두면 나중에 엉뚱한 화면으로 보낸다.
     if (interviewReturnTo) setInterviewReturnTo(null);
+    setInterviewGoalId(null);
     if (id === 'weekly') setWeekOffset(0);
     setTab(id);
     setScreen(id);
@@ -257,6 +258,9 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
   const finishPlanChain = () => {
     const to = afterPlanChain(interviewReturnTo);
     setInterviewReturnTo(null);
+    // 목표 지정 인터뷰(#442)의 대상도 여기서 놓는다 — 남겨두면 **다음 인터뷰가 물려받아**
+    // 사용자가 목표를 말할 기회 없이 지난 목표로 시작한다.
+    setInterviewGoalId(null);
     if (to === 'today') setTab('today');
     setScreen(to);
   };
@@ -268,7 +272,10 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
       NAV_META[screen]?.back ?? null,
       interviewReturnTo,
     );
-    if (drop) setInterviewReturnTo(null);
+    if (drop) {
+      setInterviewReturnTo(null);
+      setInterviewGoalId(null);
+    }
     setScreen(to);
   };
 

--- a/src/contexts/NavigationContext.tsx
+++ b/src/contexts/NavigationContext.tsx
@@ -34,6 +34,11 @@ export interface NavigationContextType {
   // isUltimate 목표를 직접 찾는다 — 목표 화면을 거치지 않고 들어와도 동작해야 하기 때문.
   mandalaGoalId: string | null;
   setMandalaGoalId: (id: string | null) => void;
+  // 이 목표 **하나만** 계획하러 들어온 인터뷰의 대상(#442). null 이면 전체 인터뷰다.
+  // 목표 관리의 "미계획" 카드 [계획 세우기] 가 세우고, `GoalIntakeScreen` 이 세션을 열 때
+  // 실어 보낸다 — 서버가 그 목표로 `goals.list`·`goals.heaviest` 를 채워 다시 묻지 않는다.
+  interviewGoalId: string | null;
+  setInterviewGoalId: (id: string | null) => void;
   // 로그아웃 — 서버의 refresh token 을 revoke 하고 세션을 비운 뒤 로그인 화면으로 보낸다.
   // 설정 화면이 부르지만 화면 전환은 AppShell 이 쥐고 있어서 여기로 내려 준다.
   logout: () => Promise<void>;
@@ -57,6 +62,8 @@ export const NavigationContext = createContext<NavigationContextType>({
   setInterviewReturnTo: () => {},
   mandalaGoalId: null,
   setMandalaGoalId: () => {},
+  interviewGoalId: null,
+  setInterviewGoalId: () => {},
   logout: async () => {},
 });
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -391,10 +391,14 @@ export const onboardingApi = {
 // ── Interview (S02) ───────────────────────────────────────────
 export const interviewApi = {
   // kind 생략 시 계획 인터뷰(하위호환). 'ultimate' 는 궁극목표 인터뷰(U0b) 시작.
-  start: (kind?: InterviewKind) =>
+  //
+  // `goalId` 를 주면 **그 목표 하나만** 계획하는 인터뷰다(#442) — 서버가
+  // `goals.list`·`goals.heaviest` 를 그 목표로 채운 채 시작해 **대상을 다시 묻지 않는다.**
+  // 목표 관리의 "미계획" 카드에서 [계획 세우기] 로 들어오는 경로.
+  start: (kind?: InterviewKind, goalId?: string) =>
     request<InterviewSession>('/interview/sessions', {
       method: 'POST',
-      body: kind ? { kind } : {},
+      body: { ...(kind ? { kind } : {}), ...(goalId ? { goalId } : {}) },
     }),
 
   get: (sessionId: string) =>

--- a/src/screens/GoalIntakeScreen.tsx
+++ b/src/screens/GoalIntakeScreen.tsx
@@ -43,7 +43,7 @@ function omxStatus(clarity: number) {
 
 export function GoalIntakeScreen({ onDone, onOutcome }: GoalIntakeScreenProps) {
   // 인터뷰 세션 id 를 전역에 올려, weekly-plan(S06) 에서 /plans/generate 가 쓸 수 있게 한다.
-  const { setInterviewSessionId } = useNavigation();
+  const { setInterviewSessionId, interviewGoalId } = useNavigation();
   const [session, setSession] = useState<InterviewSession | null>(null);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [inputText, setInputText] = useState('');
@@ -134,7 +134,9 @@ export function GoalIntakeScreen({ onDone, onOutcome }: GoalIntakeScreenProps) {
     // 항상 새 세션을 만든다. 막는 요인(기존 세션/일시 락)은 흡수하며 최대 6회 재시도.
     const beginFresh = async (attempt = 0): Promise<InterviewSession> => {
       try {
-        return await interviewApi.start();
+        // 목표 지정 인터뷰(#442)면 그 목표를 실어 보낸다 — 서버가 `goals.list`·
+        // `goals.heaviest` 를 채워 **대상을 다시 묻지 않는다.**
+        return await interviewApi.start(undefined, interviewGoalId ?? undefined);
       } catch (err) {
         if (cancelled) throw err;
         const code = err instanceof ApiError ? err.code : '';

--- a/src/screens/GoalsScreen.tsx
+++ b/src/screens/GoalsScreen.tsx
@@ -27,7 +27,7 @@ interface EditDraft {
 export function GoalsScreen() {
   // 목표의 결이 바뀌면 계획의 전제(가용 시간·역량·마감·회복 톤)가 통째로 무너진다.
   // 여기서 딥 인터뷰로 되돌아갈 수 있어야 하고, 끝나면 온보딩이 아니라 이 화면으로 와야 한다(#216).
-  const { setScreen, setInterviewReturnTo, setMandalaGoalId } = useNavigation();
+  const { setScreen, setInterviewReturnTo, setMandalaGoalId, setInterviewGoalId } = useNavigation();
   const [confirmReinterview, setConfirmReinterview] = useState(false);
   // 초기값 비움 → 로딩 중 스켈레톤, 실패 시엔 빈 목록 + 에러(더미로 가리지 않는다).
   const [goals, setGoals] = useState<ApiGoal[]>([]);
@@ -345,6 +345,23 @@ export function GoalsScreen() {
                           <div style={{ display: 'inline-flex', alignItems: 'center', gap: 4, alignSelf: 'flex-start', height: 24, padding: '0 9px', borderRadius: 9999, background: 'var(--brand-soft)', border: '1px solid var(--coral-200)', color: 'var(--coral-700)', fontSize: 11, fontWeight: 700 }}>
                             <ArrowUpRight size={10} weight="bold" /> 만다라트 축 · {g.promotedFromAxis}
                           </div>
+                        )}
+                        {/* 미계획 목표에만 — 이 목표 **하나만** 계획하러 인터뷰로 들어간다(#442).
+                            상단의 "목표가 바뀌었어요 · 다시 인터뷰하기" 와는 **다른 질문**이다:
+                            저건 "전체 판이 바뀌었다", 이건 "이 목표를 계획하고 싶다".
+                            대상을 실어 보내므로 서버가 목표를 다시 묻지 않는다. */}
+                        {g.hasPlan === false && !g.isUltimate && (
+                          <button
+                            data-tour-help="이 목표의 계획을 세워요. 목표는 이미 정해졌으니 나머지만 몇 가지 물어봐요."
+                            onClick={() => {
+                              setInterviewGoalId(g.goalId);
+                              setInterviewReturnTo('goals');
+                              setScreen('goal-intake');
+                            }}
+                            style={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', gap: 5, height: 36, borderRadius: 10, border: 'none', background: 'var(--brand-surface)', color: '#FFFCF6', fontSize: 12, fontWeight: 700, fontFamily: 'inherit', cursor: 'pointer' }}
+                          >
+                            <ChatCircleDots size={13} weight="fill" /> 이 목표 계획 세우기
+                          </button>
                         )}
                         {g.isUltimate && (
                           <button


### PR DESCRIPTION
feat(goals): 미계획 카드에 [이 목표 계획 세우기] — 그 목표만 계획한다 (#442)

기존엔 미계획 목표를 계획하려면 상단의 **"목표가 바뀌었어요 · 다시 인터뷰하기"** 를 눌러
**전체 인터뷰를 처음부터** 다시 해야 했다. 사용자는 "이 목표를 계획하고 싶다" 고
생각하는데 화면은 **전혀 다른 질문**을 던진 셈이다.

## 바뀐 것

미계획 카드(`hasPlan === false`)를 펼치면 **[이 목표 계획 세우기]** 가 나온다.
누르면 `goalId` 를 실어 인터뷰를 열고, 서버가 `goals.list`·`goals.heaviest` 를 그 목표로
채운 채 시작해 **대상을 다시 묻지 않는다.**

브라우저 실측 — 첫 질문이 목표를 묻지 않는다:

    '내년 1월 중순까지 교환학생 파견 확정 받기', 지금 어느 정도까지 해보셨나요?
    추천: 처음이에요 / 정보를 찾아보는 중이에요 / 공인어학성적은 준비되어 있어요 …

그대로 진행하면 목표 분류(2/4)에 **그 목표 하나만** 오르고 주간 계획 생성으로 이어진다.

## 기존 상단 버튼은 남긴다 — **다른 질문**이다

    카드의 [이 목표 계획 세우기]        "이 목표를 계획하고 싶다"
    상단의 [목표가 바뀌었어요]           "전체 판이 바뀌었다, 다시 정리하고 싶다"

궁극목표(`isUltimate`)에는 붙이지 않는다 — 그건 만다라트로 간다.

## 대상은 체인을 벗어날 때 **반드시 놓는다** (3곳)

남겨두면 **다음 인터뷰가 물려받아** 사용자가 목표를 말할 기회 없이 지난 목표로 시작한다.

    계획 체인 종착   finishPlanChain
    재인터뷰 그만두기 goBack 의 abandon 분기
    탭으로 이탈      handleTabChange

로그아웃 리셋에도 넣었다.

## 선행 (전부 머지됨)

    FE #316  미계획 배지(hasPlan)      — 없으면 버튼 달 자리를 화면이 모른다
    FE #317  재인터뷰 → 계획 체인       — 없으면 계획을 안 세운 채 목표 관리로 돌아간다
    BE #446  goalId 수용
    BE #443  hasPlan 필드

⚠️ 이 PR 은 원래 #319 였는데, 선행 PR 들이 **squash 머지되며 히스토리가 바뀌어** 충돌했다.
브랜치를 다시 만들지 않고 **내 변경만 패치로 뽑아** 새 main 위에 올렸다(6파일, 전부 clean).
선행분이 되돌려지지 않았는지 확인했다 — `data-tour-help` 누출 0곳(#318),
`hasPlan === false` 판정 유지(#316), `finishPlanChain` 유지(#317).

## 검증

    npx tsc --noEmit   내 변경 관련 오류 0
    브라우저 실측       미계획 배지 → 버튼 → 목표를 안 묻는 인터뷰 → 목표 분류 → 주간 계획 생성
    DB 실측            인터뷰 뒤에도 **다른 미계획 목표(토익 900점)가 그대로 남는다**

⚠️ `vitest` 는 네트워크 차단으로 로컬 실행 불가 — CI(`npm ci && npm test`)가 검증한다.
