### PR TITLE
feat(review): 지연 시간을 분·시간·일로 읽히게 쓴다

### DIFF
--- a/src/lib/dates.test.ts
+++ b/src/lib/dates.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { formatDurationMinutes } from './dates';
+
+// 주간 리뷰가 평균 지연을 `분` 으로만 찍어서 "평균 지연 5996분" 이 화면에 그대로 나왔다.
+// 100시간을 분으로 적으면 크다는 것 말고는 아무것도 안 읽힌다 — 자릿수를 세게 만든다.
+describe('formatDurationMinutes', () => {
+  it('한 시간 미만은 분으로', () => {
+    expect(formatDurationMinutes(0)).toBe('0분');
+    expect(formatDurationMinutes(38)).toBe('38분');
+    expect(formatDurationMinutes(59)).toBe('59분');
+    expect(formatDurationMinutes(59.4)).toBe('59분');
+  });
+
+  it('한 시간부터는 시간으로 — 딱 떨어지면 분을 생략한다', () => {
+    expect(formatDurationMinutes(60)).toBe('1시간');
+    expect(formatDurationMinutes(120)).toBe('2시간');
+    expect(formatDurationMinutes(150)).toBe('2시간 30분');
+  });
+
+  it('하루부터는 일로 — 딱 떨어지면 시간을 생략한다', () => {
+    expect(formatDurationMinutes(60 * 24)).toBe('1일');
+    expect(formatDurationMinutes(60 * 27)).toBe('1일 3시간');
+    // 실제로 화면에 나왔던 값. "5996분" 이 아니라 "4일 4시간" 으로 읽힌다.
+    expect(formatDurationMinutes(5996)).toBe('4일 4시간');
+  });
+
+  it('⚠️ 반올림이 자리올림을 만들지 않는다', () => {
+    // 큰 단위부터 정수로 떼고 나머지를 반올림하지 않으면 "1시간 60분" 이 나온다.
+    expect(formatDurationMinutes(119.6)).toBe('2시간');
+    expect(formatDurationMinutes(60 * 24 - 0.4)).toBe('1일');
+  });
+
+  it('음수는 부호를 밖으로 뺀다 — 계획보다 일찍 시작하면 지연이 음수다', () => {
+    expect(formatDurationMinutes(-12)).toBe('-12분');
+    expect(formatDurationMinutes(-150)).toBe('-2시간 30분');
+  });
+
+  it('값이 없거나 이상하면 지어내지 않는다', () => {
+    expect(formatDurationMinutes(Number.NaN)).toBe('-');
+    expect(formatDurationMinutes(Number.POSITIVE_INFINITY)).toBe('-');
+  });
+});

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -33,3 +33,38 @@ export function defaultCarryOverAnchorDate(d: Date = new Date()): string {
   return localDateStr(tomorrow);
 }
 export const DEFAULT_REENGAGEMENT_TIME = '09:00';
+
+
+// 분 단위 소요/지연을 사람이 읽는 단위로. 60분을 넘으면 시간, 하루를 넘으면 일.
+//
+// ⚠️ **왜 필요한가.** 주간 리뷰가 평균 지연을 `분` 으로만 찍어서, 계획 시각이 한참 지난
+// 카드를 나중에 시작하면 "평균 지연 5996분" 같은 값이 화면에 그대로 나왔다. 100시간을
+// 분으로 적으면 크다는 것 말고는 아무것도 안 읽힌다 — 자릿수를 세게 만드는 숫자다.
+//
+// 규칙:
+//   60분 미만        → "38분"
+//   24시간 미만      → "2시간" · "2시간 30분"   (분이 0이면 생략)
+//   그 이상          → "4일" · "4일 3시간"      (시간이 0이면 생략)
+//
+// 반올림은 **마지막 자리에서만** 한다 — "1시간 60분" 같은 값이 나오지 않게 큰 단위부터
+// 정수로 떼고 나머지를 반올림한다. 음수는 부호를 밖으로 빼서 "-2시간" 으로 읽히게 한다
+// (지연이 음수면 계획보다 일찍 시작했다는 뜻이라 실제로 나온다).
+export function formatDurationMinutes(minutes: number): string {
+  if (!Number.isFinite(minutes)) return '-';
+  const sign = minutes < 0 ? '-' : '';
+  const total = Math.abs(minutes);
+
+  if (total < 60) return `${sign}${Math.round(total)}분`;
+
+  const totalMinutes = Math.round(total);
+  if (totalMinutes < 60 * 24) {
+    const h = Math.floor(totalMinutes / 60);
+    const m = totalMinutes % 60;
+    return m === 0 ? `${sign}${h}시간` : `${sign}${h}시간 ${m}분`;
+  }
+
+  const totalHours = Math.round(totalMinutes / 60);
+  const d = Math.floor(totalHours / 24);
+  const h = totalHours % 24;
+  return h === 0 ? `${sign}${d}일` : `${sign}${d}일 ${h}시간`;
+}

