### PR TITLE
fix(recovery): 회복 화면 진입 직후 제안 자리가 빈 공간으로 남던 문제

### DIFF
--- a/src/app/ReActionMerged.tsx
+++ b/src/app/ReActionMerged.tsx
@@ -141,6 +141,9 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
   const [executionIds, setExecutionIds] = useState<Record<string, string>>({});
   const [recoveryReadyIds, setRecoveryReadyIds] = useState<Record<string, string>>({});
   const [recoveryPreparationError, setRecoveryPreparationError] = useState<string | null>(null);
+  // 회복 화면으로 먼저 넘어간 뒤 체크인·태그 저장이 도는 동안 true — 회복 화면이
+  // 빈 카드 자리 대신 "저장하는 중" 을 보여줄 수 있게 한다.
+  const [recoveryPreparing, setRecoveryPreparing] = useState(false);
   // 이번 세션에서 수락한 복구 횟수 (백엔드 누적 집계 엔드포인트가 없어 세션 카운트로 정직하게).
   const [recoveryCount, setRecoveryCount] = useState(0);
   // 사용자가 회복 화면에서 고른 제안 — RecoveredScreen 의 before→after 카드용.
@@ -166,6 +169,7 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
     setActiveTask(failedTask ? { ...failedTask, status: 'failed', failReason: reason } : null);
     setFailReason(reason);
     setRecoveryPreparationError(null);
+    setRecoveryPreparing(true);
     setScreen('recovery');
 
     // 실패 경로는 TodayScreen 실패시트 → 여기로 직행해 FocusScreen 을 거치지 않을 수
@@ -194,6 +198,9 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
       })
       .catch(() => {
         setRecoveryPreparationError('실행 결과를 저장하지 못했어요. 오늘 화면에서 다시 시도해 주세요.');
+      })
+      .finally(() => {
+        setRecoveryPreparing(false);
       });
   };
 
@@ -217,6 +224,8 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
   const openRecovery = () => {
     const partial = tasks.find((t) => t.status === 'partial_done' || t.status === 'recovery_pending');
     setActiveTask(partial ?? null);
+    // 이 경로는 저장을 새로 걸지 않는다 — 이미 있는 executionId 로 바로 제안을 받는다.
+    setRecoveryPreparing(false);
     setScreen('recovery');
   };
 
@@ -330,6 +339,7 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
             executionId={activeTask
               ? (activeTask.status === 'failed' ? recoveryReadyIds[activeTask.id] : executionIds[activeTask.id])
               : undefined}
+            preparing={recoveryPreparing}
             preparationError={recoveryPreparationError}
             onOpenWeekly={() => { setWeekOffset(0); setTab('weekly'); setScreen('weekly'); }}
           />

