### PR TITLE
feat(focus): 집중 중단으로 실패를 남길 때 원인을 묻는다

### DIFF
--- a/src/app/ReActionMerged.tsx
+++ b/src/app/ReActionMerged.tsx
@@ -228,9 +228,25 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
   //
   // 중단 자체는 여전히 판정이 아니다(단순 이탈은 handleExit 이 그대로 처리한다).
   // 다만 결과를 남기고 멈추는 쪽을 고르면, 그 결과가 회복의 입력이 된다.
-  const stopFocusWithResult = (id: string, result: 'partial_done' | 'failed', progressPct: number) => {
+  const stopFocusWithResult = (
+    id: string,
+    result: 'partial_done' | 'failed',
+    progressPct: number,
+    failure?: { tagCodes: string[]; memo: string; taskAversiveness: number | null },
+  ) => {
     if (result === 'failed') {
-      markFailed(id, '집중 중에 중단했어요');
+      // ⚠️ **태그를 넘기는 게 이 경로의 실질이다.** 예전엔 '집중 중에 중단했어요' 라는
+      // 고정 문구만 남기고 태그를 안 보냈다. 그러면 백엔드
+      // `select_strategies(failure_tags, ...)` 가 매칭 0 으로 떨어져 패딩 규칙이 고른
+      // **일반 카드**가 나가고, 프롬프트 변수 `failure_type` 도 `UNKNOWN` 이 된다.
+      // 회복이 이 제품의 핵심인데 그 입력이 비어 있었다.
+      markFailed(
+        id,
+        failure?.memo?.trim() || '집중 중에 중단했어요',
+        failure?.tagCodes,
+        failure?.memo,
+        failure?.taskAversiveness ?? undefined,
+      );
       return;
     }
     const t = tasks.find((x) => x.id === id);

--- a/src/screens/FocusScreen.test.tsx
+++ b/src/screens/FocusScreen.test.tsx
@@ -131,17 +131,46 @@ describe('FocusScreen 중단 시트', () => {
     expect(onStop).not.toHaveBeenCalled();
   });
 
-  it.each([
-    ['일부만 했어요', 'partial_done'],
-    ['잘 안됐어요', 'failed'],
-  ])('%s 를 고르면 결과를 실어 회복으로 넘긴다', async (label, expected) => {
+  it('일부만 했어요 를 고르면 결과를 실어 회복으로 넘긴다', async () => {
     const onBack = vi.fn();
     const onStop = vi.fn();
     view(vi.fn(), onBack, onStop);
     fireEvent.click(await screen.findByRole('button', { name: /중단/ }));
-    fireEvent.click(screen.getByRole('button', { name: new RegExp(label) }));
-    expect(onStop).toHaveBeenCalledWith(task.id, expected, expect.any(Number));
+    fireEvent.click(screen.getByRole('button', { name: /일부만 했어요/ }));
+    expect(onStop).toHaveBeenCalledWith(task.id, 'partial_done', expect.any(Number), undefined);
     // 결과를 남기는 쪽은 오늘 화면으로 빠지지 않는다 — 부모가 회복으로 보낸다.
     expect(onBack).not.toHaveBeenCalled();
+  });
+
+  it('잘 안됐어요 는 바로 끝내지 않고 원인을 먼저 묻는다', async () => {
+    const onStop = vi.fn();
+    view(vi.fn(), vi.fn(), onStop);
+    fireEvent.click(await screen.findByRole('button', { name: /중단/ }));
+    fireEvent.click(screen.getByRole('button', { name: /잘 안됐어요/ }));
+
+    expect(screen.getByText('왜 끊겼을까요?')).toBeInTheDocument();
+    // ⚠️ 아직 넘기면 안 된다 — 태그 없이 넘어가면 회복 제안이 일반 카드로 나간다.
+    expect(onStop).not.toHaveBeenCalled();
+  });
+
+  it('원인을 고르면 태그를 실어 회복으로 넘긴다', async () => {
+    const onStop = vi.fn();
+    view(vi.fn(), vi.fn(), onStop);
+    fireEvent.click(await screen.findByRole('button', { name: /중단/ }));
+    fireEvent.click(screen.getByRole('button', { name: /잘 안됐어요/ }));
+
+    const submit = screen.getByRole('button', { name: /기록하고 복구안 보기/ });
+    // 하나도 안 고르면 못 넘어간다 — 빈 태그로 넘기면 고치려던 상태 그대로다.
+    expect(submit).toBeDisabled();
+
+    fireEvent.click(screen.getByRole('button', { name: /과대 과제/ }));
+    fireEvent.click(submit);
+
+    expect(onStop).toHaveBeenCalledWith(
+      task.id,
+      'failed',
+      expect.any(Number),
+      expect.objectContaining({ tagCodes: ['과대 과제'] }),
+    );
   });
 });

--- a/src/screens/FocusScreen.tsx
+++ b/src/screens/FocusScreen.tsx
@@ -1,6 +1,7 @@
 import React, { useRef } from 'react';
 import { CaretLeft, Pause, Play, Check, X } from '@phosphor-icons/react';
 import { Chip } from '../components/Chip';
+import { FailureTagPicker, useFailureTagCatalog, type FailureTagOption } from '../components/FailureTagPicker';
 import { ReButton } from '../components/ReButton';
 import { ApiError, friendlyError, todayApi } from '../lib/api';
 import { readFocusSession, removeFocusSession, writeFocusSession, type RunIntent } from '../lib/executionSync';
@@ -17,7 +18,17 @@ interface FocusScreenProps {
   onBack: () => void;
   // 중단하면서 결과를 남길 때 — 회복 흐름으로 이어진다. progressPct 는 경과 시간
   // 비율(0~99)이라 사용자가 진행률을 따로 입력하지 않아도 근거 있는 값이 남는다.
-  onStopWithResult: (taskId: string, result: 'partial_done' | 'failed', progressPct: number) => void;
+  //
+  // `failure` 는 '잘 안됐어요' 에서만 채워진다. **회복 제안 품질이 여기에 달려 있다** —
+  // 백엔드 `select_strategies(failure_tags, ...)` 가 태그로 전략을 고르고,
+  // `failure_type` 프롬프트 변수도 태그에서 온다. 안 넘기면 `UNKNOWN` 이 되어
+  // 패딩 규칙이 고른 **일반 카드**가 나간다.
+  onStopWithResult: (
+    taskId: string,
+    result: 'partial_done' | 'failed',
+    progressPct: number,
+    failure?: { tagCodes: string[]; memo: string; taskAversiveness: number | null },
+  ) => void;
   // 실 executionId 확보 시 컨트롤러로 리프트 — 실패→회복→수락 화면들이 이 값으로
   // reflectionApi.tagExecution/recoveryApi.generateProposals 등을 실호출한다(#80).
   onExecutionStart?: (taskId: string, executionId: string) => void;
@@ -35,6 +46,13 @@ export function FocusScreen({ task, elapsedMin, totalMin, onComplete, onBack, on
   // 멈추는 경우가 더 많다 — 예전엔 그 둘을 가르지 않고 무조건 오늘 화면으로 보내서
   // 회복으로 갈 길이 없었다.
   const [exitSheet, setExitSheet] = React.useState(false);
+  // '잘 안됐어요' 를 고른 뒤 원인을 묻는 2단계. 화면을 옮기지 않고 시트 내용만 갈아끼운다 —
+  // 실패 직후에 다른 화면으로 튕기면 그 자체가 벌처럼 읽힌다.
+  const [askingReason, setAskingReason] = React.useState(false);
+  const failReasons = useFailureTagCatalog();
+  const [failTags, setFailTags] = React.useState<FailureTagOption[]>([]);
+  const [failMemo, setFailMemo] = React.useState('');
+  const [taskAversiveness, setTaskAversiveness] = React.useState<number | null>(null);
   const onExecutionStartRef = useRef(onExecutionStart);
   onExecutionStartRef.current = onExecutionStart;
 
@@ -306,7 +324,10 @@ export function FocusScreen({ task, elapsedMin, totalMin, onComplete, onBack, on
   // 결과를 남기고 나간다 — 타이머만 멈추고 판정은 부모가 서버에 기록한다.
   // 여기서 checkIn 을 직접 부르지 않는 이유: 실패 태그·회복 제안까지 이어지는
   // 순서(#269)를 markFailed 가 이미 쥐고 있어서, 두 곳에서 각자 보내면 어긋난다.
-  const stopWith = (result: 'partial_done' | 'failed') => {
+  const stopWith = (
+    result: 'partial_done' | 'failed',
+    failure?: { tagCodes: string[]; memo: string; taskAversiveness: number | null },
+  ) => {
     if (!task) return;
     if (running) {
       pauseAtRef.current = Date.now();
@@ -316,9 +337,10 @@ export function FocusScreen({ task, elapsedMin, totalMin, onComplete, onBack, on
     }
     clearSession();
     setExitSheet(false);
+    setAskingReason(false);
     // 경과 시간 비율. 목표 시간을 넘겼어도 '일부만' 이므로 99 에서 멈춘다.
     const spent = Math.min(99, Math.max(1, Math.round((elapsedSec / Math.max(1, totalMin * 60)) * 100)));
-    onStopWithResult(task.id, result, spent);
+    onStopWithResult(task.id, result, spent, failure);
   };
 
   const totalSec = Math.max(1, totalMin * 60);
@@ -387,7 +409,7 @@ export function FocusScreen({ task, elapsedMin, totalMin, onComplete, onBack, on
 
       {exitSheet && (
         <div
-          onClick={() => setExitSheet(false)}
+          onClick={() => { setExitSheet(false); setAskingReason(false); }}
           style={{ position: 'fixed', inset: 0, zIndex: 60, background: 'rgba(26,23,20,.45)', display: 'flex', alignItems: 'flex-end' }}
         >
           <div
@@ -396,6 +418,45 @@ export function FocusScreen({ task, elapsedMin, totalMin, onComplete, onBack, on
             onClick={(e) => e.stopPropagation()}
             style={{ width: '100%', background: 'var(--surface-raised)', borderRadius: '24px 24px 0 0', padding: '22px 18px calc(22px + env(safe-area-inset-bottom, 0px))', display: 'flex', flexDirection: 'column', gap: 8 }}
           >
+            {askingReason ? (
+              <>
+                {/* 2단계 — 왜 끊겼는지. 오늘 화면의 실패 시트와 **같은 폼**을 쓴다.
+                    문구를 따로 쓰면 두 경로가 갈리고, 한쪽만 고쳐지는 날이 온다. */}
+                <div style={{ fontWeight: 800, fontSize: 20, letterSpacing: '-0.01em' }}>왜 끊겼을까요?</div>
+                <p style={{ fontSize: 13, color: 'var(--text-2)', margin: '0 0 12px', lineHeight: 1.55 }}>
+                  이유를 기록하면 더 잘 맞는 복구안을 제안해드려요.
+                </p>
+                <FailureTagPicker
+                  reasons={failReasons}
+                  selected={failTags}
+                  onChange={setFailTags}
+                  memo={failMemo}
+                  onMemoChange={setFailMemo}
+                  aversiveness={taskAversiveness}
+                  onAversivenessChange={setTaskAversiveness}
+                />
+                <button
+                  onClick={() =>
+                    stopWith('failed', {
+                      tagCodes: failTags.map((t) => t.code),
+                      memo: failMemo,
+                      taskAversiveness,
+                    })
+                  }
+                  disabled={failTags.length === 0}
+                  style={{ marginTop: 12, minHeight: 48, borderRadius: 14, border: 'none', background: 'var(--text-1)', color: '#FAF6EE', fontWeight: 700, fontSize: 14, fontFamily: 'inherit', cursor: failTags.length ? 'pointer' : 'not-allowed', opacity: failTags.length ? 1 : 0.35 }}
+                >
+                  기록하고 복구안 보기
+                </button>
+                <button
+                  onClick={() => setAskingReason(false)}
+                  style={{ marginTop: 4, minHeight: 44, border: 'none', background: 'none', color: 'var(--text-3)', fontSize: 13, fontFamily: 'inherit', cursor: 'pointer' }}
+                >
+                  뒤로
+                </button>
+              </>
+            ) : (
+              <>
             <div style={{ fontWeight: 800, fontSize: 20, letterSpacing: '-0.01em' }}>지금 어떤 상태인가요?</div>
             <p style={{ fontSize: 13, color: 'var(--text-2)', margin: '0 0 8px', lineHeight: 1.55 }}>
               고른 대로 기록에 남아요. 잠시 멈추는 것이면 아무것도 기록되지 않아요.
@@ -418,11 +479,11 @@ export function FocusScreen({ task, elapsedMin, totalMin, onComplete, onBack, on
             </button>
 
             <button
-              onClick={() => stopWith('failed')}
+              onClick={() => setAskingReason(true)}
               style={{ minHeight: 52, borderRadius: 14, border: '1px solid var(--coral-200)', background: 'var(--brand-soft)', color: 'var(--coral-700)', fontWeight: 700, fontSize: 14, fontFamily: 'inherit', cursor: 'pointer', textAlign: 'left', padding: '0 16px' }}
             >
               잘 안됐어요
-              <div style={{ fontSize: 11, fontWeight: 500, color: 'var(--coral-600)', marginTop: 2 }}>실패는 데이터예요. 바로 회복 제안을 받아요.</div>
+              <div style={{ fontSize: 11, fontWeight: 500, color: 'var(--coral-600)', marginTop: 2 }}>왜 끊겼는지 한 번만 고르면, 그에 맞는 회복안을 받아요.</div>
             </button>
 
             <button
@@ -431,6 +492,8 @@ export function FocusScreen({ task, elapsedMin, totalMin, onComplete, onBack, on
             >
               계속할게요
             </button>
+              </>
+            )}
           </div>
         </div>
       )}


### PR DESCRIPTION
시연영상 콘티 검증 중 발견했습니다. Focus → **중단** → "잘 안됐어요" 를 누르면 **원인을 묻지 않고 곧장 회복 제안으로** 넘어갔습니다. 실측에서 `recovery_attempts.trigger_tag` 가 비어 있었습니다.

## 촬영 편의가 아니라 회복 품질 문제입니다

백엔드가 실패 태그를 이렇게 씁니다:

```python
select_strategies(failure_tags, strategies, ...)      # 어떤 회복 전략을 낼지
"failure_type": ", ".join(failure_tags) or "UNKNOWN"  # 프롬프트 변수
use_v3 = "AVOIDANCE" in failure_tags                  # 어떤 프롬프트를 쓸지
trigger_tag=first_matching_tag(failure_tags, s)       # 저장값
# + 같은 태그 이력 → 에스컬레이션 레벨
```

태그가 없으면 매칭 0 → 패딩 규칙(`select_strategies` 규칙 4)이 고른 **일반 카드**가 나갑니다. 회복이 이 제품의 핵심인데 그 입력이 비어 있었습니다.

**실측 비교** (같은 사용자, 같은 계획):

| | 첫 제안 |
|---|---|
| 태그 없음 (예전) | "5분 단위로 쪼개기 — 딱 5분만, 첫 단계만 해볼까요?" |
| `PLAN_TOO_BIG` (지금) | "범위 줄여서 진행 — **만약 계획이 너무 컸다면**, 학술 어휘 30개 중 **15개만** 골라 가볍게 정리해요" |

## 무엇을 했나

중단 시트를 2단계로 나눴습니다. "잘 안됐어요" → **"왜 끊겼을까요?"** → 오늘 화면의 실패 시트와 **같은 `FailureTagPicker`** 를 띄웁니다. 문구를 따로 쓰면 두 경로가 갈리고 한쪽만 고쳐지는 날이 옵니다.

화면을 옮기지 않고 **시트 내용만 갈아끼웁니다** — 실패 직후에 다른 화면으로 튕기면 그 자체가 벌처럼 읽힙니다.

`markFailed` 는 원래부터 `tagCodes`·`memo`·`taskAversiveness` 를 받아 `reflectionApi.tagExecution` 으로 보냅니다. **Focus 경로만 안 넘기고 있었습니다** — `stopFocusWithResult` 가 `'집중 중에 중단했어요'` 라는 고정 문구만 남겼습니다. 그 배관에 값을 흘려보냈을 뿐 새 API 는 없습니다.

"잘 안됐어요" 부제도 사실에 맞췄습니다 — *"바로 회복 제안을 받아요"* → *"왜 끊겼는지 한 번만 고르면, 그에 맞는 회복안을 받아요"*.

## 검증

브라우저에서 끝까지 갔습니다: 중단 → 잘 안됐어요 → "계획이 너무 컸어요" + 혐오도 4 → `execution_failure_tags.tag_code = PLAN_TOO_BIG` · `task_aversiveness = 4` 저장 확인 → 위 표의 맞춤 제안 도달. 회복 LLM 도 실제로 돌았습니다.

| 변이 | 결과 |
|---|---|
| 원인 단계 건너뛰고 즉시 종료 | 2건 실패 |
| 태그를 안 실어 보냄 | 1건 실패 |
| 빈 선택도 제출 가능 | 1건 실패 |

`35 passed` (vitest) · tsc 통과.

## 콘티

이 변경으로 **SCENE 09(실패 원인 기록, 00:49–00:57)** 가 Focus 동선에서 그대로 찍힙니다. 콘티가 지목한 네 사유(계획이 너무 컸어요 / 시작이 어려웠어요 / 시간이 부족했어요 / 피곤했어요)가 카탈로그에 전부 있습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUh7fbbySTi5QKUGkGomQJ
