### PR TITLE
fix(recovery): 회복 화면에 다시 들어가도 가짜 실패를 만들지 않는다

### DIFF
--- a/src/app/ReActionMerged.tsx
+++ b/src/app/ReActionMerged.tsx
@@ -25,7 +25,7 @@ import { EveningCheckInScreen } from '../screens/EveningCheckInScreen';
 import { WeeklyCalendarScreenV2 } from '../screens/WeeklyCalendarScreen';
 import { WeeklyReviewScreenV2 } from '../screens/WeeklyReviewScreen';
 import { useNavigation } from '../contexts/NavigationContext';
-import { reflectionApi, todayApi } from '../lib/api';
+import { ApiError, reflectionApi, todayApi } from '../lib/api';
 import type { RecoveryProposal, ScreenId, TabId, Task } from '../types';
 import type { InterviewOutcome } from '../types/api';
 import { readInterviewOutcome, writeInterviewOutcome } from '../lib/interviewOutcomeStore';
@@ -164,6 +164,16 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
   const ensureExecutionId = (id: string): Promise<string> => {
     const existing = executionIds[id];
     if (existing) return Promise.resolve(existing);
+    // ⚠️ **서버가 아는 실행을 먼저 쓴다.** 예전엔 이 메모리 맵만 보고 없으면 곧장
+    // `todayApi.start(id)` 를 불렀다. 새로고침하면 맵이 비므로, **이미 실패한 카드의**
+    // 회복 화면에 다시 들어갈 때마다 새 실행이 만들어지고 바로 failed 로 체크인됐다 —
+    // 실측: 실제로는 두 번 실패한 카드에 실행 4건이 쌓였다. 그 가짜 실패가 주간 리뷰
+    // 준수율과 회복 에스컬레이션 레벨을 함께 밀어 올린다.
+    const known = tasks.find((t) => t.id === id)?.executionId;
+    if (known) {
+      setExecutionIds((m) => ({ ...m, [id]: known }));
+      return Promise.resolve(known);
+    }
     return todayApi.start(id).then((e) => {
       setExecutionIds((m) => ({ ...m, [id]: e.executionId }));
       return e.executionId;
@@ -206,7 +216,23 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
     // 먼저 확정하고 태그 저장까지 끝난 뒤에만 회복 제안 생성을 허용한다(#269).
     ensureExecutionId(id)
       .then(async (execId) => {
-        await todayApi.checkIn({ executionId: execId, completionStatus: 'failed' }, `check-${execId}`);
+        // ⚠️ **이미 체크인된 실행이면 성공으로 친다.**
+        //
+        // 오늘 실행 기록의 실패 행을 다시 누르면(`onFailedRecover`) 이 함수가 통째로
+        // 다시 돈다 — 회복 화면으로 돌아가려는 것뿐인데 체크인까지 재전송된다.
+        // 백엔드는 `completion_status != 'in_progress'` 면 409(TODAY_ALREADY_CHECKED_IN)
+        // 를 내므로, 그대로 두면 회복 화면에 "실행 결과를 저장하지 못했어요" 라는
+        // **거짓 오류**가 뜬다. 저장은 이미 끝나 있었다.
+        //
+        // 409 를 삼키는 게 맞는 이유: 이 호출의 목적은 "이 실행을 failed 로 만든다" 이고,
+        // 409 는 **그 상태가 이미 참**이라는 뜻이다. 원하는 결과가 이미 성립했으므로
+        // 실패가 아니다. (`check-${execId}` 키는 무의미하다 — `/today/check-ins` 는
+        // 멱등 라우트 목록에 없어서 미들웨어가 재생하지 않는다.)
+        try {
+          await todayApi.checkIn({ executionId: execId, completionStatus: 'failed' }, `check-${execId}`);
+        } catch (err) {
+          if (!(err instanceof ApiError && err.code === 'TODAY_ALREADY_CHECKED_IN')) throw err;
+        }
         if ((tagCodes && tagCodes.length > 0) || taskAversiveness != null || memo?.trim()) {
           await reflectionApi.tagExecution(execId, {
             tagCodes: tagCodes ?? [],

--- a/src/screens/TodayScreen.tsx
+++ b/src/screens/TodayScreen.tsx
@@ -150,6 +150,7 @@ function actionToTask(a: AgendaCard): Task {
     firstStep: a.firstStep ?? undefined,
     priority: a.priority,
     cancellable: a.cancellable,
+    executionId: a.executionId ?? undefined,
   };
 }
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -655,6 +655,9 @@ export interface AgendaCard {
   // 이 카드를 취소할 수 있는가(BE 파생 필드). 판정 규칙(실행 이력·source·status)은
   // BE 안에만 두고 FE 는 이 값만 본다 — 규칙을 복제하면 조용히 어긋난다.
   cancellable: boolean;
+  // 이 카드의 가장 최근 실행 id (없으면 null). 실패한 카드의 회복 화면에 다시 들어갈 때
+  // 이 값을 쓴다 — 없으면 FE 가 새 실행을 만들어 **가짜 실패 기록**이 늘어난다.
+  executionId: string | null;
 }
 
 // /today/agenda 안의 고정 일정 행. 관리 화면의 FixedSchedule 과 다른 스키마다 —

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -61,6 +61,8 @@ export interface Task {
   priority?: number;
   // 취소 가능 여부(백엔드 판정). 취소 UI 노출에만 쓴다.
   cancellable?: boolean;
+  // 백엔드 AgendaCard.executionId — 이 카드의 가장 최근 실행. 회복 재진입에 쓴다.
+  executionId?: string;
 }
 
 export interface Goal {


### PR DESCRIPTION
> 백엔드 [#459](https://github.com/hanium-reaction/reaction-backend/pull/459) 과 한 쌍입니다. 그 PR 이 `AgendaCard.executionId` 를 내려주고, 이 PR 이 그걸 씁니다.

사용자가 *"회복이 여전히 안 된다"* 고 해서 브라우저로 다시 눌러 보다 찾았습니다.

## 증상

실패한 카드의 회복 화면에 **다시 들어갈 때마다 실행 기록이 하나씩 늘었습니다.** 실측 — 실제로는 두 번 실패한 카드에 `execution_events` 4건, 전부 failed. 그리고 빨간 배너: **"실행 결과를 저장하지 못했어요."**

## 원인 둘

**① `ensureExecutionId` 가 메모리 맵만 봤다**

새로고침하면 비므로 `todayApi.start(id)` 로 **새 실행을 만들고** 곧바로 failed 로 체크인했습니다. 이제 어젠다가 내려주는 `executionId` 를 먼저 씁니다.

**② 이미 체크인된 실행에 체크인을 또 보냈다**

오늘 실행 기록의 실패 행을 누르면(`onFailedRecover`) `markFailed` 가 통째로 다시 돕니다 — 회복 화면으로 돌아가려는 것뿐인데 체크인까지 재전송됩니다. 백엔드는 `completion_status != 'in_progress'` 면 409(`TODAY_ALREADY_CHECKED_IN`) 를 냅니다.

409 를 삼키는 게 맞는 이유: 이 호출의 목적은 *"이 실행을 failed 로 만든다"* 이고, 409 는 **그 상태가 이미 참**이라는 뜻입니다. 원하는 결과가 이미 성립했으므로 실패가 아닙니다. (`check-${execId}` 키는 무의미했습니다 — `/today/check-ins` 는 멱등 라우트 목록에 없습니다.)

## 왜 심각한가

가짜 실패가 지표를 직접 오염시킵니다 — 주간 리뷰 준수율·평균 지연의 분모, 그리고 회복 에스컬레이션(`same_card_failures`). 실측에서 두 번 실패한 사용자가 **L3 재협상**까지 올라갔고, L3 는 LLM 개인화를 끄므로 맞춤 제안이 사라지고 "오프라인 모드" 안내까지 떴습니다.

> **회복 화면을 다시 열어 본 것만으로 사용자가 더 못하는 사람으로 기록됐습니다.**

## 검증

브라우저 실측 — 회복 화면에 두 번 더 재진입(새로고침 포함):

```
기준선 4 · 4  →  재진입 후 4 · 4          가짜 실패 0
POST /today/check-ins             409     ← 이미 종료된 실행. 관용 처리로 배너 없음
POST /recovery/proposals/generate 201     ← 제안 정상
```

`35 passed` (vitest) · tsc 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUh7fbbySTi5QKUGkGomQJ