--- a/src/screens/RecoveryScreen.test.tsx
+++ b/src/screens/RecoveryScreen.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MergedRecoveryScreen } from './RecoveryScreen';
+import { recoveryApi } from '../lib/api';
+import type { Task } from '../types';
+
+vi.mock('../lib/api', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../lib/api')>();
+  return {
+    ...original,
+    recoveryApi: { ...original.recoveryApi, generateProposals: vi.fn(), decide: vi.fn() },
+  };
+});
+
+const task: Task = { id: 'task-1', title: '보고서 작성', status: 'failed' };
+const api = recoveryApi as unknown as {
+  generateProposals: ReturnType<typeof vi.fn>;
+  decide: ReturnType<typeof vi.fn>;
+};
+
+function view(props: Partial<React.ComponentProps<typeof MergedRecoveryScreen>> = {}) {
+  return render(
+    <MergedRecoveryScreen
+      task={task}
+      failReason="시간이 부족했어요"
+      onAccept={vi.fn()}
+      onDismiss={vi.fn()}
+      onOpenWeekly={vi.fn()}
+      {...props}
+    />,
+  );
+}
+
+// 회복 화면은 진입 직후 두 번 기다린다 — 실행 기록 저장(executionId 확보)과 LLM 제안
+// 생성이다. 예전엔 두 구간 모두 카드 자리가 아무 표시 없는 빈 공간이었다.
+describe('MergedRecoveryScreen 대기 상태', () => {
+  beforeEach(() => {
+    api.generateProposals.mockReset();
+    api.decide.mockReset();
+    sessionStorage.clear();
+  });
+
+  it('실행 기록을 저장하는 동안 빈 공간 대신 진행 안내를 보여준다', () => {
+    view({ preparing: true, executionId: undefined });
+    expect(screen.getByText(/실행 기록을 저장하고 있어요/)).toBeInTheDocument();
+    expect(api.generateProposals).not.toHaveBeenCalled();
+  });
+
+  it('제안을 불러오는 동안에도 진행 안내를 유지한다', async () => {
+    api.generateProposals.mockReturnValue(new Promise(() => {}));
+    view({ executionId: 'exec-1' });
+    expect(await screen.findByText(/회복 제안을 준비하고 있어요/)).toBeInTheDocument();
+  });
+
+  it('기다리는 동안 카드 자리를 스켈레톤으로 채운다', async () => {
+    api.generateProposals.mockReturnValue(new Promise(() => {}));
+    const { container } = view({ executionId: 'exec-1' });
+    await waitFor(() => expect(container.querySelectorAll('.rx-skeleton').length).toBeGreaterThan(0));
+  });
+
+  it('안내 배너를 닫아둔 세션에서도 대기 안내는 사라지지 않는다', async () => {
+    sessionStorage.setItem('reaction.demoNotice.recovery-proposals', '1');
+    api.generateProposals.mockReturnValue(new Promise(() => {}));
+    view({ executionId: 'exec-1' });
+    expect(await screen.findByText(/회복 제안을 준비하고 있어요/)).toBeInTheDocument();
+  });
+
+  it('제안이 도착하면 대기 안내를 걷고 카드를 보여준다', async () => {
+    api.generateProposals.mockResolvedValue({
+      aiSource: 'llm',
+      recoveryMode: 'standard',
+      cards: [{
+        attemptId: 'a-1',
+        optionGroup: 'DOWNSCOPE',
+        strategyType: 'DOWNSCOPE',
+        labelKo: '15분만 다시',
+        suggestedActionText: '작게 쪼개서 다시 붙어요.',
+        minRecoveryUnitMinutes: 15,
+        allowRestMode: false,
+        triggerTag: 'TIME_SHORTAGE',
+      }],
+    });
+    view({ executionId: 'exec-1' });
+    expect(await screen.findByText('15분만 다시')).toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByText(/회복 제안을 준비하고 있어요/)).not.toBeInTheDocument());
+  });
+});

