### PR TITLE
fix(focus): 중단해도 회복으로 갈 길이 없었다

### DIFF
--- a/src/app/ReActionMerged.tsx
+++ b/src/app/ReActionMerged.tsx
@@ -158,11 +158,40 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
   const markDone = (id: string) =>
     setTasks((ts) => ts.map((t) => t.id === id ? { ...t, status: 'done' } : t));
 
-  const markPartial = (id: string, pct: number) =>
-    setTasks((ts) => ts.map((t) => t.id === id
-      ? { ...t, status: pct >= 100 ? 'done' : pct === 0 ? 'todo' : 'partial_done', progress: pct }
-      : t
-    ));
+  // 아직 실행이 없으면 먼저 start() 로 executionId 를 확보한다. 실패·부분완료가
+  // TodayScreen 시트에서 곧바로 올 수 있어서, FocusScreen 을 거치지 않은 액션도
+  // 있기 때문이다(#80 "실패 시 auto-start").
+  const ensureExecutionId = (id: string): Promise<string> => {
+    const existing = executionIds[id];
+    if (existing) return Promise.resolve(existing);
+    return todayApi.start(id).then((e) => {
+      setExecutionIds((m) => ({ ...m, [id]: e.executionId }));
+      return e.executionId;
+    });
+  };
+
+  const markPartial = (id: string, pct: number) => {
+    const status = pct >= 100 ? 'done' : pct === 0 ? 'todo' : 'partial_done';
+    setTasks((ts) => ts.map((t) => t.id === id ? { ...t, status, progress: pct } : t));
+    // 0% 는 "안 한 걸로 되돌린다" 라서 서버에 남길 결과가 없다.
+    if (status === 'todo') {
+      setRecoveryPreparing(false);
+      return;
+    }
+    // 예전엔 로컬 상태만 바꾸고 끝냈다. 그래서 '일부만' 은 서버에 아무것도 남지
+    // 않았고, 회복 제안 생성(failed/partial_done 실행만 받는다)이 거절됐다.
+    ensureExecutionId(id)
+      .then(async (execId) => {
+        await todayApi.checkIn({ executionId: execId, completionStatus: status }, `check-${execId}`);
+        setRecoveryReadyIds((m) => ({ ...m, [id]: execId }));
+      })
+      .catch(() => {
+        setRecoveryPreparationError('실행 결과를 저장하지 못했어요. 오늘 화면에서 다시 시도해 주세요.');
+      })
+      .finally(() => {
+        setRecoveryPreparing(false);
+      });
+  };
 
   const markFailed = (id: string, reason: string, tagCodes?: string[], memo?: string, taskAversiveness?: number) => {
     setTasks((ts) => ts.map((t) => t.id === id ? { ...t, status: 'failed', failReason: reason } : t));
@@ -173,19 +202,9 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
     setRecoveryPreparing(true);
     setScreen('recovery');
 
-    // 실패 경로는 TodayScreen 실패시트 → 여기로 직행해 FocusScreen 을 거치지 않을 수
-    // 있다 — 그런 미시작 액션은 먼저 start() 로 executionId 를 확보한다(#80 "실패 시 auto-start").
-    const existing = executionIds[id];
-    const ensureExecutionId = existing
-      ? Promise.resolve(existing)
-      : todayApi.start(id).then((e) => {
-          setExecutionIds((m) => ({ ...m, [id]: e.executionId }));
-          return e.executionId;
-        });
-
     // failure-tags와 recovery generate는 failed/partial_done 실행만 받으므로, 체크인을
     // 먼저 확정하고 태그 저장까지 끝난 뒤에만 회복 제안 생성을 허용한다(#269).
-    ensureExecutionId
+    ensureExecutionId(id)
       .then(async (execId) => {
         await todayApi.checkIn({ executionId: execId, completionStatus: 'failed' }, `check-${execId}`);
         if ((tagCodes && tagCodes.length > 0) || taskAversiveness != null || memo?.trim()) {
@@ -203,6 +222,24 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
       .finally(() => {
         setRecoveryPreparing(false);
       });
+  };
+
+  // 집중 화면의 [중단] 시트에서 결과를 고르고 나온 경우 — 회복으로 잇는다.
+  //
+  // 중단 자체는 여전히 판정이 아니다(단순 이탈은 handleExit 이 그대로 처리한다).
+  // 다만 결과를 남기고 멈추는 쪽을 고르면, 그 결과가 회복의 입력이 된다.
+  const stopFocusWithResult = (id: string, result: 'partial_done' | 'failed', progressPct: number) => {
+    if (result === 'failed') {
+      markFailed(id, '집중 중에 중단했어요');
+      return;
+    }
+    const t = tasks.find((x) => x.id === id);
+    setActiveTask(t ? { ...t, status: 'partial_done', progress: progressPct } : null);
+    setFailReason('');
+    setRecoveryPreparationError(null);
+    setRecoveryPreparing(true);
+    setScreen('recovery');
+    markPartial(id, progressPct);
   };
 
   // 실제 시작 트리거 — task 를 in_progress 로 전이하고 focus 화면으로.
@@ -225,8 +262,9 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
   const openRecovery = () => {
     const partial = tasks.find((t) => t.status === 'partial_done' || t.status === 'recovery_pending');
     setActiveTask(partial ?? null);
-    // 이 경로는 저장을 새로 걸지 않는다 — 이미 있는 executionId 로 바로 제안을 받는다.
-    setRecoveryPreparing(false);
+    // 이 경로는 저장을 새로 걸지 않는다. 다만 방금 '일부만' 을 누르고 바로 들어온
+    // 경우엔 체크인이 아직 돌고 있을 수 있어, 그때는 준비 중으로 보여준다.
+    setRecoveryPreparing(!!partial && !recoveryReadyIds[partial.id]);
     setScreen('recovery');
   };
 
@@ -345,6 +383,7 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
             onBack={() => { setScreen('today'); setActiveTask(null); }}
             onPause={() => setScreen('today')}
             onComplete={handleFocusComplete}
+            onStopWithResult={stopFocusWithResult}
             onExecutionStart={(taskId, execId) => setExecutionIds((m) => ({ ...m, [taskId]: execId }))}
           />
         )}
@@ -355,7 +394,9 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
             onAccept={acceptRecovery}
             onDismiss={() => setScreen('today')}
             executionId={activeTask
-              ? (activeTask.status === 'failed' ? recoveryReadyIds[activeTask.id] : executionIds[activeTask.id])
+              ? (activeTask.status === 'failed' || activeTask.status === 'partial_done'
+                  ? recoveryReadyIds[activeTask.id]
+                  : executionIds[activeTask.id])
               : undefined}
             preparing={recoveryPreparing}
             preparationError={recoveryPreparationError}

--- a/src/screens/FocusScreen.test.tsx
+++ b/src/screens/FocusScreen.test.tsx
@@ -24,8 +24,8 @@ const api = todayApi as unknown as {
   checkIn: ReturnType<typeof vi.fn>;
 };
 
-function view(onComplete = vi.fn(), onBack = vi.fn()) {
-  return render(<FocusScreen task={task} elapsedMin={0} totalMin={25} onPause={() => {}} onComplete={onComplete} onBack={onBack} />);
+function view(onComplete = vi.fn(), onBack = vi.fn(), onStopWithResult = vi.fn()) {
+  return render(<FocusScreen task={task} elapsedMin={0} totalMin={25} onPause={() => {}} onComplete={onComplete} onBack={onBack} onStopWithResult={onStopWithResult} />);
 }
 
 describe('FocusScreen execution contract', () => {
@@ -101,5 +101,47 @@ describe('FocusScreen execution contract', () => {
     await waitFor(() => expect(api.pause).toHaveBeenCalledWith('exec-1'));
     const saved = JSON.parse(sessionStorage.getItem('reaction.focus.task-1') ?? '{}');
     expect(saved.running).toBe(false);
+  });
+});
+
+// [중단] 은 결과 판정이 아니지만, 결과를 남기려고 멈추는 경우가 더 많다. 예전엔 둘을
+// 가르지 않고 무조건 오늘 화면으로 보내서 회복으로 갈 길이 아예 없었다.
+describe('FocusScreen 중단 시트', () => {
+  beforeEach(() => {
+    api.start.mockReset(); api.pause.mockReset(); api.resume.mockReset(); api.checkIn.mockReset();
+    api.start.mockResolvedValue({ executionId: 'exec-1' });
+    api.pause.mockResolvedValue({});
+  });
+
+  it('중단을 누르면 바로 나가지 않고 상태를 묻는다', async () => {
+    const onBack = vi.fn();
+    view(vi.fn(), onBack);
+    fireEvent.click(await screen.findByRole('button', { name: /중단/ }));
+    expect(screen.getByText('지금 어떤 상태인가요?')).toBeInTheDocument();
+    expect(onBack).not.toHaveBeenCalled();
+  });
+
+  it('잠시 멈추는 쪽은 결과를 남기지 않고 오늘 화면으로 돌아간다', async () => {
+    const onBack = vi.fn();
+    const onStop = vi.fn();
+    view(vi.fn(), onBack, onStop);
+    fireEvent.click(await screen.findByRole('button', { name: /중단/ }));
+    fireEvent.click(screen.getByRole('button', { name: /잠시 멈추고 나갈게요/ }));
+    expect(onBack).toHaveBeenCalledOnce();
+    expect(onStop).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['일부만 했어요', 'partial_done'],
+    ['잘 안됐어요', 'failed'],
+  ])('%s 를 고르면 결과를 실어 회복으로 넘긴다', async (label, expected) => {
+    const onBack = vi.fn();
+    const onStop = vi.fn();
+    view(vi.fn(), onBack, onStop);
+    fireEvent.click(await screen.findByRole('button', { name: /중단/ }));
+    fireEvent.click(screen.getByRole('button', { name: new RegExp(label) }));
+    expect(onStop).toHaveBeenCalledWith(task.id, expected, expect.any(Number));
+    // 결과를 남기는 쪽은 오늘 화면으로 빠지지 않는다 — 부모가 회복으로 보낸다.
+    expect(onBack).not.toHaveBeenCalled();
   });
 });

--- a/src/screens/FocusScreen.tsx
+++ b/src/screens/FocusScreen.tsx
@@ -15,12 +15,15 @@ interface FocusScreenProps {
   onPause: () => void;
   onComplete: () => void;
   onBack: () => void;
+  // 중단하면서 결과를 남길 때 — 회복 흐름으로 이어진다. progressPct 는 경과 시간
+  // 비율(0~99)이라 사용자가 진행률을 따로 입력하지 않아도 근거 있는 값이 남는다.
+  onStopWithResult: (taskId: string, result: 'partial_done' | 'failed', progressPct: number) => void;
   // 실 executionId 확보 시 컨트롤러로 리프트 — 실패→회복→수락 화면들이 이 값으로
   // reflectionApi.tagExecution/recoveryApi.generateProposals 등을 실호출한다(#80).
   onExecutionStart?: (taskId: string, executionId: string) => void;
 }
 
-export function FocusScreen({ task, elapsedMin, totalMin, onComplete, onBack, onExecutionStart }: FocusScreenProps) {
+export function FocusScreen({ task, elapsedMin, totalMin, onComplete, onBack, onStopWithResult, onExecutionStart }: FocusScreenProps) {
   type SyncState = 'pending' | 'synced' | 'retrying' | 'failed';
   const executionIdRef = useRef<string | null>(null);
   const queuedRunIntentRef = useRef<RunIntent | null>(null);
@@ -28,6 +31,10 @@ export function FocusScreen({ task, elapsedMin, totalMin, onComplete, onBack, on
   const [syncError, setSyncError] = React.useState<string | null>(null);
   const [failedMutation, setFailedMutation] = React.useState<'start' | 'run' | 'check-in' | null>(null);
   const [completing, setCompleting] = React.useState(false);
+  // [중단] 을 눌렀을 때 뜨는 시트. 중단은 결과 판정이 아니지만, 결과를 남기고 싶어서
+  // 멈추는 경우가 더 많다 — 예전엔 그 둘을 가르지 않고 무조건 오늘 화면으로 보내서
+  // 회복으로 갈 길이 없었다.
+  const [exitSheet, setExitSheet] = React.useState(false);
   const onExecutionStartRef = useRef(onExecutionStart);
   onExecutionStartRef.current = onExecutionStart;
 
@@ -296,6 +303,24 @@ export function FocusScreen({ task, elapsedMin, totalMin, onComplete, onBack, on
     onBack();
   };
 
+  // 결과를 남기고 나간다 — 타이머만 멈추고 판정은 부모가 서버에 기록한다.
+  // 여기서 checkIn 을 직접 부르지 않는 이유: 실패 태그·회복 제안까지 이어지는
+  // 순서(#269)를 markFailed 가 이미 쥐고 있어서, 두 곳에서 각자 보내면 어긋난다.
+  const stopWith = (result: 'partial_done' | 'failed') => {
+    if (!task) return;
+    if (running) {
+      pauseAtRef.current = Date.now();
+      setRunning(false);
+      runningRef.current = false;
+      persist({ running: false });
+    }
+    clearSession();
+    setExitSheet(false);
+    // 경과 시간 비율. 목표 시간을 넘겼어도 '일부만' 이므로 99 에서 멈춘다.
+    const spent = Math.min(99, Math.max(1, Math.round((elapsedSec / Math.max(1, totalMin * 60)) * 100)));
+    onStopWithResult(task.id, result, spent);
+  };
+
   const totalSec = Math.max(1, totalMin * 60);
   const pct = Math.min(elapsedSec / totalSec, 1);
   const mm = Math.floor(elapsedSec / 60);
@@ -352,13 +377,63 @@ export function FocusScreen({ task, elapsedMin, totalMin, onComplete, onBack, on
         <ReButton variant="ghost" size="lg" full onClick={toggleRun}>
           {running ? <><Pause size={16} /> 멈춤</> : <><Play size={16} weight="fill" /> 이어서</>}
         </ReButton>
-        <ReButton variant="ghost" size="lg" full onClick={handleExit}>
+        <ReButton variant="ghost" size="lg" full onClick={() => setExitSheet(true)}>
           <X size={16} /> 중단
         </ReButton>
         <ReButton variant="primary" size="lg" full onClick={() => void handleComplete()} disabled={completing || syncState === 'pending' || syncState === 'retrying'}>
           <Check size={16} /> {completing ? '저장 중…' : '완료'}
         </ReButton>
       </div>
+
+      {exitSheet && (
+        <div
+          onClick={() => setExitSheet(false)}
+          style={{ position: 'fixed', inset: 0, zIndex: 60, background: 'rgba(26,23,20,.45)', display: 'flex', alignItems: 'flex-end' }}
+        >
+          <div
+            role="dialog"
+            aria-label="중단하고 나가기"
+            onClick={(e) => e.stopPropagation()}
+            style={{ width: '100%', background: 'var(--surface-raised)', borderRadius: '24px 24px 0 0', padding: '22px 18px calc(22px + env(safe-area-inset-bottom, 0px))', display: 'flex', flexDirection: 'column', gap: 8 }}
+          >
+            <div style={{ fontWeight: 800, fontSize: 20, letterSpacing: '-0.01em' }}>지금 어떤 상태인가요?</div>
+            <p style={{ fontSize: 13, color: 'var(--text-2)', margin: '0 0 8px', lineHeight: 1.55 }}>
+              고른 대로 기록에 남아요. 잠시 멈추는 것이면 아무것도 기록되지 않아요.
+            </p>
+
+            <button
+              onClick={() => { setExitSheet(false); handleExit(); }}
+              style={{ minHeight: 52, borderRadius: 14, border: '1px solid var(--sand-200)', background: 'var(--surface-ground)', color: 'var(--text-1)', fontWeight: 700, fontSize: 14, fontFamily: 'inherit', cursor: 'pointer', textAlign: 'left', padding: '0 16px' }}
+            >
+              잠시 멈추고 나갈게요
+              <div style={{ fontSize: 11, fontWeight: 500, color: 'var(--text-3)', marginTop: 2 }}>타이머만 멈춰요. 오늘 화면에서 이어서 할 수 있어요.</div>
+            </button>
+
+            <button
+              onClick={() => stopWith('partial_done')}
+              style={{ minHeight: 52, borderRadius: 14, border: '1px solid var(--sand-200)', background: 'var(--surface-ground)', color: 'var(--text-1)', fontWeight: 700, fontSize: 14, fontFamily: 'inherit', cursor: 'pointer', textAlign: 'left', padding: '0 16px' }}
+            >
+              일부만 했어요
+              <div style={{ fontSize: 11, fontWeight: 500, color: 'var(--text-3)', marginTop: 2 }}>여기까지 한 만큼 남기고, 이어갈 방법을 받아요.</div>
+            </button>
+
+            <button
+              onClick={() => stopWith('failed')}
+              style={{ minHeight: 52, borderRadius: 14, border: '1px solid var(--coral-200)', background: 'var(--brand-soft)', color: 'var(--coral-700)', fontWeight: 700, fontSize: 14, fontFamily: 'inherit', cursor: 'pointer', textAlign: 'left', padding: '0 16px' }}
+            >
+              잘 안됐어요
+              <div style={{ fontSize: 11, fontWeight: 500, color: 'var(--coral-600)', marginTop: 2 }}>실패는 데이터예요. 바로 회복 제안을 받아요.</div>
+            </button>
+
+            <button
+              onClick={() => setExitSheet(false)}
+              style={{ marginTop: 4, minHeight: 44, border: 'none', background: 'none', color: 'var(--text-3)', fontSize: 13, fontFamily: 'inherit', cursor: 'pointer' }}
+            >
+              계속할게요
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## 증상

집중 화면에서 **[중단]** 을 눌러도 회복 화면으로 넘어가지 않습니다. 오늘 화면으로 나갈 뿐이고, 거기서 회복으로 들어갈 방법도 없습니다.

## 원인

중단이 오늘 화면으로 가는 것 자체는 설계대로입니다 — `FocusScreen.tsx` 의 주석대로 "뒤로가기/중단은 결과 판정이 아니다" 입니다. **문제는 나간 다음입니다. 결과를 남길 곳이 사라져 있었습니다.**

#309 가 "화면 이탈이 완료가 되는 것" 을 막으면서 히어로 카드의 세 버튼(완료 / 일부만 / 잘 안됨)을 통째로 지웠습니다. 그런데 문제였던 건 **[완료] 하나**이고, 함께 지워진 **[일부만] · [잘 안됨] 은 회복 흐름의 유일한 입구**였습니다.

남은 흔적이 이를 보여줍니다.

- `HeroTaskCard` 는 `onComplete` · `onPartial` · `onFail` 을 props 로 받지만 **구조 분해조차 하지 않아 절대 호출하지 않습니다**
- `TodayScreen` 의 `failSheet` · `partialSheet` 는 **열 방법이 없는 죽은 코드**가 됐습니다
- `TaskRow` 는 `failed` · `partial_done` 만 회복으로 보냅니다. 중단한 카드는 `in_progress` 라 눌러도 히어로로 올라갈 뿐입니다
- 정작 투어 도움말은 아직 "끝나면 완료·일부만·잘 안됨 중에 골라 기록해요" 라고 말합니다

## 수정

**[중단] 에 시트를 붙여 결과를 묻습니다.**

```
  ⏸ 멈춤   ✗ 중단   ✓ 완료
              │
              ▼
  ┌──────────────────────┐
  │ 지금 어떤 상태인가요?      │
  │  잠시 멈추고 나갈게요      │ → 오늘 화면 (종전과 동일)
  │  일부만 했어요           │ → 회복 화면
  │  잘 안됐어요            │ → 회복 화면
  └──────────────────────┘
```

중단이 곧 실패가 되지는 않습니다. 잠깐 자리를 비우는 경우는 종전대로 타이머만 멈추고 아무것도 기록하지 않습니다. #309 의 의도("단순 이탈이 판정이 되지 않게")를 그대로 지키면서, 결과를 남기고 싶은 쪽에만 길을 냈습니다.

진행률은 **경과 시간 비율**로 채웁니다. 사용자가 따로 입력하지 않아도 근거 있는 값이 남고, 목표 시간을 넘겼어도 '일부만' 이므로 99에서 멈춥니다.

### 함께 고친 것

`markPartial` 이 **로컬 상태만 바꾸고 서버에 아무것도 보내지 않고 있었습니다.** '일부만' 으로 기록해도 서버에는 여전히 `in_progress` 실행이라, 회복 제안 생성(`failed`/`partial_done` 실행만 받습니다)이 거절될 자리였습니다. 새 경로가 이 위에 올라타므로 함께 고쳤습니다.

`executionId` 확보 로직은 `markFailed` 안에 인라인으로 있던 것을 꺼내 두 경로가 함께 씁니다.

## 검증

`FocusScreen.test.tsx` 에 회귀 테스트 4건을 추가했습니다.

- 중단을 누르면 바로 나가지 않고 상태를 묻는다
- 잠시 멈추는 쪽은 결과를 남기지 않고 오늘 화면으로 돌아간다
- '일부만 했어요' 를 고르면 결과를 실어 회복으로 넘긴다
- '잘 안됐어요' 를 고르면 결과를 실어 회복으로 넘긴다

- `npm test` — 34 passed (전부 통과)
- `npx tsc --noEmit` — 오류 없음
- `npx vite build` — 성공

## 남은 것 (이 PR 범위 밖)

오늘 화면 쪽의 죽은 코드는 그대로 뒀습니다 — `HeroTaskCard` 의 호출되지 않는 세 prop, `TodayScreen` 의 열리지 않는 두 시트, 그리고 실제와 어긋난 투어 도움말 문구입니다. 이번 변경으로 회복 입구는 열렸지만, 집중 화면을 거치지 않고 오늘 화면에서 바로 '일부만'·'잘 안됨' 을 기록하던 경로는 아직 닫혀 있습니다. 되살릴지 정리할지는 별도로 정하는 편이 좋겠습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M3Fh9uAbvP2DRsDMFngoS5
