### PR TITLE
fix(recovery): 복구코치 재진입 및 회복 선택별 완료 흐름 수정

### DIFF
--- a/src/app/ReActionMerged.tsx
+++ b/src/app/ReActionMerged.tsx
@@ -19,6 +19,7 @@ import { MyInfoScreen } from '../screens/MyInfoScreen';
 import { MergedTodayScreen } from '../screens/TodayScreen';
 import { FocusScreen } from '../screens/FocusScreen';
 import { MergedRecoveryScreen } from '../screens/RecoveryScreen';
+import { resolveRecoveryEntry } from '../lib/recoveryEntry';
 import { RecoveredScreen, type AppliedRecovery } from '../screens/RecoveredScreen';
 import { WeeklySwitch } from '../components/WeeklySwitch';
 import { EveningCheckInScreen } from '../screens/EveningCheckInScreen';
@@ -301,19 +302,20 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
     setScreen('focus');
   };
 
-  const openRecovery = () => {
-    const partial = tasks.find((t) => t.status === 'partial_done' || t.status === 'recovery_pending');
-    setActiveTask(partial ?? null);
-    // 이 경로는 저장을 새로 걸지 않는다. 다만 방금 '일부만' 을 누르고 바로 들어온
-    // 경우엔 체크인이 아직 돌고 있을 수 있어, 그때는 준비 중으로 보여준다.
-    setRecoveryPreparing(!!partial && !recoveryReadyIds[partial.id]);
+  const openRecovery = (id?: string) => {
+    const { task: target, executionId: execId } = resolveRecoveryEntry(tasks, recoveryReadyIds, executionIds, id);
+    setActiveTask(target ?? null);
+    setFailReason(target?.failReason ?? '');
+    setRecoveryPreparationError(target && !execId ? '실행 기록을 찾지 못했어요. 오늘 화면을 새로고침한 뒤 다시 시도해 주세요.' : null);
+    setRecoveryPreparing(false);
+    if (target && execId) setRecoveryReadyIds((m) => ({ ...m, [target.id]: execId }));
     setScreen('recovery');
   };
 
   // RecoveryScreen 에서 고른 실제(또는 데모) 제안 객체를 그대로 받아 before→after 를 구성한다.
   // (예전엔 optionId 만 받아 더미 데이터에서 재조회했었다 — 실 회복 카드의
   // 제목/설명이 더미로 가려지던 문제 #80)
-  const acceptRecovery = (proposal: RecoveryProposal) => {
+  const acceptRecovery = (proposal: RecoveryProposal, requiresReplan = true) => {
     setRecoveryCount((c) => c + 1);
     if (activeTask) {
       setAppliedRecovery({
@@ -322,6 +324,8 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
         proposalTitle: proposal.title,
         proposalDesc: proposal.desc,
         proposalTime: proposal.time ?? '',
+        requiresReplan,
+        proposalType: proposal.type,
       });
       // 회복안 수락은 원 행동의 완료가 아니다. 실패/부분완료 상태는 그대로 보존하고,
       // 승인된 회복안은 appliedRecovery(및 서버 resulting action)로 별도 표현한다(#283).
@@ -438,7 +442,7 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
             executionId={activeTask
               ? (activeTask.status === 'failed' || activeTask.status === 'partial_done'
                   ? recoveryReadyIds[activeTask.id]
-                  : executionIds[activeTask.id])
+                  : recoveryReadyIds[activeTask.id] ?? executionIds[activeTask.id])
               : undefined}
             preparing={recoveryPreparing}
             preparationError={recoveryPreparationError}
@@ -449,6 +453,7 @@ export function ReActionMerged({ hideTabs = false }: ReActionMergedProps) {
           <RecoveredScreen
             recoveryCount={recoveryCount}
             applied={appliedRecovery}
+            onOpenWeekly={() => { setWeekOffset(0); setTab('weekly'); setScreen('weekly'); }}
             onDone={() => { setTab('today'); setScreen('today'); setAppliedRecovery(null); }}
             executionId={activeTask
               ? (recoveryReadyIds[activeTask.id] ?? executionIds[activeTask.id])

--- a/src/components/HeroTaskCard.tsx
+++ b/src/components/HeroTaskCard.tsx
@@ -49,6 +49,7 @@ export function HeroTaskCard({
   goalLabel,
   goalColor,
   onStart,
+  onFail,
   startDisabled = false,
   startLabel = '시작하기',
   onDetail,
@@ -216,6 +217,11 @@ export function HeroTaskCard({
           }}
         >
           {startLabel} {!startDisabled && <CaretRight size={14} />}
+        </button>
+      )}
+      {!startDisabled && (
+        <button onClick={onFail} style={{ minHeight: 44, width: '100%', border: '1px solid var(--coral-200)', borderRadius: 12, background: 'var(--brand-soft)', color: 'var(--brand-ink)', fontFamily: 'inherit', cursor: 'pointer' }}>
+          잘 안됐나요? 복구 코치
         </button>
       )}
     </div>

--- a/src/components/TodayTimeline.tsx
+++ b/src/components/TodayTimeline.tsx
@@ -17,7 +17,7 @@ interface TodayTimelineProps {
   interactive?: boolean;
   onSelect: (id: string) => void;
   onFailedRecover: (id: string, reason: string) => void;
-  onPartialRecover: () => void;
+  onPartialRecover: (id: string) => void;
 }
 
 function statusColor(task: Task): string {
@@ -55,7 +55,7 @@ export function TodayTimeline({ items, title = '오늘의 타임라인', orderLa
                 <TaskRow task={task} time={shownTime} dur={dur} goalLabel={goalLabel} goalColor={goalColor} hideTime interactive={interactive}
                   onSelect={() => onSelect(task.id)}
                   onFailedRecover={() => onFailedRecover(task.id, task.failReason || '')}
-                  onPartialRecover={onPartialRecover}
+                  onPartialRecover={() => onPartialRecover(task.id)}
                 />
               </div>
             </div>

--- a/src/lib/recoveryEntry.test.ts
+++ b/src/lib/recoveryEntry.test.ts
@@ -1,0 +1,18 @@
+import { expect, it } from 'vitest';
+import { resolveRecoveryEntry } from './recoveryEntry';
+import type { Task } from '../types';
+
+const tasks: Task[] = [
+  { id: 'a', title: '첫 번째', status: 'partial_done', executionId: 'exec-a' },
+  { id: 'b', title: '두 번째', status: 'partial_done', executionId: 'exec-b' },
+];
+it('새로고침으로 메모리가 비어도 선택한 두 번째 기록의 서버 실행을 사용한다', () => {
+  expect(resolveRecoveryEntry(tasks, {}, {}, 'b')).toEqual({ task: tasks[1], executionId: 'exec-b' });
+});
+it('실패만 있는 경우에도 복구 대상을 찾는다', () => {
+  const failed: Task = { ...tasks[0], status: 'failed' };
+  expect(resolveRecoveryEntry([failed], {}, {}).executionId).toBe('exec-a');
+});
+it('없는 기록을 누르면 다른 항목을 임의로 선택하지 않는다', () => {
+  expect(resolveRecoveryEntry(tasks, {}, {}, 'missing').task).toBeUndefined();
+});

--- a/src/lib/recoveryEntry.ts
+++ b/src/lib/recoveryEntry.ts
@@ -1,0 +1,6 @@
+import type { Task } from '../types';
+
+export function resolveRecoveryEntry(tasks: Task[], ready: Record<string, string>, running: Record<string, string>, id?: string) {
+  const task = tasks.find((t) => (!id || t.id === id) && ['failed', 'partial_done', 'recovery_pending'].includes(t.status));
+  return { task, executionId: task && (ready[task.id] ?? task.executionId ?? running[task.id]) };
+}

--- a/src/screens/RecoveredScreen.test.tsx
+++ b/src/screens/RecoveredScreen.test.tsx
@@ -1,0 +1,42 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, expect, it, vi } from 'vitest';
+import { RecoveredScreen } from './RecoveredScreen';
+import { replanApi } from '../lib/api';
+
+vi.mock('../lib/api', async (original) => ({
+  ...await original<typeof import('../lib/api')>(),
+  replanApi: { diff: vi.fn(), approve: vi.fn() },
+}));
+const applied = { taskTitle: '공부', failReason: '', proposalTitle: '회복', proposalDesc: '', proposalTime: '' };
+beforeEach(() => vi.clearAllMocks());
+
+it.each(['PARK', 'RESCHEDULE'])('%s 수락은 재계획 API 없이 완료하고 선택에 맞게 안내한다', async (proposalType) => {
+  const onDone = vi.fn();
+  const onOpenWeekly = vi.fn();
+  render(<RecoveredScreen recoveryCount={1} executionId="exec-1" applied={{ ...applied, proposalType, requiresReplan: false }} onDone={onDone} onOpenWeekly={onOpenWeekly} />);
+  expect(replanApi.diff).not.toHaveBeenCalled();
+  if (proposalType === 'RESCHEDULE') {
+    fireEvent.click(screen.getByText('주간 계획 열기'));
+    expect(onOpenWeekly).toHaveBeenCalledOnce();
+  } else {
+    expect(screen.getByText(/잠시 보류하고/)).toBeInTheDocument();
+    expect(screen.queryByText('주간 계획 열기')).not.toBeInTheDocument();
+  }
+  fireEvent.click(screen.getByText('오늘로 돌아가기'));
+  expect(onDone).toHaveBeenCalledOnce();
+  expect(replanApi.approve).not.toHaveBeenCalled();
+});
+
+it('미리보기는 승인 전 상태이며 승인 실패 시 화면을 유지한다', async () => {
+  vi.mocked(replanApi.diff).mockResolvedValue({ before: { title: '공부' }, after: { title: '10분 공부', startAt: '2026-09-05T10:00:00+09:00', endAt: '2026-09-05T10:10:00+09:00' } } as Awaited<ReturnType<typeof replanApi.diff>>);
+  vi.mocked(replanApi.approve).mockRejectedValueOnce(new Error('offline')).mockResolvedValueOnce(undefined as never);
+  const onDone = vi.fn();
+  render(<RecoveredScreen recoveryCount={1} executionId="exec-1" applied={{ ...applied, requiresReplan: true }} onDone={onDone} />);
+  await screen.findByText(/변경 예정이에요/);
+  expect(screen.queryByText('실제 일정에 반영됐어요')).not.toBeInTheDocument();
+  fireEvent.click(screen.getByText('일정 반영하기'));
+  await screen.findByText('다시 시도');
+  expect(onDone).not.toHaveBeenCalled();
+  fireEvent.click(screen.getByText('다시 시도'));
+  await waitFor(() => expect(onDone).toHaveBeenCalledOnce());
+});

--- a/src/screens/RecoveredScreen.tsx
+++ b/src/screens/RecoveredScreen.tsx
@@ -13,12 +13,15 @@ export interface AppliedRecovery {
   proposalTitle: string;
   proposalDesc: string;
   proposalTime: string;
+  requiresReplan?: boolean;
+  proposalType?: string;
 }
 
 interface RecoveredScreenProps {
   recoveryCount: number;
   applied?: AppliedRecovery | null;
   onDone: () => void;
+  onOpenWeekly?: () => void;
   // 회복 수락으로 생성된 새 액션의 execution id.
   // RecoveryScreen → 컨트롤러가 전달한다. 없으면 replan 연동을 시도하지 않는다
   // (존재하지 않는 stub id 로 호출해 404/오작동하던 문제 제거).
@@ -41,22 +44,25 @@ function formatKstRange(startAt: string, endAt: string): string {
   }
 }
 
-export function RecoveredScreen({ recoveryCount, applied, onDone, executionId }: RecoveredScreenProps) {
+export function RecoveredScreen({ recoveryCount, applied, onDone, onOpenWeekly, executionId }: RecoveredScreenProps) {
+  const needsReplan = applied?.requiresReplan ?? true;
   // mock-and-replace: 진입 시 replan diff 조회 — 실제 executionId 가 있을 때만.
   // 백엔드(#20-B)가 before/after 를 주면 실데이터로 교체, 실패/없음이면 applied props fallback.
   const [diff, setDiff] = useState<ReplanDiff | null>(null);
   const [diffError, setDiffError] = useState<string | null>(null);
   const [approveError, setApproveError] = useState<string | null>(null);
   const [approving, setApproving] = useState(false);
+  const [retry, setRetry] = useState(0);
   useEffect(() => {
-    if (!executionId) return;
+    if (!executionId || !needsReplan) return;
+    setDiffError(null);
     let cancelled = false;
     replanApi.diff(executionId).then(
       (d) => { if (!cancelled && d?.before && d?.after) setDiff(d); },
       (err) => { if (!cancelled) setDiffError(friendlyError(err, '실제 일정 변경 내용을 불러오지 못했어요.')); },
     );
     return () => { cancelled = true; };
-  }, [executionId]);
+  }, [executionId, needsReplan, retry]);
 
   // 표시 데이터: 백엔드 diff 가 있으면 우선, 없으면 클라이언트 applied.
   const usingRealDiff = !!diff;
@@ -75,7 +81,7 @@ export function RecoveredScreen({ recoveryCount, applied, onDone, executionId }:
     // Idempotency-Key 는 반드시 "대상 스코프"여야 한다(#164) — approve 는 body 가 없어
     // 모든 호출의 body 해시가 같으므로, Date.now() 같은 전역 값을 쓰면 재시도마다 키가
     // 달라져 멱등 보호가 무력해진다. executionId 로 고정한다.
-    if (executionId) {
+    if (executionId && needsReplan) {
       setApproving(true);
       setApproveError(null);
       try {
@@ -95,7 +101,9 @@ export function RecoveredScreen({ recoveryCount, applied, onDone, executionId }:
       <div style={{ width: 72, height: 72, borderRadius: 9999, background: 'var(--coral-50)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
         <ArrowsClockwise size={32} weight="fill" color="var(--brand)" />
       </div>
-      <div style={{ fontSize: 28, fontWeight: 500, letterSpacing: '-0.01em' }}>복구 계획이 준비됐어요</div>
+      <div style={{ fontSize: 28, fontWeight: 500, letterSpacing: '-0.01em' }}>{needsReplan ? '복구 계획을 확인해 주세요' : '회복 선택을 저장했어요'}</div>
+      {!needsReplan && <p>{applied?.proposalType === 'PARK' ? '잠시 보류하고 선택한 시점에 다시 돌아와요.' : '시간 변경은 주간 계획에서 직접 완료해 주세요.'}</p>}
+      {!needsReplan && applied?.proposalType === 'RESCHEDULE' && <button onClick={onOpenWeekly}>주간 계획 열기</button>}
 
       {/* Before → After — 무엇이 어떻게 바뀌었는지 한눈에. */}
       {view ? (
@@ -128,9 +136,9 @@ export function RecoveredScreen({ recoveryCount, applied, onDone, executionId }:
           </div>
 
           {/* 백엔드 diff 가 응답하면 실제 일정 반영 확정, 아니면 미리보기임을 정직하게 알림. */}
-          {usingRealDiff ? (
+          {!needsReplan ? <p>선택은 저장됐으며 새 일정은 자동으로 만들지 않았어요.</p> : usingRealDiff ? (
             <div style={{ display: 'inline-flex', alignItems: 'center', gap: 5, alignSelf: 'flex-start', marginTop: 2, fontSize: 12, fontWeight: 700, color: 'var(--success-ink)' }}>
-              <CheckCircle size={12} weight="fill" /> 실제 일정에 반영됐어요
+              <CheckCircle size={12} weight="fill" /> 변경 예정이에요. 아래 버튼으로 승인해 주세요.
             </div>
           ) : (
             <div style={{ marginTop: 2 }}>
@@ -148,6 +156,7 @@ export function RecoveredScreen({ recoveryCount, applied, onDone, executionId }:
       {(diffError || approveError) && (
         <div style={{ width: '100%', maxWidth: 320 }}>
           <ErrorBanner>{approveError ?? diffError}</ErrorBanner>
+          {diffError && <button onClick={() => setRetry((n) => n + 1)}>변경 내용 다시 불러오기</button>}
         </div>
       )}
       <div style={{ background: 'var(--surface-raised)', border: '1px solid var(--sand-200)', borderRadius: 18, padding: 18, width: '100%', maxWidth: 320, textAlign: 'left', flexShrink: 0 }}>
@@ -160,7 +169,7 @@ export function RecoveredScreen({ recoveryCount, applied, onDone, executionId }:
         </div>
       </div>
 
-      <button onClick={handleDone} disabled={approving} style={{ width: 160, height: 44, borderRadius: 12, border: 'none', background: 'var(--brand-surface)', color: '#FFFCF6', fontWeight: 700, fontSize: 14, fontFamily: 'inherit', cursor: approving ? 'default' : 'pointer', opacity: approving ? 0.6 : 1, flexShrink: 0 }}>{approving ? '반영하는 중…' : approveError ? '다시 시도' : '알겠어요'}</button>
+      <button onClick={handleDone} disabled={approving || (needsReplan && !!executionId && !diff)} style={{ width: 160, height: 44, borderRadius: 12, border: 'none', background: 'var(--brand-surface)', color: '#FFFCF6', fontWeight: 700, fontSize: 14, fontFamily: 'inherit', cursor: approving ? 'default' : 'pointer', opacity: approving ? 0.6 : 1, flexShrink: 0 }}>{approving ? '반영하는 중…' : approveError ? '다시 시도' : needsReplan ? '일정 반영하기' : '오늘로 돌아가기'}</button>
     </div>
   );
 }

--- a/src/screens/RecoveryScreen.test.tsx
+++ b/src/screens/RecoveryScreen.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MergedRecoveryScreen } from './RecoveryScreen';
 import { recoveryApi } from '../lib/api';
@@ -34,6 +34,15 @@ function view(props: Partial<React.ComponentProps<typeof MergedRecoveryScreen>> 
 // 회복 화면은 진입 직후 두 번 기다린다 — 실행 기록 저장(executionId 확보)과 LLM 제안
 // 생성이다. 예전엔 두 구간 모두 카드 자리가 아무 표시 없는 빈 공간이었다.
 describe('MergedRecoveryScreen 대기 상태', () => {
+  it.each(['PARK', 'RESCHEDULE'])('%s에서 새 행동이 없어도 수락 완료로 연결한다', async (optionGroup) => {
+    api.generateProposals.mockResolvedValue({ aiSource: 'rule', cards: [{ attemptId: 'selected', optionGroup, labelKo: '선택할 회복안', suggestedActionText: '다시 이어가요' }] });
+    api.decide.mockResolvedValue({ resultingActionItemId: null });
+    const onAccept = vi.fn();
+    view({ executionId: 'exec-1', onAccept });
+    fireEvent.click(await screen.findByText('선택할 회복안'));
+    fireEvent.click(screen.getByText('이 방법으로'));
+    await waitFor(() => expect(onAccept).toHaveBeenCalledWith(expect.objectContaining({ id: 'selected' }), false), { timeout: 2500 });
+  });
   beforeEach(() => {
     api.generateProposals.mockReset();
     api.decide.mockReset();

--- a/src/screens/RecoveryScreen.tsx
+++ b/src/screens/RecoveryScreen.tsx
@@ -101,7 +101,7 @@ interface MergedRecoveryScreenProps {
   failReason?: string;
   // 선택된 실제 제안 객체를 그대로 올려준다 — 컨트롤러가 더미에서 id 로 재조회하지
   // 않고, 실제 카드 내용을 그대로 써야 정직하다(#80).
-  onAccept: (proposal: RecoveryProposal) => void;
+  onAccept: (proposal: RecoveryProposal, requiresReplan: boolean) => void;
   onDismiss: () => void;
   // 시작/실패한 실제 실행의 executionId. 데모 task 엔 없으므로 optional.
   // 있으면 백엔드 LLM 회복 제안(POST /recovery/proposals/generate)과 연동한다.
@@ -130,7 +130,6 @@ export function MergedRecoveryScreen({ task, failReason, onAccept, onDismiss, ex
   const [alreadyDecided, setAlreadyDecided] = useState(false);
   const [loadingProposals, setLoadingProposals] = useState(false);
   const [proposalError, setProposalError] = useState<string | null>(null);
-  const [manualScheduleNeeded, setManualScheduleNeeded] = useState(false);
   const [recoveryMode, setRecoveryMode] = useState<'standard' | 'goal_renegotiation'>('standard');
   // 재관여 앵커(#221) — PARK/CARRY_OVER 수락 시 "다음에 다시 볼 시점". 기본값은 다음
   // 주간 리뷰(다음 주 월요일 09:00)로 미리 채워, 마찰 없이 그대로 확인만 해도 되게 한다.
@@ -197,23 +196,13 @@ export function MergedRecoveryScreen({ task, failReason, onAccept, onDismiss, ex
   }, [executionId]);
   useEffect(() => { loadProposals(); }, [loadProposals]);
 
-  if (manualScheduleNeeded) {
-    return (
-      <div style={{ position: 'absolute', inset: 0, zIndex: 50, background: 'var(--surface-ground)', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '40px 24px', gap: 14 }}>
-        <div style={{ fontWeight: 700, fontSize: 22 }}>시간은 주간 계획에서 옮겨주세요</div>
-        <p style={{ fontSize: 13, color: 'var(--text-2)', maxWidth: 280, margin: 0, lineHeight: 1.6 }}>이 선택은 새 일정을 자동으로 만들지 않아요. 주간 계획에서 원하는 시간으로 직접 옮길 수 있어요.</p>
-        <button onClick={onOpenWeekly} style={{ height: 44, padding: '0 20px', borderRadius: 12, border: 'none', background: 'var(--text-1)', color: '#FAF6EE', fontWeight: 700, fontSize: 14, fontFamily: 'inherit', cursor: 'pointer' }}>주간 계획 열기</button>
-        <button onClick={onDismiss} style={{ border: 'none', background: 'none', color: 'var(--text-3)', fontSize: 12, fontFamily: 'inherit', cursor: 'pointer' }}>오늘로 돌아가기</button>
-      </div>
-    );
-  }
-
   // 이미 회복 결정을 마친 실행에 재진입 — 에러가 아니라 정상 상태로 안내한다(#164).
   if (alreadyDecided) {
     return (
       <div style={{ position: 'absolute', inset: 0, zIndex: 50, background: 'var(--surface-ground)', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '40px 24px', gap: 14 }}>
         <div style={{ fontWeight: 700, fontSize: 22 }}>이미 회복 계획을 골랐어요</div>
-        <p style={{ fontSize: 13, color: 'var(--text-2)', maxWidth: 260, margin: 0, lineHeight: 1.6 }}>이 카드는 회복 방법이 정해져 있어요. 주간 계획에서 새로 잡힌 시간을 확인할 수 있어요.</p>
+        <p style={{ fontSize: 13, color: 'var(--text-2)', maxWidth: 260, margin: 0, lineHeight: 1.6 }}>이 실행에는 이미 저장한 회복 선택이 있어요. 주간 계획에서 일정을 확인해 주세요.</p>
+        <button onClick={onOpenWeekly}>주간 계획 열기</button>
         <button onClick={onDismiss} style={{ height: 44, padding: '0 20px', borderRadius: 12, border: 'none', background: 'var(--text-1)', color: '#FAF6EE', fontWeight: 700, fontSize: 14, fontFamily: 'inherit', cursor: 'pointer' }}>오늘로 돌아가기</button>
       </div>
     );
@@ -244,6 +233,7 @@ export function MergedRecoveryScreen({ task, failReason, onAccept, onDismiss, ex
   const accept = async () => {
     if (!sel || deciding) return;
     const chosen = proposals.find((p) => p.id === sel);
+    let requiresReplan = false;
     // 사용자 선택 저장 — 실제 executionId 가 있을 때만(없으면 task.id 는 executionId 가
     // 아니라 백엔드에서 실패하므로 호출하지 않는다). usingRealProposals 면 sel 은 실제
     // attemptId 이므로 그대로 전달. Idempotency-Key 동봉.
@@ -263,10 +253,7 @@ export function MergedRecoveryScreen({ task, failReason, onAccept, onDismiss, ex
           `rec-${executionId}-${sel}`,
           reEngagementAnchorAt,
         );
-        if (result.resultingActionItemId === null) {
-          setManualScheduleNeeded(true);
-          return;
-        }
+        requiresReplan = !!result.resultingActionItemId;
       } catch (err) {
         setDecideError(friendlyError(err, '회복 계획을 저장하지 못했어요. 잠시 후 다시 시도해 주세요.'));
         return;
@@ -280,7 +267,7 @@ export function MergedRecoveryScreen({ task, failReason, onAccept, onDismiss, ex
     // 서는 앵커 호출을 추가하지 않는다 — 그 작업이 머지되면 renegotiating===true
     // 분기에서 앵커 설정 API를 이어붙이면 된다.
     setAccepted(true);
-    if (chosen) setTimeout(() => onAccept(chosen), 1400);
+    if (chosen) setTimeout(() => onAccept(chosen, requiresReplan), 1400);
   };
 
   if (accepted) {

--- a/src/screens/TodayScreen.tsx
+++ b/src/screens/TodayScreen.tsx
@@ -87,7 +87,7 @@ interface MergedTodayScreenProps {
   // 백엔드 openapi 에 task_aversiveness 필드가 아직 없어 전송하지 않는다 — 연결 지점은
   // ReActionMerged.markFailed 안에 주석으로 남겨둠.
   onFail: (id: string, reason: string, tagCodes?: string[], memo?: string, taskAversiveness?: number) => void;
-  onOpenRecovery: () => void;
+  onOpenRecovery: (id?: string) => void;
   onEvening: () => void;
   // /today/agenda 실데이터 로드 성공 시 부모의 tasks 를 이 목록으로 교체한다.
   // (기존엔 이 화면이 자체 로컬 tasks 상태로만 반영해, 부모가 들고 있는 openTask 등이
@@ -556,7 +556,7 @@ export function MergedTodayScreen({ tasks: allTasks, onOpen, onMarkDone, onParti
   };
 
   const showToast = (msg: string, tone: 'ok' | 'error' = 'ok') => { setToast({ msg, tone }); setTimeout(() => setToast(null), 2200); };
-  const partialTasks = tasks.filter((t) => t.status === 'partial_done' || t.status === 'recovery_pending');
+  const partialTasks = tasks.filter((t) => t.status === 'failed' || t.status === 'partial_done' || t.status === 'recovery_pending');
   const doneTasks = tasks.filter((t) => t.status === 'done');
   // 일정이 0개면 "모두 완료"가 아니다(0===0 이라도) — 없는 걸 다 했다고 하지 않는다.
   const allDone = tasks.length > 0 && doneTasks.length === tasks.length;
@@ -669,7 +669,7 @@ export function MergedTodayScreen({ tasks: allTasks, onOpen, onMarkDone, onParti
               // 회복은 이 제품의 핵심 차별점인데 ⋮ 옆 작은 아이콘이라 존재감이 없었다.
               // 이름을 붙인 칩으로 올린다 — 뭘 누르는 건지 읽히게.
               <button
-                onClick={onOpenRecovery}
+                onClick={() => onOpenRecovery()}
                 title={`회복 제안 ${partialTasks.length}건`}
                 style={{ height: 32, padding: '0 11px 0 9px', borderRadius: 9999, border: '1px solid var(--coral-200)', background: 'var(--brand-soft)', display: 'inline-flex', alignItems: 'center', gap: 5, cursor: 'pointer', fontFamily: 'inherit' }}
               >
@@ -763,7 +763,7 @@ export function MergedTodayScreen({ tasks: allTasks, onOpen, onMarkDone, onParti
               orderLabel={usingWeeklyFallback ? '예정순' : '시간순'}
               interactive={!usingWeeklyFallback}
               onSelect={setSelectedTaskId}
-              onFailedRecover={onFail}
+              onFailedRecover={onOpenRecovery}
               onPartialRecover={onOpenRecovery}
             />
 
@@ -773,7 +773,7 @@ export function MergedTodayScreen({ tasks: allTasks, onOpen, onMarkDone, onParti
               orderLabel={`${executionHistory.length}건`}
               interactive={!usingWeeklyFallback}
               onSelect={setSelectedTaskId}
-              onFailedRecover={onFail}
+              onFailedRecover={onOpenRecovery}
               onPartialRecover={onOpenRecovery}
             />
           </>


### PR DESCRIPTION
새로고침 후 부분완료 기록을 누르면 준비 중에서 멈추던 문제를 해결합니다. 클릭한 기록의 서버 executionId를 사용하고 실패 기록 재진입 시 체크인을 반복하지 않습니다. 오늘 카드에 복구 버튼을 추가하고 실패 기록도 회복 배지에 포함합니다. PARK와 RESCHEDULE 수락도 확인 화면으로 연결하며 각각 보류 안내와 수동 일정 변경을 제공합니다. 재계획은 승인 전임을 표시하고 변경 조회 재시도를 제공합니다. 검증: 빌드, 타입 검사, 기존 및 신규 회귀 테스트 통과. API 경로 검사 PASS. 필드 검사 PASS이나 기존 OpenAPI 스냅샷 경고 2건이 남아 있습니다.