--- a/src/screens/RecoveryScreen.tsx
+++ b/src/screens/RecoveryScreen.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import {
   ArrowsClockwise,
+  CircleNotch,
   Flag,
   Sparkle,
   Check,
@@ -12,6 +13,7 @@ import { DemoNotice } from '../components/DemoNotice';
 import { RecoveryOptionCard } from '../components/RecoveryOptionCard';
 import { ReEngagementAnchorPicker } from '../components/ReEngagementAnchorPicker';
 import { EmptyState } from '../components/EmptyState';
+import { SkeletonBlock } from '../components/SkeletonBlock';
 import { ErrorBanner } from '../components/ErrorBanner';
 import { localDateStr, defaultCarryOverAnchorDate, defaultReEngagementAnchorDate, DEFAULT_REENGAGEMENT_TIME } from '../lib/dates';
 import type { Task, RecoveryProposal } from '../types';
@@ -105,11 +107,14 @@ interface MergedRecoveryScreenProps {
   // 있으면 백엔드 LLM 회복 제안(POST /recovery/proposals/generate)과 연동한다.
   // task.id 는 task id 일 뿐 executionId 가 아니라서 그것으로는 호출하지 않는다.
   executionId?: string;
+  // 실행 기록(체크인·태그)을 저장하는 중 — 아직 executionId 가 없지만 곧 온다.
+  // 데모 카드처럼 executionId 가 영영 오지 않는 경우와 구분하려고 부모가 내려준다.
+  preparing?: boolean;
   preparationError?: string | null;
   onOpenWeekly: () => void;
 }
 
-export function MergedRecoveryScreen({ task, failReason, onAccept, onDismiss, executionId, preparationError, onOpenWeekly }: MergedRecoveryScreenProps) {
+export function MergedRecoveryScreen({ task, failReason, onAccept, onDismiss, executionId, preparing = false, preparationError, onOpenWeekly }: MergedRecoveryScreenProps) {
   const [sel, setSel] = useState<string | null>(null);
   const [showWhy, setShowWhy] = useState<string | null>(null);
   const [accepted, setAccepted] = useState(false);
@@ -136,6 +141,18 @@ export function MergedRecoveryScreen({ task, failReason, onAccept, onDismiss, ex
   const needsAnchor = !!selectedProposal && REENGAGEMENT_GROUPS.has(selectedProposal.type);
 
   const renegotiating = usingRealProposals && recoveryMode === 'goal_renegotiation';
+
+  // 제안 카드가 아직 없는 두 가지 대기 상태를 하나로 묶는다.
+  //  (1) loadingProposals — LLM 호출이 도는 중. 수 초 걸린다.
+  //  (2) preparing && !executionId — 체크인·태그 저장을 기다리는 중. markFailed 가
+  //      화면 전환을 먼저 하고 저장을 뒤에 하므로 executionId 가 늦게 온다.
+  //  (3) executionId 는 왔는데 첫 응답이 아직 — loadProposals 는 effect 라 커밋
+  //      다음에 돌기 때문에, 이 칸이 없으면 그 사이 한 프레임이 빈 채로 지나간다.
+  // 셋 다 예전에는 아무 표시가 없어서 카드 자리가 그냥 빈 공간으로 남았다.
+  const waiting =
+    loadingProposals ||
+    (preparing && !executionId) ||
+    (!!executionId && !usingRealProposals && !proposalError);
 
   useEffect(() => {
     if (selectedProposal?.type === 'CARRY_OVER') {
@@ -317,10 +334,21 @@ export function MergedRecoveryScreen({ task, failReason, onAccept, onDismiss, ex
               : '끝까지 가지 못해도 괜찮아요. 다시 시작할 방법이 있어요.'}
           </p>
 
-          {!usingRealProposals && !proposalError && !preparationError && (
+          {/* 대기 안내는 DemoNotice 로 띄우지 않는다 — 그건 sessionStorage 로 한 번
+              닫으면 세션 내내 사라지는 배너라, 닫아둔 사용자에게는 카드 자리가 아무
+              설명 없는 빈 공간이 됐다. 기다리는 중이라는 사실은 닫히지 않아야 한다. */}
+          {waiting && !proposalError && !preparationError && (
+            <div style={{ marginBottom: 14, display: 'flex', alignItems: 'center', gap: 7, padding: '8px 10px', background: 'var(--sand-100)', border: '1px solid var(--sand-200)', borderRadius: 10, fontSize: 11, color: 'var(--text-2)', lineHeight: 1.5 }}>
+              <CircleNotch size={13} weight="bold" className="animate-spin-loader" style={{ flexShrink: 0 }} />
+              {executionId
+                ? '회복 제안을 준비하고 있어요. 잠시만 기다려 주세요.'
+                : '실행 기록을 저장하고 있어요. 저장이 끝나면 제안을 불러올게요.'}
+            </div>
+          )}
+          {!usingRealProposals && !waiting && !proposalError && !preparationError && (
             <div style={{ marginBottom: 14 }}>
               <DemoNotice storageKey="recovery-proposals">
-                {loadingProposals || executionId ? '회복 제안을 준비하고 있어요.' : '실행 결과를 저장한 뒤 회복 제안을 준비할게요.'}
+                이 카드에는 실행 기록이 없어 회복 제안을 불러오지 못했어요. 오늘 화면에서 카드를 시작한 뒤 다시 시도해 주세요.
               </DemoNotice>
             </div>
           )}
@@ -329,7 +357,7 @@ export function MergedRecoveryScreen({ task, failReason, onAccept, onDismiss, ex
               <ErrorBanner>{proposalError ?? preparationError}</ErrorBanner>
             </div>
           )}
-          {usingRealProposals && proposals.length === 0 && (
+          {usingRealProposals && !waiting && proposals.length === 0 && (
             <div style={{ marginBottom: 14 }}>
               <EmptyState>지금은 제안할 복구안이 없어요.</EmptyState>
             </div>
@@ -341,6 +369,9 @@ export function MergedRecoveryScreen({ task, failReason, onAccept, onDismiss, ex
           )}
 
           <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            {/* 기다리는 동안 카드 자리를 스켈레톤으로 잡아둔다. 비워 두면 위아래 문구만
+                남아 "제안이 없는 화면" 으로 읽힌다. */}
+            {waiting && proposals.length === 0 && <SkeletonBlock count={3} height={76} radius={14} />}
             {proposals.map((p, i) => (
               <RecoveryOptionCard
                 key={p.id}


### PR DESCRIPTION
## 증상

실행이 중단된 카드를 '잘 안됨' 으로 표시해 회복 화면으로 넘어가면, 제안 카드가 들어갈 자리가 아무것도 없는 빈 공간으로 남습니다. 위아래의 문구("오늘은 절반쯤 왔어요." / "실패는 데이터예요.")만 떠 있어서, 기다려야 하는 화면이 아니라 **제안이 없는 화면**으로 읽힙니다.

## 원인

회복 화면은 진입 직후 두 번 기다립니다. 두 구간 모두 표시가 없었습니다.

**① 실행 기록을 저장하는 구간.** `ReActionMerged.markFailed` 는 `setScreen('recovery')` 를 먼저 하고 체크인·태그 저장을 뒤에 겁니다(#269 의 순서 제약). 그래서 화면이 뜬 시점에는 `executionId` 가 아직 없고, `loadProposals` 는 `if (!executionId) return;` 으로 즉시 빠지면서 `loadingProposals` 조차 켜지 않습니다. 로딩 표시가 나올 자리 자체가 없었습니다.

**② LLM 제안을 생성하는 구간.** `POST /recovery/proposals/generate` 응답까지 수 초가 걸리는데, 제안 목록에 로딩 자리표시가 없어 그동안 카드 영역이 통째로 비었습니다.

**③ 안내가 닫히는 배너에 얹혀 있었습니다.** 그동안의 상태 문구를 `DemoNotice` 로 띄우고 있었는데, 이 컴포넌트는 `sessionStorage` 에 닫힘을 기억합니다(`DemoNotice.tsx:21`). 한 번 닫은 사용자에게는 설명조차 뜨지 않아 완전한 빈 화면이 됩니다. 의미상으로도 `DemoNotice` 는 "미리보기 데이터" 배너이지 로딩 안내가 아닙니다.

## 수정

- **`recoveryPreparing` 을 부모가 내려줍니다.** 저장을 기다리는 중인지, 아니면 데모 카드처럼 `executionId` 가 영영 오지 않는지를 화면이 구분할 수 있어야 합니다. 이 구분이 없으면 데모 카드에서 스켈레톤이 무한히 돕니다.
- **대기 안내를 닫히지 않는 문구로 분리했습니다.** 기다리는 중이라는 사실은 사용자가 닫을 수 있는 정보가 아닙니다. `DemoNotice` 는 실행 기록이 없는 경우의 안내로 되돌렸습니다.
- **카드 자리를 `SkeletonBlock` 으로 잡아둡니다.** 이 컴포넌트의 주석이 그대로 이 상황을 설명합니다 — 정적 빈 박스는 "로딩 중" 이 아니라 "데이터가 없는 빈 화면" 으로 읽힙니다.
- 대기 판정에 `executionId` 는 왔지만 첫 응답이 아직인 구간을 포함했습니다. `loadProposals` 는 effect 라 커밋 다음에 돌기 때문에, 이 칸이 없으면 그 사이 한 프레임이 빈 채로 지나갑니다.

## 검증

`src/screens/RecoveryScreen.test.tsx` 를 새로 추가했습니다 (5건).

- 실행 기록을 저장하는 동안 진행 안내가 뜬다
- 제안을 불러오는 동안에도 진행 안내를 유지한다
- 기다리는 동안 카드 자리를 스켈레톤으로 채운다
- **안내 배너를 닫아둔 세션에서도 대기 안내는 사라지지 않는다**
- 제안이 도착하면 대기 안내를 걷고 카드를 보여준다

고치기 전 코드에 이 테스트를 그대로 돌리면 1번과 4번이 실패합니다. 즉 두 건이 실제 회귀를 잡습니다.

- `npm test` — 19 passed (기존 14건 포함, 전부 통과)
- `npx tsc --noEmit` — 오류 없음
- `npx vite build` — 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M3Fh9uAbvP2DRsDMFngoS5