--- a/src/screens/WeeklyReviewScreen.tsx
+++ b/src/screens/WeeklyReviewScreen.tsx
@@ -3,7 +3,7 @@ import { SectionHeader } from '../components/SectionHeader';
 import React, { useEffect, useState } from 'react';
 import { Sparkle, ArrowRight } from '@phosphor-icons/react';
 import { friendlyError, goalsApi, reviewsApi } from '../lib/api';
-import { localDateStr } from '../lib/dates';
+import { formatDurationMinutes, localDateStr } from '../lib/dates';
 import { DemoNotice } from '../components/DemoNotice';
 import { useNavigation } from '../contexts/NavigationContext';
 import type { WeeklyReviewResponse, HabitPenaltyCandidate, MandalaWeeklySummary, NextCycleProposal, StaleAxisProposal } from '../types/api';
@@ -275,7 +275,7 @@ export function WeeklyReviewScreenV2() {
         {(real?.consistencyDays != null || real?.avgDelayMinutes != null || real?.repeatedFailureCount != null) && (
           <div style={{ background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', borderRadius: 14, padding: '10px 14px', fontSize: 12, color: 'var(--text-2)', display: 'flex', gap: 14, flexWrap: 'wrap' }}>
             {real?.consistencyDays != null && <span><b className="tnum" style={{ color: 'var(--text-1)' }}>{real.consistencyDays}일</b> 연속 실행</span>}
-            {real?.avgDelayMinutes != null && <span>평균 지연 <b className="tnum" style={{ color: 'var(--text-1)' }}>{Math.round(real.avgDelayMinutes)}분</b></span>}
+            {real?.avgDelayMinutes != null && <span>평균 지연 <b className="tnum" style={{ color: 'var(--text-1)' }}>{formatDurationMinutes(real.avgDelayMinutes)}</b></span>}
             {real?.repeatedFailureCount != null && <span>반복 실패 <b className="tnum" style={{ color: 'var(--text-1)' }}>{real.repeatedFailureCount}회</b></span>}
           </div>
         )}


### PR DESCRIPTION
주간 리뷰가 평균 지연을 `분` 으로만 찍었습니다. 계획 시각이 한참 지난 카드를 나중에 시작하면 이런 값이 화면에 그대로 나옵니다:

> 평균 지연 **5996분**

100시간을 분으로 적으면 **크다는 것 말고는 아무것도 안 읽힙니다** — 자릿수를 세게 만드는 숫자입니다. 시연영상 SCENE 14가 이 화면이라 숫자 하나가 신뢰를 깎습니다.

## 규칙

```
60분 미만    →  "38분"
24시간 미만  →  "2시간"  ·  "2시간 30분"     (분이 0이면 생략)
그 이상      →  "4일"    ·  "4일 3시간"      (시간이 0이면 생략)
```

위 값은 이제 **"4일 4시간"** 으로 읽힙니다.

## 두 가지를 조심했습니다

**반올림이 자리올림을 만들지 않게** — 큰 단위부터 정수로 떼고 나머지를 반올림합니다. `Math.round(minutes/60)` 로 시간을 구하면 119.6분이 "2시간"이 아니라 **"1시간 60분"** 이 됩니다.

**음수는 부호를 밖으로** — 계획보다 일찍 시작하면 지연이 음수입니다(실측: `-3778`). 부호를 단위 안에 두면 "-2시간 -30분" 같은 게 나옵니다. `-2시간 30분` 으로 읽히게 했습니다.

`NaN`/`Infinity` 는 `'-'` 로 냅니다 — 없는 값을 `0` 으로 적으면 "지연 없음" 이라는 **거짓**이 됩니다.

## 검증

| 변이 | 결과 |
|---|---|
| 시간 단위 없이 분으로만 | 4건 실패 |
| 일 단위 없이 시간까지만 | 2건 실패 |
| 큰 단위부터 안 떼고 반올림 | 2건 실패 |

`41 passed` (vitest) · tsc 통과. 브라우저 실측 — 데모 계정 주간 리뷰가 **"평균 지연 19분"** 으로 정상 표시.

## 범위

`avgDelayMinutes` 렌더 한 곳만 바꿨습니다. 다른 분 단위 표시(세션 길이 등)는 대부분 60분 이하라 지금 형태가 자연스러워 손대지 않았습니다 — 필요해지면 같은 함수를 쓰면 됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUh7fbbySTi5QKUGkGomQJ
