### PR TITLE
fix(tour): ReButton 이 투어 설명을 버리고 있었다

### DIFF
--- a/src/components/ReButton.test.tsx
+++ b/src/components/ReButton.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ReButton } from './ReButton';
+
+// 가이드 투어는 요소의 data-tour-help 속성에서 설명을 읽는다(GuidedTourOverlay 의
+// description()). ReButton 이 이 속성을 넘기지 않으면 그 버튼만 설명이 안 뜨는데,
+// TypeScript 는 하이픈이 들어간 JSX 속성을 검사하지 않아 오류조차 나지 않는다.
+// 화면에는 아무 이상이 없어 보이므로, 여기서 잠가둔다.
+describe('ReButton', () => {
+  it('투어 설명을 실제 button 속성으로 넘긴다', () => {
+    render(<ReButton data-tour-help="이 버튼이 하는 일">누르기</ReButton>);
+    expect(screen.getByRole('button', { name: '누르기' })).toHaveAttribute(
+      'data-tour-help',
+      '이 버튼이 하는 일',
+    );
+  });
+
+  it('설명을 주지 않으면 속성을 만들지 않는다', () => {
+    render(<ReButton>누르기</ReButton>);
+    expect(screen.getByRole('button', { name: '누르기' })).not.toHaveAttribute('data-tour-help');
+  });
+});

--- a/src/components/ReButton.tsx
+++ b/src/components/ReButton.tsx
@@ -9,6 +9,12 @@ interface ReButtonProps {
   style?: React.CSSProperties;
   disabled?: boolean;
   full?: boolean;
+  // 가이드 투어(GuidedTourOverlay)가 읽어 갈 설명. 받아서 실제 <button> 으로 넘긴다.
+  //
+  // 통로가 없으면 <ReButton data-tour-help="…"> 는 조용히 버려진다 — TypeScript 는
+  // 하이픈이 들어간 JSX 속성을 검사하지 않아서 오류도 나지 않는다. 속성을 제자리에
+  // 옮겨 적어도 그 버튼만 설명이 안 뜨는데, 화면에는 아무 이상이 없어 보인다.
+  'data-tour-help'?: string;
 }
 
 const heights: Record<ButtonSize, number> = { sm: 36, md: 44, lg: 52 };
@@ -30,11 +36,13 @@ export function ReButton({
   style = {},
   disabled,
   full,
+  'data-tour-help': tourHelp,
 }: ReButtonProps) {
   return (
     <button
       onClick={onClick}
       disabled={disabled}
+      data-tour-help={tourHelp}
       style={{
         height: heights[size],
         minWidth: 44,

--- a/src/screens/GoalsScreen.tsx
+++ b/src/screens/GoalsScreen.tsx
@@ -266,7 +266,12 @@ export function GoalsScreen() {
                 variant={ultimateGoal ? 'ghost' : 'primary'}
                 size="sm"
                 onClick={() => { setMandalaGoalId(null); setScreen('ultimate-interview'); }}
-                data-tour-help="장기 목표를 만다라트로 펼쳐 하위 영역까지 정해요."
+                // 이미 세워둔 궁극적 목표가 있으면 이 버튼은 "새로 세우기" 가 아니라
+                // "다시 세우기" 다. 무엇이 바뀌는지 밝히지 않으면 되돌리기 어려운
+                // 동작을 설명 없이 누르게 된다.
+                data-tour-help={ultimateGoal
+                  ? '인터뷰를 다시 해서 궁극적 목표를 새로 세우고, 만다라트 초안도 다시 만들어요.'
+                  : '장기 목표를 만다라트로 펼쳐 하위 영역까지 정해요.'}
               >
                 {ultimateGoal ? '다시 세우기' : '궁극적 목표 세우기'}
               </ReButton>


### PR DESCRIPTION
> **범위가 바뀌었습니다.** 처음 이 PR 은 `data-tour-help` 네 곳이 버튼 안에 글자로 찍히던 문제를 고쳤는데, 그 사이 #318 이 같은 네 곳을 먼저 고쳤습니다. 겹치는 부분은 걷어내고, **#318 이 고치지 못한 한 곳**만 남겼습니다.

## 무엇이 남아 있나

#318 은 「다시 세우기」 버튼의 `data-tour-help` 도 여는 태그의 속성 자리로 옮겼습니다. 그런데 이 버튼은 `<button>` 이 아니라 `ReButton` 입니다.

```jsx
<ReButton
  variant={ultimateGoal ? 'ghost' : 'primary'}
  onClick={...}
  data-tour-help="장기 목표를 만다라트로 펼쳐 하위 영역까지 정해요."   // ← 여기서 끝난다
>
```

`ReButtonProps` 에 이 prop 이 없어서, 값은 내부 `<button>` 까지 가지 못하고 **조용히 버려집니다.** 화면에 글자는 더 이상 찍히지 않지만, 이 버튼의 투어 설명은 여전히 나오지 않습니다.

## 왜 아무도 눈치채지 못했나

TypeScript 는 **하이픈이 들어간 JSX 속성을 검사하지 않습니다.** `data-*` 와 `aria-*` 는 임의 값이 허용되는 자리라, 받는 쪽에 그 prop 이 없어도 오류가 나지 않습니다. `npx tsc --noEmit` 도, 빌드도, 화면도 전부 멀쩡해 보입니다. 겉으로 드러나는 신호가 하나도 없는 종류의 실패입니다.

## 수정

- `ReButton` 이 `data-tour-help` 를 받아 실제 `<button>` 으로 넘깁니다.
- 「다시 세우기」는 궁극적 목표가 이미 있을 때와 없을 때 하는 일이 다르므로 문구를 나눴습니다. 이미 있을 때는 인터뷰를 다시 해서 만다라트 초안까지 새로 만든다는 실제 경로(`ReActionMerged` 의 `onGoalReady` → `mandala-draft`)를 밝힙니다. 되돌리기 어려운 동작인데 지금 문구는 처음 세우는 경우만 설명하고 있었습니다.

## 검증

`src/components/ReButton.test.tsx` 를 추가했습니다.

- 투어 설명을 실제 button 속성으로 넘긴다 — **고치기 전 코드에서 실패**합니다
- 설명을 주지 않으면 속성을 만들지 않는다

무음으로 실패하는 종류라, 사람 눈 대신 테스트가 지키게 했습니다.

- `npm test` — 30 passed (전부 통과)
- `npx tsc --noEmit` — 오류 없음
- `npx vite build` — 성공

## 남은 것 (이 PR 범위 밖)

#310 이 다루는 「다시 세우기」 확인 시트는 여전히 미구현입니다. 지금은 버튼을 누르면 확인 절차 없이 곧바로 궁극적 목표 인터뷰로 넘어가며, 백엔드의 `GET /goals/{goalId}/mandala/rebuild-preflight` 에 연결돼 있지 않습니다. 이번 변경은 그 버튼의 **설명**만 살렸습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M3Fh9uAbvP2DRsDMFngoS5
